### PR TITLE
Add `forget` command

### DIFF
--- a/cmd/lazy-tmux/main.go
+++ b/cmd/lazy-tmux/main.go
@@ -95,6 +95,13 @@ func runCLI(args []string, stdout, stderr io.Writer) int {
 		}
 
 		return 0
+	case "forget":
+		err := runForget(cfg, args[1:])
+		if err != nil {
+			return writeFatalErr(stderr, err)
+		}
+
+		return 0
 	case "help", "-h", "--help":
 		usageTo(stdout)
 		return 0
@@ -426,6 +433,38 @@ func runSleep(base config.Config, args []string) error {
 	return nil
 }
 
+func runForget(base config.Config, args []string) error {
+	forgetFlags := flag.NewFlagSet("forget", flag.ContinueOnError)
+	forgetFlags.SetOutput(io.Discard)
+	session := forgetFlags.String("session", "", "stored session to forget")
+	shared := addSharedFlags(forgetFlags, base, true)
+
+	err := forgetFlags.Parse(args)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			forgetFlags.SetOutput(os.Stdout)
+			forgetFlags.Usage()
+
+			return nil
+		}
+
+		return fmt.Errorf("parse forget flags: %w", err)
+	}
+
+	if strings.TrimSpace(*session) == "" {
+		return fmt.Errorf("forget requires --session")
+	}
+
+	a := app.New(shared.apply(base))
+
+	err = a.Forget(strings.TrimSpace(*session))
+	if err != nil {
+		return fmt.Errorf("forget session: %w", err)
+	}
+
+	return nil
+}
+
 func usage() {
 	usageTo(os.Stdout)
 }
@@ -441,6 +480,7 @@ Commands:
   restore    Restore one session from disk
   wakeup     Restore a saved session (lazy load) without switching clients
   sleep      Save and close a running session
+  forget     Remove a stored session from disk
   picker     Open session picker and restore selected session (default: TUI)
   bootstrap  Restore one session at tmux startup (default: last)
   daemon     Periodically save all sessions

--- a/cmd/lazy-tmux/main_test.go
+++ b/cmd/lazy-tmux/main_test.go
@@ -220,7 +220,7 @@ func TestRunForgetRequiresSession(t *testing.T) {
 	}
 }
 
