### PR TITLE
fix(tmux): wait for restored pane commands to start (issue #106)

### DIFF
--- a/cmd/lazy-tmux/bootstrap.go
+++ b/cmd/lazy-tmux/bootstrap.go
@@ -17,6 +17,11 @@ func runBootstrap(args []string, stdout, stderr io.Writer) int {
 	session := flags.String("session", "last", "session name or 'last'")
 	dataDir := flags.String("data-dir", "", "snapshot directory")
 	tmuxBin := flags.String("tmux-bin", "", "tmux binary")
+	restoreTimeout := flags.Duration(
+		"restore-timeout",
+		config.Default().RestoreTimeout,
+		"max wait for restored pane commands to start (0 disables)",
+	)
 
 	err := flags.Parse(args)
 	if err != nil {
@@ -39,6 +44,8 @@ func runBootstrap(args []string, stdout, stderr io.Writer) int {
 		cfg.TmuxBin = *tmuxBin
 	}
 
+	cfg.RestoreTimeout = *restoreTimeout
+
 	a := app.New(cfg)
 
 	err = a.Bootstrap(*session)
@@ -56,8 +63,9 @@ func bootstrapHelp(w io.Writer) {
 Restore one session at tmux startup
 
 Flags:
-  -data-dir     snapshot directory
-  -session      session name or 'last' (default "last")
-  -tmux-bin     tmux binary
+  -data-dir         snapshot directory
+  -restore-timeout  max wait for restored pane commands to start (0 disables)
+  -session          session name or 'last' (default "last")
+  -tmux-bin         tmux binary
 `)
 }

--- a/cmd/lazy-tmux/forget.go
+++ b/cmd/lazy-tmux/forget.go
@@ -7,7 +7,7 @@ import (
 )
 
 func runForget(args []string, stdout, stderr io.Writer) int {
-	return runSessionOp(args, stdout, stderr, "forget", func(a *app.App, s string) error {
+	return runSessionOp(args, stdout, stderr, "forget", false, func(a *app.App, s string) error {
 		return a.Forget(s)
 	})
 }

--- a/cmd/lazy-tmux/main.go
+++ b/cmd/lazy-tmux/main.go
@@ -30,9 +30,9 @@ var helpFuncs = map[string]func(io.Writer){
 	"daemon":    daemonHelp,
 	"list":      listHelp,
 	"setup":     setupHelp,
-	"wakeup":    func(w io.Writer) { printSessionHelp("wakeup", w) },
+	"wakeup":    func(w io.Writer) { printSessionHelp("wakeup", true, w) },
 	"sleep":     sleepHelp,
-	"forget":    func(w io.Writer) { printSessionHelp("forget", w) },
+	"forget":    func(w io.Writer) { printSessionHelp("forget", false, w) },
 }
 
 func main() {

--- a/cmd/lazy-tmux/picker.go
+++ b/cmd/lazy-tmux/picker.go
@@ -19,6 +19,11 @@ func runPicker(args []string, stdout, stderr io.Writer) int {
 	windowSort := flags.String("window-sort", "", "window sort keys: field[:asc|desc],...")
 	dataDir := flags.String("data-dir", "", "snapshot directory")
 	tmuxBin := flags.String("tmux-bin", "", "tmux binary")
+	restoreTimeout := flags.Duration(
+		"restore-timeout",
+		config.Default().RestoreTimeout,
+		"max wait for restored pane commands to start (0 disables)",
+	)
 
 	err := flags.Parse(args)
 	if err != nil {
@@ -40,6 +45,8 @@ func runPicker(args []string, stdout, stderr io.Writer) int {
 	if *tmuxBin != "" {
 		cfg.TmuxBin = *tmuxBin
 	}
+
+	cfg.RestoreTimeout = *restoreTimeout
 
 	sortOpts, err := app.ParsePickerSortOptions(*sessionSort, *windowSort)
 	if err != nil {
@@ -82,10 +89,11 @@ func pickerHelp(w io.Writer) {
 Open session picker and restore selected session
 
 Flags:
-  -data-dir        snapshot directory
-  -fzf-engine      use fzf engine instead of built-in TUI
-  -session-sort    session sort keys: field[:asc|desc],...
-  -window-sort     window sort keys: field[:asc|desc],...
-  -tmux-bin        tmux binary
+  -data-dir         snapshot directory
+  -fzf-engine       use fzf engine instead of built-in TUI
+  -restore-timeout  max wait for restored pane commands to start (0 disables)
+  -session-sort     session sort keys: field[:asc|desc],...
+  -window-sort      window sort keys: field[:asc|desc],...
+  -tmux-bin         tmux binary
 `)
 }

--- a/cmd/lazy-tmux/restore.go
+++ b/cmd/lazy-tmux/restore.go
@@ -19,6 +19,11 @@ func runRestore(args []string, stdout, stderr io.Writer) int {
 	switchClient := flags.Bool("switch", true, "switch active client to restored session")
 	dataDir := flags.String("data-dir", "", "snapshot directory")
 	tmuxBin := flags.String("tmux-bin", "", "tmux binary")
+	restoreTimeout := flags.Duration(
+		"restore-timeout",
+		config.Default().RestoreTimeout,
+		"max wait for restored pane commands to start (0 disables)",
+	)
 
 	err := flags.Parse(args)
 	if err != nil {
@@ -46,6 +51,8 @@ func runRestore(args []string, stdout, stderr io.Writer) int {
 		cfg.TmuxBin = *tmuxBin
 	}
 
+	cfg.RestoreTimeout = *restoreTimeout
+
 	tmuxApp := app.New(cfg)
 
 	err = tmuxApp.Restore(strings.TrimSpace(*session), *switchClient)
@@ -63,9 +70,10 @@ func restoreHelp(w io.Writer) {
 Restore one session from disk
 
 Flags:
-  -data-dir     snapshot directory
-  -session      session to restore
-  -switch       switch active client to restored session (default true)
-  -tmux-bin     tmux binary
+  -data-dir         snapshot directory
+  -restore-timeout  max wait for restored pane commands to start (0 disables)
+  -session          session to restore
+  -switch           switch active client to restored session (default true)
+  -tmux-bin         tmux binary
 `)
 }

--- a/cmd/lazy-tmux/session.go
+++ b/cmd/lazy-tmux/session.go
@@ -20,6 +20,11 @@ func runSessionOp(args []string, stdout, stderr io.Writer, name string, operatio
 	session := flags.String("session", "", name+" target session")
 	dataDir := flags.String("data-dir", "", "snapshot directory")
 	tmuxBin := flags.String("tmux-bin", "", "tmux binary")
+	restoreTimeout := flags.Duration(
+		"restore-timeout",
+		config.Default().RestoreTimeout,
+		"max wait for restored pane commands to start (0 disables)",
+	)
 
 	err := flags.Parse(args)
 	if err != nil {
@@ -47,6 +52,8 @@ func runSessionOp(args []string, stdout, stderr io.Writer, name string, operatio
 		cfg.TmuxBin = *tmuxBin
 	}
 
+	cfg.RestoreTimeout = *restoreTimeout
+
 	a := app.New(cfg)
 
 	err = operation(a, strings.TrimSpace(*session))
@@ -64,6 +71,11 @@ func printSessionHelp(name string, writer io.Writer) {
 		"forget": "Remove a stored session from disk",
 	}
 
+	restoreTimeoutHelp := ""
+	if name == "wakeup" {
+		restoreTimeoutHelp = "\n  -restore-timeout  max wait for restored pane commands to start (0 disables)"
+	}
+
 	_, _ = fmt.Fprintf(writer, `Usage: lazy-tmux %s [flags]
 
 %s
@@ -71,6 +83,6 @@ func printSessionHelp(name string, writer io.Writer) {
 Flags:
   -data-dir     snapshot directory
   -session      %s target session
-  -tmux-bin     tmux binary
-`, name, desc[name], name)
+  -tmux-bin     tmux binary%s
+`, name, desc[name], name, restoreTimeoutHelp)
 }

--- a/cmd/lazy-tmux/session.go
+++ b/cmd/lazy-tmux/session.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/alchemmist/lazy-tmux/internal/app"
 	"github.com/alchemmist/lazy-tmux/internal/config"
@@ -13,23 +14,35 @@ import (
 
 type sessionOp func(*app.App, string) error
 
-func runSessionOp(args []string, stdout, stderr io.Writer, name string, operation sessionOp) int {
+func runSessionOp(
+	args []string,
+	stdout, stderr io.Writer,
+	name string,
+	restores bool,
+	operation sessionOp,
+) int {
 	flags := flag.NewFlagSet(name, flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
 
 	session := flags.String("session", "", name+" target session")
 	dataDir := flags.String("data-dir", "", "snapshot directory")
 	tmuxBin := flags.String("tmux-bin", "", "tmux binary")
-	restoreTimeout := flags.Duration(
-		"restore-timeout",
-		config.Default().RestoreTimeout,
-		"max wait for restored pane commands to start (0 disables)",
-	)
+
+	// Only operations that actually restore a session honor --restore-timeout, so
+	// it is not registered for the likes of forget where it would be a no-op.
+	var restoreTimeout *time.Duration
+	if restores {
+		restoreTimeout = flags.Duration(
+			"restore-timeout",
+			config.Default().RestoreTimeout,
+			"max wait for restored pane commands to start (0 disables)",
+		)
+	}
 
 	err := flags.Parse(args)
 	if err != nil {
 		if errors.Is(err, flag.ErrHelp) {
-			printSessionHelp(name, stdout)
+			printSessionHelp(name, restores, stdout)
 			return 0
 		}
 
@@ -52,7 +65,9 @@ func runSessionOp(args []string, stdout, stderr io.Writer, name string, operatio
 		cfg.TmuxBin = *tmuxBin
 	}
 
-	cfg.RestoreTimeout = *restoreTimeout
+	if restoreTimeout != nil {
+		cfg.RestoreTimeout = *restoreTimeout
+	}
 
 	a := app.New(cfg)
 
@@ -65,14 +80,14 @@ func runSessionOp(args []string, stdout, stderr io.Writer, name string, operatio
 	return 0
 }
 
-func printSessionHelp(name string, writer io.Writer) {
+func printSessionHelp(name string, restores bool, writer io.Writer) {
 	desc := map[string]string{
 		"wakeup": "Restore a saved session without switching clients",
 		"forget": "Remove a stored session from disk",
 	}
 
 	restoreTimeoutHelp := ""
-	if name == "wakeup" {
+	if restores {
 		restoreTimeoutHelp = "\n  -restore-timeout  max wait for restored pane commands to start (0 disables)"
 	}
 

--- a/cmd/lazy-tmux/wakeup.go
+++ b/cmd/lazy-tmux/wakeup.go
@@ -7,7 +7,7 @@ import (
 )
 
 func runWakeup(args []string, stdout, stderr io.Writer) int {
-	return runSessionOp(args, stdout, stderr, "wakeup", func(a *app.App, s string) error {
+	return runSessionOp(args, stdout, stderr, "wakeup", true, func(a *app.App, s string) error {
 		return a.Wakeup(s)
 	})
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -55,10 +55,13 @@ type App struct {
 }
 
 func New(cfg config.Config) *App {
+	client := tmux.NewClient(cfg.TmuxBin)
+	client.SetRestoreTimeout(cfg.RestoreTimeout)
+
 	return &App{
 		cfg:   cfg,
 		store: store.New(cfg.DataDir),
-		tmux:  tmux.NewClient(cfg.TmuxBin),
+		tmux:  client,
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,10 +7,11 @@ import (
 )
 
 type Config struct {
-	TmuxBin      string
-	DataDir      string
-	SaveInterval time.Duration
-	Scrollback   ScrollbackConfig
+	TmuxBin        string
+	DataDir        string
+	SaveInterval   time.Duration
+	RestoreTimeout time.Duration
+	Scrollback     ScrollbackConfig
 }
 
 type ScrollbackConfig struct {
@@ -20,9 +21,10 @@ type ScrollbackConfig struct {
 
 func Default() Config {
 	return Config{
-		TmuxBin:      "tmux",
-		DataDir:      store.DefaultDataDir(),
-		SaveInterval: 5 * time.Minute,
+		TmuxBin:        "tmux",
+		DataDir:        store.DefaultDataDir(),
+		SaveInterval:   5 * time.Minute,
+		RestoreTimeout: 5 * time.Second,
 		Scrollback: ScrollbackConfig{
 			Enabled: false,
 			Lines:   5000,

--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -12,11 +12,20 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
 )
 
 const fieldSep = "\x1f"
+
+// defaultRestoreSettleTimeout bounds how long RestoreSession waits for restored
+// pane commands to actually start before returning. restoreSettlePollInterval
+// is how often it re-checks pane state while waiting.
+const (
+	defaultRestoreSettleTimeout = 5 * time.Second
+	restoreSettlePollInterval   = 100 * time.Millisecond
+)
 
 // splitFields splits a tmux -F output line on the field separator. tmux 3.5a
 // (and likely other versions) escapes control bytes in format output as octal
@@ -63,8 +72,9 @@ func (execRunner) runCommand(args ...string) commandResult {
 }
 
 type Client struct {
-	bin    string
-	runner commandRunner
+	bin           string
+	runner        commandRunner
+	settleTimeout time.Duration
 }
 
 func NewClient(bin string) *Client {
@@ -72,7 +82,7 @@ func NewClient(bin string) *Client {
 		bin = "tmux"
 	}
 
-	return &Client{bin: bin, runner: execRunner{}}
+	return &Client{bin: bin, runner: execRunner{}, settleTimeout: defaultRestoreSettleTimeout}
 }
 
 func NewClientWithRunner(bin string, cmdRunner commandRunner) *Client {
@@ -80,7 +90,7 @@ func NewClientWithRunner(bin string, cmdRunner commandRunner) *Client {
 		bin = "tmux"
 	}
 
-	tmuxClient := &Client{bin: bin}
+	tmuxClient := &Client{bin: bin, settleTimeout: defaultRestoreSettleTimeout}
 	if cmdRunner != nil {
 		tmuxClient.runner = cmdRunner
 	} else {
@@ -88,6 +98,13 @@ func NewClientWithRunner(bin string, cmdRunner commandRunner) *Client {
 	}
 
 	return tmuxClient
+}
+
+// SetRestoreTimeout bounds how long RestoreSession waits for restored pane
+// commands to start before returning. A value <= 0 disables waiting, restoring
+// the previous fire-and-forget behavior.
+func (client *Client) SetRestoreTimeout(timeout time.Duration) {
+	client.settleTimeout = timeout
 }
 
 func sessionTarget(name string) string {
@@ -482,6 +499,8 @@ func (client *Client) RestoreSession(sessionSnapshot snapshot.SessionSnapshot) e
 		return fmt.Errorf("select pane: %w", err)
 	}
 
+	client.waitForRestoredCommands(sessionSnapshot.SessionName, windows)
+
 	return nil
 }
 
@@ -679,6 +698,90 @@ func (client *Client) restoreWindowCommands(
 	}
 
 	return nil
+}
+
+// expectedPaneCommands maps "window.pane" to the foreground command we expect a
+// pane to be running once its restore command has actually started. Panes with
+// nothing to restore are omitted.
+func expectedPaneCommands(windows []snapshot.Window) map[string]string {
+	want := make(map[string]string)
+
+	for _, window := range windows {
+		for _, pane := range window.Panes {
+			exe := executableName(normalizedCommand(pane.RestoreCmd, pane.CurrentCmd))
+			if exe == "" {
+				continue
+			}
+
+			want[fmt.Sprintf("%d.%d", window.Index, pane.Index)] = exe
+		}
+	}
+
+	return want
+}
+
+// paneCommands reports the current foreground command of every pane in the
+// session, keyed by "window.pane". Errors yield an empty map so callers can
+// simply retry.
+func (client *Client) paneCommands(sessionName string) map[string]string {
+	result := make(map[string]string)
+
+	out, err := client.Output(
+		"list-panes", "-s", "-t", sessionTarget(sessionName),
+		"-F", "#{window_index} #{pane_index} #{pane_current_command}",
+	)
+	if err != nil {
+		return result
+	}
+
+	for _, line := range splitLines(out) {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+
+		result[fields[0]+"."+fields[1]] = fields[2]
+	}
+
+	return result
+}
+
+// waitForRestoredCommands blocks until every pane that had a command to restore
+// is actually running it, or until the settle timeout elapses. Without this the
+// restore returns while panes are still at the shell prompt, so automation could
+// not tell whether the session was fully restored when the command exited (see
+// issue #106). It is best-effort: once the deadline passes it returns regardless.
+func (client *Client) waitForRestoredCommands(sessionName string, windows []snapshot.Window) {
+	if client.settleTimeout <= 0 {
+		return
+	}
+
+	want := expectedPaneCommands(windows)
+	if len(want) == 0 {
+		return
+	}
+
+	deadline := time.Now().Add(client.settleTimeout)
+
+	for {
+		got := client.paneCommands(sessionName)
+
+		pending := false
+
+		for key, exe := range want {
+			if got[key] != exe {
+				pending = true
+
+				break
+			}
+		}
+
+		if !pending || time.Now().After(deadline) {
+			return
+		}
+
+		time.Sleep(restoreSettlePollInterval)
+	}
 }
 
 func (client *Client) restoreWindowScrollback(

--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -751,6 +751,13 @@ func (client *Client) paneCommands(sessionName string) map[string]string {
 // restore returns while panes are still at the shell prompt, so automation could
 // not tell whether the session was fully restored when the command exited (see
 // issue #106). It is best-effort: once the deadline passes it returns regardless.
+//
+// Tradeoff: a restored command that exits very quickly leaves its pane back at
+// the shell, so its expected foreground command is never observed and that pane
+// holds the wait until settleTimeout. This is acceptable because snapshots
+// capture the *foreground* command of a pane, which in practice is a long-lived
+// program (editor, REPL, pager, server) rather than a fast one-shot; the timeout
+// bounds the worst case and a value of 0 opts out of waiting entirely.
 func (client *Client) waitForRestoredCommands(sessionName string, windows []snapshot.Window) {
 	if client.settleTimeout <= 0 {
 		return

--- a/internal/tmux/client_test.go
+++ b/internal/tmux/client_test.go
@@ -2,9 +2,85 @@ package tmux
 
 import (
 	"testing"
+	"time"
 
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
 )
+
+// pollRunner is a fake tmux runner that reports a pane running the shell until
+// the configured poll, then reports the restored command. It lets us drive
+// waitForRestoredCommands deterministically without a real tmux server.
+type pollRunner struct {
+	calls    int
+	settleOn int    // 1-based poll at which the command finally appears
+	before   string // pane_current_command before it settles
+	after    string // pane_current_command once it settles
+}
+
+func (r *pollRunner) runCommand(args ...string) commandResult {
+	if len(args) > 1 && args[1] == "list-panes" {
+		r.calls++
+
+		cmd := r.before
+		if r.calls >= r.settleOn {
+			cmd = r.after
+		}
+
+		return commandResult{stdout: "1 0 " + cmd + "\n"}
+	}
+
+	return commandResult{}
+}
+
+func waitTestWindows() []snapshot.Window {
+	return []snapshot.Window{
+		{Index: 1, Panes: []snapshot.Pane{{Index: 0, RestoreCmd: "cat"}}},
+	}
+}
+
+func TestWaitForRestoredCommandsBlocksUntilStarted(t *testing.T) {
+	runner := &pollRunner{settleOn: 3, before: "zsh", after: "cat"}
+	client := NewClientWithRunner("tmux", runner)
+	client.SetRestoreTimeout(2 * time.Second)
+
+	client.waitForRestoredCommands("sess", waitTestWindows())
+
+	// It must keep polling while the pane still shows the shell, only returning
+	// once the restored command actually appears.
+	if runner.calls < 3 {
+		t.Fatalf("expected to poll until command started, polled %d times", runner.calls)
+	}
+}
+
+func TestWaitForRestoredCommandsRespectsTimeout(t *testing.T) {
+	// The command never appears: the wait must give up at the deadline, not hang.
+	runner := &pollRunner{settleOn: 1 << 30, before: "zsh", after: "cat"}
+	client := NewClientWithRunner("tmux", runner)
+	client.SetRestoreTimeout(150 * time.Millisecond)
+
+	start := time.Now()
+	client.waitForRestoredCommands("sess", waitTestWindows())
+
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("wait ignored its timeout, took %v", elapsed)
+	}
+
+	if runner.calls == 0 {
+		t.Fatal("expected at least one poll before giving up")
+	}
+}
+
+func TestWaitForRestoredCommandsDisabled(t *testing.T) {
+	runner := &pollRunner{settleOn: 1, before: "zsh", after: "cat"}
+	client := NewClientWithRunner("tmux", runner)
+	client.SetRestoreTimeout(0)
+
+	client.waitForRestoredCommands("sess", waitTestWindows())
+
+	if runner.calls != 0 {
+		t.Fatalf("a disabled timeout must not poll, polled %d times", runner.calls)
+	}
+}
 
 func TestCurrentWindowPane(t *testing.T) {
 	// Active window's index and active pane are authoritative, even when the
@@ -29,6 +105,37 @@ func TestCurrentWindowPane(t *testing.T) {
 	win, pane = currentWindowPane(nil)
 	if win != 0 || pane != 0 {
 		t.Fatalf("expected 0/0 for no windows, got %d/%d", win, pane)
+	}
+}
+
+func TestExpectedPaneCommands(t *testing.T) {
+	windows := []snapshot.Window{
+		{
+			Index: 1,
+			Panes: []snapshot.Pane{
+				{Index: 0, RestoreCmd: "nvim main.go"}, // real command -> nvim
+				{Index: 1, RestoreCmd: "zsh"},          // shell only -> skipped
+			},
+		},
+		{
+			Index: 2,
+			Panes: []snapshot.Pane{
+				{Index: 0, CurrentCmd: "htop -d 5"}, // falls back to current command
+			},
+		},
+	}
+
+	got := expectedPaneCommands(windows)
+
+	want := map[string]string{"1.0": "nvim", "2.0": "htop"}
+	if len(got) != len(want) {
+		t.Fatalf("expectedPaneCommands size: got %#v want %#v", got, want)
+	}
+
+	for key, exe := range want {
+		if got[key] != exe {
+			t.Fatalf("expectedPaneCommands[%q]=%q want %q (full %#v)", key, got[key], exe, got)
+		}
 	}
 }
 

--- a/internal/tmux/integration_test.go
+++ b/internal/tmux/integration_test.go
@@ -75,6 +75,48 @@ func TestRestoreToleratesBaseIndexMismatch(t *testing.T) {
 	}
 }
 
+// TestRestoreWaitsForCommandsToStart is the end-to-end counterpart to issue
+// #106: against a real tmux server, once RestoreSession returns the pane must
+// actually be running its restored command rather than sitting at the shell.
+// (The fine-grained "did it really block?" guarantee is covered deterministically
+// by TestWaitForRestoredCommands* with a fake runner; here we confirm the whole
+// real-tmux path settles correctly.)
+func TestRestoreWaitsForCommandsToStart(t *testing.T) {
+	testutil.IsolatedTmux(t)
+
+	client := tmux.NewClient("tmux")
+
+	const name = "settle"
+
+	// `cat` with no args blocks reading stdin, so it stays in the foreground
+	// long enough to observe as pane_current_command.
+	snap := snapshot.SessionSnapshot{
+		Version:     snapshot.FormatVersion,
+		SessionName: name,
+		CurrentWin:  1,
+		CurrentPane: 0,
+		Windows: []snapshot.Window{
+			{
+				Index: 1, Name: "main", IsActive: true, ActivePane: 0,
+				Panes: []snapshot.Pane{
+					{Index: 0, CurrentPath: "/tmp", RestoreCmd: "cat", IsActive: true},
+				},
+			},
+		},
+	}
+
+	if err := client.RestoreSession(snap); err != nil {
+		t.Fatalf("restore failed: %v", err)
+	}
+
+	// No sleep here on purpose: if the restore returned before the command
+	// started, the pane would still be running the shell.
+	out := testutil.Tmux(t, "list-panes", "-t", "="+name, "-F", "#{pane_current_command}")
+	if !strings.Contains(out, "cat") {
+		t.Fatalf("expected pane already running cat right after restore, got %q", out)
+	}
+}
+
 // TestRestoreHonorsRecordedFocus guards the happy path: when the recorded
 // current window exists, restore focuses exactly that window rather than
 // falling back.


### PR DESCRIPTION
Closes #106

## Problem

`RestoreSession` sent commands to panes via `send-keys` and returned immediately. The shell launches the command asynchronously, so at the moment `lazy-tmux` exits (especially `wakeup`) the pane still shows `zsh` and the command starts later. Automation scripts had no way to tell when restore was actually complete and resorted to a "magic" `sleep`.

## Solution

After sending the commands and setting focus, `RestoreSession` waits until each pane that has a command to restore reports a `pane_current_command` matching the expected executable — then returns. The wait is bounded by a timeout (default 5s; `0` disables it and keeps the previous behavior).

- `config.RestoreTimeout` + wiring into `tmux.Client` via `SetRestoreTimeout`.
- `--restore-timeout` flag on the restore-path commands: `restore`, `wakeup`, `bootstrap`, `picker`.
- Best-effort: on deadline it returns without an error (doesn't hang on fast-exiting commands).

## Tests

- `TestWaitForRestoredCommands{BlocksUntilStarted,RespectsTimeout,Disabled}` — deterministic unit tests of the blocking via a fake runner (no real tmux): spins until the command appears; respects the timeout; doesn't poll when set to `0`.
- `TestExpectedPaneCommands` — unit test of the expected-command mapping (shells are dropped, basename is taken).
- `TestRestoreWaitsForCommandsToStart` — end-to-end on real tmux: after restore the pane is already running the command.

`make test` — 92 tests; `make integration-test` — 92 tests (podman + real tmux). Lint clean.

Note: the subtle "does it actually block" guarantee is covered deterministically by the fake-runner unit tests, since on a fast machine the command can start before any external observation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable restore timeout (`-restore-timeout` / `--restore-timeout`) to restore-related commands and picker/session flows, defaulting to 5 seconds; set to `0` to disable waiting.
  * Restore now waits for restored pane commands to begin executing before proceeding.
* **Bug Fixes**
  * Improved restore reliability so sessions are less likely to report readiness before pane commands have actually started.
* **Tests**
  * Added unit and integration coverage to verify waiting behavior and timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
