### PR TITLE
feat(restore): command allowlist (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ data_dir        = "~/.local/share/lazy-tmux"  # where snapshots are stored
 save_interval   = "5m"        # daemon autosave interval (Go duration)
 restore_timeout = "5s"        # max wait for restored pane commands to start (0 disables)
 
+# Allowlist of commands lazy-tmux may replay on restore, matched by program
+# name. Omit the key to restore every command (default). Set it to restore only
+# these programs; set it to [] to restore no commands at all.
+restore_allowlist = ["nvim", "vim", "htop", "less", "tail", "ssh"]
+
 [scrollback]
 enabled = false               # capture shell pane scrollback
 lines   = 5000                # max scrollback lines per pane

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -57,6 +57,7 @@ type App struct {
 func New(cfg config.Config) *App {
 	client := tmux.NewClient(cfg.TmuxBin)
 	client.SetRestoreTimeout(cfg.RestoreTimeout)
+	client.SetRestoreAllowlist(cfg.RestoreAllowlist)
 
 	return &App{
 		cfg:   cfg,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,13 @@ type Config struct {
 	SaveInterval   time.Duration
 	RestoreTimeout time.Duration
 	Scrollback     ScrollbackConfig
+
+	// RestoreAllowlist limits which commands are replayed on restore, matched by
+	// executable name. A nil slice means no allowlist is configured and every
+	// command is restored (the default). A non-nil slice — including an empty
+	// one — activates the allowlist: only the listed commands are restored, and
+	// an empty list restores none.
+	RestoreAllowlist []string
 }
 
 type ScrollbackConfig struct {
@@ -106,11 +113,12 @@ func LoadFrom(path string) (Config, error) {
 // leaves the corresponding default untouched, rather than overwriting it with a
 // zero value.
 type fileConfig struct {
-	TmuxBin        *string             `toml:"tmux_bin"`
-	DataDir        *string             `toml:"data_dir"`
-	SaveInterval   *duration           `toml:"save_interval"`
-	RestoreTimeout *duration           `toml:"restore_timeout"`
-	Scrollback     *fileScrollbackConf `toml:"scrollback"`
+	TmuxBin          *string             `toml:"tmux_bin"`
+	DataDir          *string             `toml:"data_dir"`
+	SaveInterval     *duration           `toml:"save_interval"`
+	RestoreTimeout   *duration           `toml:"restore_timeout"`
+	RestoreAllowlist *[]string           `toml:"restore_allowlist"`
+	Scrollback       *fileScrollbackConf `toml:"scrollback"`
 }
 
 type fileScrollbackConf struct {
@@ -134,6 +142,17 @@ func (cfg Config) withFile(file fileConfig) Config {
 
 	if file.RestoreTimeout != nil {
 		cfg.RestoreTimeout = file.RestoreTimeout.Duration
+	}
+
+	if file.RestoreAllowlist != nil {
+		// Keep the slice non-nil even when empty so a configured-but-empty
+		// allowlist stays distinguishable from "no allowlist configured".
+		allowlist := *file.RestoreAllowlist
+		if allowlist == nil {
+			allowlist = []string{}
+		}
+
+		cfg.RestoreAllowlist = allowlist
 	}
 
 	if file.Scrollback != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -62,7 +63,7 @@ func TestLoadFromMissingFileUsesDefaults(t *testing.T) {
 		t.Fatalf("missing file must not error: %v", err)
 	}
 
-	if cfg != Default() {
+	if !reflect.DeepEqual(cfg, Default()) {
 		t.Fatalf("missing file should yield defaults, got %+v", cfg)
 	}
 }
@@ -160,6 +161,40 @@ func TestLoadFromInvalidDurationErrors(t *testing.T) {
 
 	if _, err := LoadFrom(path); err == nil {
 		t.Fatal("expected error for invalid duration")
+	}
+}
+
+func TestLoadFromRestoreAllowlist(t *testing.T) {
+	// Absent key -> nil (allowlist disabled, restore everything).
+	cfg, err := LoadFrom(writeConfig(t, "tmux_bin = \"tmux\"\n"))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if cfg.RestoreAllowlist != nil {
+		t.Fatalf("absent allowlist should be nil, got %#v", cfg.RestoreAllowlist)
+	}
+
+	// Populated list.
+	cfg, err = LoadFrom(writeConfig(t, "restore_allowlist = [\"nvim\", \"htop\"]\n"))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if len(cfg.RestoreAllowlist) != 2 ||
+		cfg.RestoreAllowlist[0] != "nvim" ||
+		cfg.RestoreAllowlist[1] != "htop" {
+		t.Fatalf("allowlist: got %#v", cfg.RestoreAllowlist)
+	}
+
+	// Explicitly empty list -> non-nil empty (allowlist active, restore nothing).
+	cfg, err = LoadFrom(writeConfig(t, "restore_allowlist = []\n"))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if cfg.RestoreAllowlist == nil || len(cfg.RestoreAllowlist) != 0 {
+		t.Fatalf("empty allowlist should be non-nil empty, got %#v", cfg.RestoreAllowlist)
 	}
 }
 

--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -75,6 +75,13 @@ type Client struct {
 	bin           string
 	runner        commandRunner
 	settleTimeout time.Duration
+
+	// allowlist limits which commands RestoreSession replays, keyed by
+	// executable name. allowlistSet distinguishes "no allowlist configured"
+	// (restore everything) from a configured-but-empty allowlist (restore
+	// nothing).
+	allowlist    map[string]struct{}
+	allowlistSet bool
 }
 
 func NewClient(bin string) *Client {
@@ -105,6 +112,30 @@ func NewClientWithRunner(bin string, cmdRunner commandRunner) *Client {
 // the previous fire-and-forget behavior.
 func (client *Client) SetRestoreTimeout(timeout time.Duration) {
 	client.settleTimeout = timeout
+}
+
+// SetRestoreAllowlist configures which commands RestoreSession may replay,
+// matched by executable name. A nil slice clears the allowlist so every command
+// is restored; a non-nil slice (including an empty one) activates it, restoring
+// only the listed commands. List entries are normalized to their executable
+// name, so both "nvim" and "/usr/bin/nvim" match a pane running nvim.
+func (client *Client) SetRestoreAllowlist(list []string) {
+	if list == nil {
+		client.allowlistSet = false
+		client.allowlist = nil
+
+		return
+	}
+
+	client.allowlistSet = true
+	client.allowlist = make(map[string]struct{}, len(list))
+
+	for _, item := range list {
+		name := executableName(strings.TrimSpace(item))
+		if name != "" {
+			client.allowlist[name] = struct{}{}
+		}
+	}
 }
 
 func sessionTarget(name string) string {
@@ -689,6 +720,12 @@ func (client *Client) restoreWindowCommands(
 			continue
 		}
 
+		// Skip commands the allowlist does not permit, so lazy-tmux never
+		// replays arbitrary programs the user has not opted into (issue #74).
+		if !client.commandAllowed(executableName(cmd)) {
+			continue
+		}
+
 		target := sessionPaneTarget(sessionName, windowIndex, pane.Index)
 
 		_, err := client.Output("send-keys", "-t", target, cmd, "C-m")
@@ -700,16 +737,30 @@ func (client *Client) restoreWindowCommands(
 	return nil
 }
 
+// commandAllowed reports whether a command with the given executable name may be
+// restored under the current allowlist. With no allowlist configured every
+// command is allowed.
+func (client *Client) commandAllowed(executable string) bool {
+	if !client.allowlistSet {
+		return true
+	}
+
+	_, ok := client.allowlist[executable]
+
+	return ok
+}
+
 // expectedPaneCommands maps "window.pane" to the foreground command we expect a
 // pane to be running once its restore command has actually started. Panes with
-// nothing to restore are omitted.
-func expectedPaneCommands(windows []snapshot.Window) map[string]string {
+// nothing to restore, or whose command the allowlist blocks, are omitted so the
+// settle wait does not block on commands that will never start.
+func (client *Client) expectedPaneCommands(windows []snapshot.Window) map[string]string {
 	want := make(map[string]string)
 
 	for _, window := range windows {
 		for _, pane := range window.Panes {
 			exe := executableName(normalizedCommand(pane.RestoreCmd, pane.CurrentCmd))
-			if exe == "" {
+			if exe == "" || !client.commandAllowed(exe) {
 				continue
 			}
 
@@ -763,7 +814,7 @@ func (client *Client) waitForRestoredCommands(sessionName string, windows []snap
 		return
 	}
 
-	want := expectedPaneCommands(windows)
+	want := client.expectedPaneCommands(windows)
 	if len(want) == 0 {
 		return
 	}

--- a/internal/tmux/client_test.go
+++ b/internal/tmux/client_test.go
@@ -125,7 +125,8 @@ func TestExpectedPaneCommands(t *testing.T) {
 		},
 	}
 
-	got := expectedPaneCommands(windows)
+	// No allowlist configured -> every real command is expected.
+	got := NewClient("tmux").expectedPaneCommands(windows)
 
 	want := map[string]string{"1.0": "nvim", "2.0": "htop"}
 	if len(got) != len(want) {
@@ -136,6 +137,65 @@ func TestExpectedPaneCommands(t *testing.T) {
 		if got[key] != exe {
 			t.Fatalf("expectedPaneCommands[%q]=%q want %q (full %#v)", key, got[key], exe, got)
 		}
+	}
+}
+
+func TestRestoreAllowlist(t *testing.T) {
+	client := NewClient("tmux")
+
+	// No allowlist configured: everything is allowed.
+	if !client.commandAllowed("nvim") || !client.commandAllowed("rm") {
+		t.Fatal("with no allowlist, all commands must be allowed")
+	}
+
+	// Configured allowlist: only listed executables (path entries normalized).
+	client.SetRestoreAllowlist([]string{"nvim", "/usr/bin/htop", "  tmux  "})
+
+	for _, allowed := range []string{"nvim", "htop", "tmux"} {
+		if !client.commandAllowed(allowed) {
+			t.Fatalf("%q should be allowed", allowed)
+		}
+	}
+
+	for _, blocked := range []string{"rm", "bash", "node"} {
+		if client.commandAllowed(blocked) {
+			t.Fatalf("%q should be blocked", blocked)
+		}
+	}
+
+	// Empty (but configured) allowlist blocks everything.
+	client.SetRestoreAllowlist([]string{})
+
+	if client.commandAllowed("nvim") {
+		t.Fatal("an empty allowlist must block all commands")
+	}
+
+	// Clearing with nil restores allow-all behavior.
+	client.SetRestoreAllowlist(nil)
+
+	if !client.commandAllowed("nvim") {
+		t.Fatal("a nil allowlist must allow all commands again")
+	}
+}
+
+func TestExpectedPaneCommandsRespectsAllowlist(t *testing.T) {
+	windows := []snapshot.Window{
+		{
+			Index: 1,
+			Panes: []snapshot.Pane{
+				{Index: 0, RestoreCmd: "nvim"},
+				{Index: 1, RestoreCmd: "htop"},
+			},
+		},
+	}
+
+	client := NewClient("tmux")
+	client.SetRestoreAllowlist([]string{"nvim"})
+
+	got := client.expectedPaneCommands(windows)
+
+	if len(got) != 1 || got["1.0"] != "nvim" {
+		t.Fatalf("allowlist should keep only nvim, got %#v", got)
 	}
 }
 

--- a/internal/tmux/integration_test.go
+++ b/internal/tmux/integration_test.go
@@ -117,6 +117,64 @@ func TestRestoreWaitsForCommandsToStart(t *testing.T) {
 	}
 }
 
+// TestRestoreAllowlistFiltersCommands covers issue #74 end-to-end: with an
+// allowlist configured, only permitted commands are replayed; a disallowed
+// command leaves its pane at the shell.
+func TestRestoreAllowlistFiltersCommands(t *testing.T) {
+	testutil.IsolatedTmux(t)
+
+	client := tmux.NewClient("tmux")
+	client.SetRestoreAllowlist([]string{"cat"}) // allow cat, block everything else
+
+	const name = "guarded"
+
+	// Two panes: one runs an allowed command (cat), one a blocked command (tail).
+	// Both block on stdin, so if restored they would show as the foreground cmd.
+	snap := snapshot.SessionSnapshot{
+		Version:     snapshot.FormatVersion,
+		SessionName: name,
+		CurrentWin:  1,
+		CurrentPane: 0,
+		Windows: []snapshot.Window{
+			{
+				Index: 1, Name: "main", IsActive: true, ActivePane: 0,
+				Panes: []snapshot.Pane{
+					{Index: 0, CurrentPath: "/tmp", RestoreCmd: "cat", IsActive: true},
+					{Index: 1, CurrentPath: "/tmp", RestoreCmd: "tail"},
+				},
+			},
+		},
+	}
+
+	if err := client.RestoreSession(snap); err != nil {
+		t.Fatalf("restore failed: %v", err)
+	}
+
+	out := testutil.Tmux(
+		t,
+		"list-panes",
+		"-t",
+		"="+name,
+		"-F",
+		"#{pane_index} #{pane_current_command}",
+	)
+
+	cmds := map[string]string{}
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		if fields := strings.Fields(line); len(fields) == 2 {
+			cmds[fields[0]] = fields[1]
+		}
+	}
+
+	if cmds["0"] != "cat" {
+		t.Fatalf("allowed pane should run cat, got %q (all: %v)", cmds["0"], cmds)
+	}
+
+	if cmds["1"] == "tail" {
+		t.Fatalf("blocked pane must not run tail, but it did (all: %v)", cmds)
+	}
+}
+
 // TestRestoreHonorsRecordedFocus guards the happy path: when the recorded
 // current window exists, restore focuses exactly that window rather than
 // falling back.

--- a/lazy-tmux.example.toml
+++ b/lazy-tmux.example.toml
@@ -21,6 +21,12 @@ save_interval = "5m"
 # before returning. "0s" disables waiting (old fire-and-forget behavior).
 restore_timeout = "5s"
 
+# Allowlist of commands lazy-tmux may replay on restore, matched by program
+# name (e.g. "nvim" matches "/usr/bin/nvim main.go"). Omit this key entirely to
+# restore every command (the default). Provide a list to restore only those
+# programs; use an empty list [] to restore no commands at all.
+# restore_allowlist = ["nvim", "vim", "htop", "less", "tail", "ssh"]
+
 [scrollback]
 # Capture and replay shell pane scrollback on save/restore.
 enabled = false


### PR DESCRIPTION
Closes #74

The second PR for #74 — on top of the config system (#118). It implements what was agreed in the issue discussion: restrict which commands lazy-tmux restores, so it never re-runs an arbitrary program that happened to be active at save time (like the allowlist in tmux-resurrect).

## Behavior

Configured via the `restore_allowlist` key in TOML, matched by executable name:

```toml
restore_allowlist = ["nvim", "vim", "htop", "less", "tail", "ssh"]
```

- **Key omitted** → allowlist is off, every command is restored (default, backward compatible).
- **List given** → only the listed programs are restored; the rest are skipped (the pane is created with the shell/path, but the command is not replayed).
- **Empty list `[]`** → no command is restored at all (for the most cautious).

Matching is by basename: an entry `nvim` (or `/usr/bin/nvim`) matches a pane running `nvim main.go`.

## Implementation

- `config.RestoreAllowlist []string` (nil = off / non-nil = active, distinguished via nil-vs-set). Passed into `tmux.Client` via `SetRestoreAllowlist`.
- Filtering in `restoreWindowCommands` (don't send disallowed commands) **and** in `expectedPaneCommands` (so the settle-wait doesn't wait on disallowed commands, which would otherwise block until the timeout).

## Tests

- Unit: `TestRestoreAllowlist` (allow-all when nil, list filtering with path normalization, empty list = block everything, nil → allow-all again), `TestExpectedPaneCommandsRespectsAllowlist`, config `TestLoadFromRestoreAllowlist` (list / empty / absent).
- Integration (real tmux): `TestRestoreAllowlistFiltersCommands` — two panes (`cat` allowed, `tail` disallowed), allowlist `["cat"]`; verified that without filtering the test fails (`map[0:cat 1:tail]`), and with the fix `tail` doesn't start.

`make test` — 107; `make integration-test` — 107 (podman + real tmux); lint/vet clean. README + `lazy-tmux.example.toml` updated.
