### PR TITLE
fix(tmux): tolerate stale current window/pane on restore (base-index 1)

### DIFF
--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -335,6 +335,70 @@ func currentWindowPane(windows []snapshot.Window) (int, int) {
 	return 0, 0
 }
 
+// findWindow returns the window with the given index, if present.
+func findWindow(windows []snapshot.Window, index int) (snapshot.Window, bool) {
+	for _, window := range windows {
+		if window.Index == index {
+			return window, true
+		}
+	}
+
+	return snapshot.Window{}, false
+}
+
+// paneExists reports whether a pane with the given index is present.
+func paneExists(panes []snapshot.Pane, index int) bool {
+	for _, pane := range panes {
+		if pane.Index == index {
+			return true
+		}
+	}
+
+	return false
+}
+
+// clampPane resolves a pane index to one that actually exists in the window,
+// preferring the requested index, then the window's active pane, then its
+// first pane.
+func clampPane(window snapshot.Window, paneIndex int) int {
+	if paneExists(window.Panes, paneIndex) {
+		return paneIndex
+	}
+
+	if paneExists(window.Panes, window.ActivePane) {
+		return window.ActivePane
+	}
+
+	if len(window.Panes) > 0 {
+		return window.Panes[0].Index
+	}
+
+	return paneIndex
+}
+
+// resolveRestoreFocus picks the window/pane to focus after a restore, tolerating
+// snapshots whose recorded current window/pane no longer matches the restored
+// windows. Snapshots captured before the base-index fix store current_window 0
+// while windows are indexed from 1 (e.g. under `set -g base-index 1`), so
+// selecting the recorded index would fail with "can't find window: 0".
+func resolveRestoreFocus(
+	sessionSnapshot snapshot.SessionSnapshot,
+	windows []snapshot.Window,
+) (int, int) {
+	// Honor the recorded focus when its window still exists.
+	if window, ok := findWindow(windows, sessionSnapshot.CurrentWin); ok {
+		return window.Index, clampPane(window, sessionSnapshot.CurrentPane)
+	}
+
+	// Otherwise fall back to the active window (or the first one).
+	win, pane := currentWindowPane(windows)
+	if window, ok := findWindow(windows, win); ok {
+		return win, clampPane(window, pane)
+	}
+
+	return win, pane
+}
+
 func (client *Client) RestoreSession(sessionSnapshot snapshot.SessionSnapshot) error {
 	if sessionSnapshot.SessionName == "" {
 		return errors.New("empty session name")
@@ -394,10 +458,12 @@ func (client *Client) RestoreSession(sessionSnapshot snapshot.SessionSnapshot) e
 		}
 	}
 
