### PR TITLE
Suppting `--scrollback` flag in `sleep` command

### DIFF
--- a/cmd/lazy-tmux/main.go
+++ b/cmd/lazy-tmux/main.go
@@ -398,6 +398,16 @@ func runSleep(base config.Config, args []string) error {
 	sleepFlags := flag.NewFlagSet("sleep", flag.ContinueOnError)
 	sleepFlags.SetOutput(io.Discard)
 	session := sleepFlags.String("session", "", "session to sleep")
+	scrollback := sleepFlags.Bool(
+		"scrollback",
+		base.Scrollback.Enabled,
+		"capture shell pane scrollback",
+	)
+	scrollbackLines := sleepFlags.Int(
+		"scrollback-lines",
+		base.Scrollback.Lines,
+		"max shell scrollback lines per pane",
+	)
 	shared := addSharedFlags(sleepFlags, base, true)
 
 	err := sleepFlags.Parse(args)
@@ -412,11 +422,18 @@ func runSleep(base config.Config, args []string) error {
 		return fmt.Errorf("parse sleep flags: %w", err)
 	}
 
+	if *scrollback && *scrollbackLines <= 0 {
+		return fmt.Errorf("sleep requires --scrollback-lines > 0 when --scrollback is enabled")
+	}
+
 	if strings.TrimSpace(*session) == "" {
 		return fmt.Errorf("sleep requires --session")
 	}
 
-	a := app.New(shared.apply(base))
+	cfg := shared.apply(base)
+	cfg.Scrollback.Enabled = *scrollback
+	cfg.Scrollback.Lines = *scrollbackLines
+	a := app.New(cfg)
 
 	err = a.Sleep(strings.TrimSpace(*session))
 	if err != nil {

--- a/index.html
+++ b/index.html
@@ -594,7 +594,7 @@
               <td>Restore a saved session (lazy load) that is not currently running</td>
             </tr>
             <tr>
-              <td><code>sleep --session NAME [--scrollback]</code></td>
+              <td><code>sleep --session NAME [--scrollback] [--scrollback-lines N]</code></td>
               <td>Save session state (with optional scrollback) and close a running session</td>
             </tr>
             <tr>

--- a/index.html
+++ b/index.html
@@ -594,8 +594,8 @@
               <td>Restore a saved session (lazy load) that is not currently running</td>
             </tr>
             <tr>
-              <td><code>sleep --session NAME</code></td>
-              <td>Save session state and close a running session</td>
+              <td><code>sleep --session NAME [--scrollback]</code></td>
+              <td>Save session state (with optional scrollback) and close a running session</td>
             </tr>
             <tr>
               <td><code>--fzf-engine</code></td>


### PR DESCRIPTION
Close #80


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --scrollback flag to enable capturing shell pane scrollback when saving sessions.
  * Added --scrollback-lines flag to set the maximum number of scrollback lines captured per pane.
  * Added validation to ensure scrollback lines are configured when scrollback capture is enabled.

* **Documentation**
  * Updated CLI docs to reflect new scrollback options for the sleep command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->