-func TestRunForgetOnNonexistentSessionFails(t *testing.T) {
+func TestRunForgetOnNonexistentSessionSucceeds(t *testing.T) {
 	var out bytes.Buffer
 
 	var errOut bytes.Buffer
@@ -228,12 +228,8 @@ func TestRunForgetOnNonexistentSessionFails(t *testing.T) {
 	dir := t.TempDir()
 
 	code := runCLI([]string{"forget", "--session", "nonexistent", "--data-dir", dir}, &out, &errOut)
-	if code != 1 {
-		t.Fatalf("expected exit code 1, got %d", code)
-	}
-
-	if !strings.Contains(errOut.String(), "not found") {
-		t.Fatalf("unexpected stderr: %s", errOut.String())
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
 	}
 }
 

--- a/cmd/lazy-tmux/main_test.go
+++ b/cmd/lazy-tmux/main_test.go
@@ -204,3 +204,68 @@ func TestRunSleepOnNonrunningSessionFails(t *testing.T) {
 		t.Fatalf("unexpected stderr: %s", errOut.String())
 	}
 }
+
+func TestRunForgetRequiresSession(t *testing.T) {
+	var out bytes.Buffer
+
+	var errOut bytes.Buffer
+
+	code := runCLI([]string{"forget"}, &out, &errOut)
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+
+	if !strings.Contains(errOut.String(), "forget requires --session") {
+		t.Fatalf("unexpected stderr: %s", errOut.String())
+	}
+}
+
+func TestRunForgetOnNonexistentSessionFails(t *testing.T) {
+	var out bytes.Buffer
+
+	var errOut bytes.Buffer
+
+	dir := t.TempDir()
+
+	code := runCLI([]string{"forget", "--session", "nonexistent", "--data-dir", dir}, &out, &errOut)
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+
+	if !strings.Contains(errOut.String(), "not found") {
+		t.Fatalf("unexpected stderr: %s", errOut.String())
+	}
+}
+
+func TestRunForgetDeletesStoredSession(t *testing.T) {
+	var out bytes.Buffer
+
+	var errOut bytes.Buffer
+
+	dir := t.TempDir()
+	testStore := store.New(dir)
+
+	err := testStore.SaveSession(snapshot.SessionSnapshot{
+		Version:     snapshot.FormatVersion,
+		SessionName: "demo",
+		CapturedAt:  time.Now().UTC(),
+		Windows:     []snapshot.Window{{Index: 0, Panes: []snapshot.Pane{{Index: 0}}}},
+	})
+	if err != nil {
+		t.Fatalf("save session: %v", err)
+	}
+
+	code := runCLI([]string{"forget", "--session", "demo", "--data-dir", dir}, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+
+	exists, err := testStore.SessionExists("demo")
+	if err != nil {
+		t.Fatalf("session exists: %v", err)
+	}
+
+	if exists {
+		t.Fatalf("expected session to be deleted, but it still exists")
+	}
+}

--- a/internal/app/app_crud.go
+++ b/internal/app/app_crud.go
@@ -81,16 +81,7 @@ func (a *App) Forget(session string) error {
 		return fmt.Errorf("session name is empty")
 	}
 
-	exists, err := a.store.SessionExists(session)
-	if err != nil {
-		return fmt.Errorf("check session exists: %w", err)
-	}
-
-	if !exists {
-		return fmt.Errorf("stored session %q not found", session)
-	}
-
-	err = a.store.DeleteSession(session)
+	err := a.store.DeleteSession(strings.TrimSpace(session))
 	if err != nil {
 		return fmt.Errorf("delete session storage: %w", err)
 	}

--- a/internal/app/app_crud.go
+++ b/internal/app/app_crud.go
@@ -76,6 +76,28 @@ func (a *App) DeleteWindow(session string, windowIndex int) error {
 	return nil
 }
 
+func (a *App) Forget(session string) error {
+	if strings.TrimSpace(session) == "" {
+		return fmt.Errorf("session name is empty")
+	}
+
+	exists, err := a.store.SessionExists(session)
+	if err != nil {
+		return fmt.Errorf("check session exists: %w", err)
+	}
+
+	if !exists {
+		return fmt.Errorf("stored session %q not found", session)
+	}
+
+	err = a.store.DeleteSession(session)
+	if err != nil {
+		return fmt.Errorf("delete session storage: %w", err)
+	}
+
+	return nil
+}
+
 func (a *App) DeleteSession(session string) error {
 	if a.tmux.SessionExists(session) {
 		err := a.tmux.KillSession(session)

--- a/internal/app/app_crud_test.go
+++ b/internal/app/app_crud_test.go
@@ -525,7 +525,12 @@ func TestSleepNotRunning(t *testing.T) {
 }
 
 func TestForgetEmptyName(t *testing.T) {
-	testApp := NewWithTmux(testConfig(), &fakeTmuxClient{})
+	dir := t.TempDir()
+	testCfg := config.Config{
+		TmuxBin: "tmux",
+		DataDir: dir,
+	}
+	testApp := NewWithTmux(testCfg, &fakeTmuxClient{})
 
 	err := testApp.Forget("")
 	if err == nil {
@@ -534,23 +539,26 @@ func TestForgetEmptyName(t *testing.T) {
 }
 
 func TestForgetNonexistent(t *testing.T) {
-	testApp := NewWithTmux(testConfig(), &fakeTmuxClient{})
+	dir := t.TempDir()
+	testCfg := config.Config{
+		TmuxBin: "tmux",
+		DataDir: dir,
+	}
+	testApp := NewWithTmux(testCfg, &fakeTmuxClient{})
 
 	err := testApp.Forget("nonexistent")
-	if err == nil {
-		t.Fatal("expected error for nonexistent session")
+	if err != nil {
+		t.Fatalf("unexpected error for nonexistent session: %v", err)
 	}
 }
 
 func TestForgetDeletesStoredSession(t *testing.T) {
 	dir := t.TempDir()
-	testConfig := func() config.Config {
-		return config.Config{
-			TmuxBin: "tmux",
-			DataDir: dir,
-		}
+	testCfg := config.Config{
+		TmuxBin: "tmux",
+		DataDir: dir,
 	}
-	testApp := NewWithTmux(testConfig(), &fakeTmuxClient{})
+	testApp := NewWithTmux(testCfg, &fakeTmuxClient{})
 
 	testStore := newTestStore(dir)
 
@@ -575,6 +583,24 @@ func TestForgetDeletesStoredSession(t *testing.T) {
 	}
 
 	if exists {
-		t.Fatal("expected session to be deleted, but it still exists")
+		t.Fatal("expected session file to be deleted, but it still exists")
+	}
+
+	scrollbackExists, err := testStore.ScrollbackExists("my-session")
+	if err != nil {
+		t.Fatalf("scrollback exists: %v", err)
+	}
+
+	if scrollbackExists {
+		t.Fatal("expected scrollback data to be deleted, but it still exists")
+	}
+
+	indexExists, err := testStore.IndexEntryExists("my-session")
+	if err != nil {
+		t.Fatalf("index entry exists: %v", err)
+	}
+
+	if indexExists {
+		t.Fatal("expected index entry to be deleted, but it still exists")
 	}
 }

--- a/internal/app/app_crud_test.go
+++ b/internal/app/app_crud_test.go
@@ -2,7 +2,9 @@ package app
 
 import (
 	"testing"
+	"time"
 
+	"github.com/alchemmist/lazy-tmux/internal/config"
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
 	"github.com/alchemmist/lazy-tmux/internal/store"
 )
@@ -519,5 +521,60 @@ func TestSleepNotRunning(t *testing.T) {
 	err := testApp.Sleep("non-running")
 	if err == nil {
 		t.Fatal("expected error for non-running session")
+	}
+}
+
+func TestForgetEmptyName(t *testing.T) {
+	testApp := NewWithTmux(testConfig(), &fakeTmuxClient{})
+
+	err := testApp.Forget("")
+	if err == nil {
+		t.Fatal("expected error for empty session")
+	}
+}
+
+func TestForgetNonexistent(t *testing.T) {
+	testApp := NewWithTmux(testConfig(), &fakeTmuxClient{})
+
+	err := testApp.Forget("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent session")
+	}
+}
+
+func TestForgetDeletesStoredSession(t *testing.T) {
+	dir := t.TempDir()
+	testConfig := func() config.Config {
+		return config.Config{
+			TmuxBin: "tmux",
+			DataDir: dir,
+		}
+	}
+	testApp := NewWithTmux(testConfig(), &fakeTmuxClient{})
+
+	testStore := newTestStore(dir)
+
+	err := testStore.SaveSession(snapshot.SessionSnapshot{
+		Version:     snapshot.FormatVersion,
+		SessionName: "my-session",
+		CapturedAt:  time.Now().UTC(),
+		Windows:     []snapshot.Window{{Index: 0, Panes: []snapshot.Pane{{Index: 0}}}},
+	})
+	if err != nil {
+		t.Fatalf("save session: %v", err)
+	}
+
+	err = testApp.Forget("my-session")
+	if err != nil {
+		t.Fatalf("forget session: %v", err)
+	}
+
+	exists, err := testStore.SessionExists("my-session")
+	if err != nil {
+		t.Fatalf("session exists: %v", err)
+	}
+
+	if exists {
+		t.Fatal("expected session to be deleted, but it still exists")
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -262,6 +262,55 @@ func (s *Store) LatestRecord() (snapshot.Record, error) {
 	return recs[0], nil
 }
 
+func (s *Store) ScrollbackExists(name string) (bool, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false, errors.New("empty session name")
+	}
+
+	safeName, err := safeScrollbackSessionName(name)
+	if err != nil {
+		return false, err
+	}
+
+	scrollRoot := filepath.Clean(filepath.Join(s.baseDir, scrollbackDir))
+	sessionDir := filepath.Clean(filepath.Join(scrollRoot, safeName))
+
+	_, err = os.Stat(sessionDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("stat scrollback dir: %w", err)
+	}
+
+	return true, nil
+}
+
+func (s *Store) IndexEntryExists(name string) (bool, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false, errors.New("empty session name")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	idx, err := s.loadIndexUnlocked()
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	_, ok := idx.Sessions[name]
+
+	return ok, nil
+}
+
 func (s *Store) MarkSessionAccessed(name string, accessTime time.Time) error {
 	name = strings.TrimSpace(name)
 	if name == "" {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -299,10 +299,6 @@ func (s *Store) IndexEntryExists(name string) (bool, error) {
 
 	idx, err := s.loadIndexUnlocked()
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return false, nil
-		}
-
 		return false, err
 	}
 


### PR DESCRIPTION
Close #79


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "forget" CLI command to remove stored sessions from disk; supports --help and requires a session name.
  * App-level support to delete persisted sessions and associated storage entries.

* **Bug Fixes / Validation**
  * Validates blank/missing session names with clear error messages.
  * Graceful behavior when forgetting nonexistent sessions.

* **Tests**
  * Integration and unit tests for validation, nonexistence, and successful deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->