+	focusWin, focusPane := resolveRestoreFocus(sessionSnapshot, windows)
+
 	_, err = client.Output(
 		"select-window",
 		"-t",
-		sessionWindowTarget(sessionSnapshot.SessionName, sessionSnapshot.CurrentWin),
+		sessionWindowTarget(sessionSnapshot.SessionName, focusWin),
 	)
 	if err != nil {
 		return fmt.Errorf("select window: %w", err)
@@ -408,8 +474,8 @@ func (client *Client) RestoreSession(sessionSnapshot snapshot.SessionSnapshot) e
 		"-t",
 		sessionPaneTarget(
 			sessionSnapshot.SessionName,
-			sessionSnapshot.CurrentWin,
-			sessionSnapshot.CurrentPane,
+			focusWin,
+			focusPane,
 		),
 	)
 	if err != nil {

--- a/internal/tmux/integration_test.go
+++ b/internal/tmux/integration_test.go
@@ -1,0 +1,112 @@
+package tmux_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alchemmist/lazy-tmux/internal/snapshot"
+	"github.com/alchemmist/lazy-tmux/internal/testutil"
+	"github.com/alchemmist/lazy-tmux/internal/tmux"
+)
+
+// activeWindowIndex returns the index of the active window in a live session,
+// reading it straight from the isolated tmux server.
+func activeWindowIndex(t *testing.T, name string) string {
+	t.Helper()
+
+	out := testutil.Tmux(
+		t,
+		"list-windows",
+		"-t",
+		"="+name,
+		"-F",
+		"#{window_index} #{window_active}",
+	)
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[1] == "1" {
+			return fields[0]
+		}
+	}
+
+	t.Fatalf("no active window found in %q", out)
+
+	return ""
+}
+
+// TestRestoreToleratesBaseIndexMismatch reproduces issues #103/#105: a snapshot
+// captured under `set -g base-index 1` records windows indexed from 1 while the
+// current window is stored as 0. Restoring it used to fail hard with
+// "can't find window: 0" because the focus selection trusted the recorded index
+// blindly. The restore must now succeed and focus the only real window instead.
+func TestRestoreToleratesBaseIndexMismatch(t *testing.T) {
+	testutil.IsolatedTmux(t)
+
+	client := tmux.NewClient("tmux")
+
+	const name = "legacy"
+
+	snap := snapshot.SessionSnapshot{
+		Version:     snapshot.FormatVersion,
+		SessionName: name,
+		CurrentWin:  0, // stale: no window has index 0
+		CurrentPane: 0,
+		Windows: []snapshot.Window{
+			{
+				Index:      1,
+				Name:       "main",
+				IsActive:   true,
+				ActivePane: 0,
+				Panes:      []snapshot.Pane{{Index: 0, CurrentPath: "/tmp", IsActive: true}},
+			},
+		},
+	}
+
+	if err := client.RestoreSession(snap); err != nil {
+		t.Fatalf("restore with stale current_window must not fail: %v", err)
+	}
+
+	if _, err := testutil.TmuxTry("has-session", "-t", "="+name); err != nil {
+		t.Fatalf("session should be alive after restore: %v", err)
+	}
+
+	if got := activeWindowIndex(t, name); got != "1" {
+		t.Fatalf("expected window 1 focused, got %q", got)
+	}
+}
+
+// TestRestoreHonorsRecordedFocus guards the happy path: when the recorded
+// current window exists, restore focuses exactly that window rather than
+// falling back.
+func TestRestoreHonorsRecordedFocus(t *testing.T) {
+	testutil.IsolatedTmux(t)
+
+	client := tmux.NewClient("tmux")
+
+	const name = "multi"
+
+	snap := snapshot.SessionSnapshot{
+		Version:     snapshot.FormatVersion,
+		SessionName: name,
+		CurrentWin:  2,
+		CurrentPane: 0,
+		Windows: []snapshot.Window{
+			{
+				Index: 1, Name: "one", ActivePane: 0,
+				Panes: []snapshot.Pane{{Index: 0, CurrentPath: "/tmp"}},
+			},
+			{
+				Index: 2, Name: "two", IsActive: true, ActivePane: 0,
+				Panes: []snapshot.Pane{{Index: 0, CurrentPath: "/tmp", IsActive: true}},
+			},
+		},
+	}
+
+	if err := client.RestoreSession(snap); err != nil {
+		t.Fatalf("restore failed: %v", err)
+	}
+
+	if got := activeWindowIndex(t, name); got != "2" {
+		t.Fatalf("expected recorded window 2 focused, got %q", got)
+	}
+}


### PR DESCRIPTION
Closes #103
Closes #105

## Problem

Snapshots taken with `set -g base-index 1` store windows indexed from 1, but `current_window: 0`. `RestoreSession` blindly called `select-window -t =<session>:0`, which failed with `can't find window: 0`. This affected `restore`, `picker`, `wakeup` and `bootstrap`. Confirmed by several users (including on tmux 3.6a).

PR #101 only fixed writing new snapshots — the old snapshots already on affected users' disks kept failing on restore.

## Solution

- `resolveRestoreFocus` picks the window/pane to focus: it honors the recorded index if that window exists; otherwise it falls back to the active window (or the first one), and clamps the pane to an existing one (`clampPane`).
- `RestoreSession` no longer trusts the recorded index blindly.

## Tests

New `internal/tmux/integration_test.go` (real tmux in a container):
- `TestRestoreToleratesBaseIndexMismatch` — reproduces #105 (window index 1, `current_window: 0`); verified that without the fix it fails with exactly `can't find window: 0`.
- `TestRestoreHonorsRecordedFocus` — happy-path regression: valid `current_window: 2` → focus lands on 2.

`make integration-test` — 87 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tmux session restore so focus is restored more reliably when window or pane indices differ from the snapshot.
  * If the recorded window or pane no longer exists, restore now falls back to a valid window/pane instead of failing or focusing the wrong target.
  * Session restore now better preserves the original focused window when it is still available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
