### PR TITLE
fix(release): prevent AUR push race between concurrent releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - "v*.*.*"
 
+# Serialize releases so two tags pushed close together never run their AUR
+# pushes concurrently and race each other (non-fast-forward rejections).
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 permissions:
   contents: write
 

--- a/scripts/aur-update.sh
+++ b/scripts/aur-update.sh
@@ -35,7 +35,9 @@ fi
 workdir=$(mktemp -d)
 trap 'rm -rf "$workdir"' EXIT
 
-git clone --depth=1 --single-branch "$AUR_REPO_URL" "$workdir"
+# Full (not shallow) clone so the rebase-on-retry below has the history it needs
+# if a concurrent release advanced the AUR repo between clone and push.
+git clone --single-branch "$AUR_REPO_URL" "$workdir"
 
 pkgbuild="$workdir/PKGBUILD"
 srcinfo="$workdir/.SRCINFO"
@@ -64,4 +66,18 @@ if git -C "$workdir" diff --cached --quiet; then
 fi
 
 git -C "$workdir" commit -m "update to ${tag}"
-git -C "$workdir" push
+
+# Push with retry: a concurrent release may have advanced the AUR repo since we
+# cloned, which rejects the push as non-fast-forward. Rebase onto the latest
+# remote state and retry a few times before giving up.
+for attempt in 1 2 3; do
+  if git -C "$workdir" push; then
+    exit 0
+  fi
+
+  echo "AUR push rejected (attempt ${attempt}); rebasing onto remote and retrying" >&2
+  git -C "$workdir" pull --rebase --no-edit
+done
+
+echo "AUR push failed after retries" >&2
+exit 1


### PR DESCRIPTION
Release **v0.1.19** failed at the "Update AUR" step. This is not a code defect — both GitHub releases (v0.1.18 and v0.1.19) published fully with all artifacts; only the AUR push went red.

## Cause

Two tags (`v0.1.18` and `v0.1.19`) were pushed almost simultaneously → two release workflows ran in parallel. `aur-update.sh` does `git clone` of the AUR repo → commit → `push`. v0.1.18 pushed first and moved AUR forward; v0.1.19 pushed on top of a stale clone → `failed to push some refs` (non-fast-forward).

AUR is currently on 0.1.18 (the code is identical to 0.1.19 — it's a merge of the same tree), so users do get the feature; the only problem is the red workflow and a one-patch desync.

## Fix

- **`concurrency: group: release`** in `release.yml` — releases are now serialized, so two tags in a row won't run in parallel.
- **Resilient AUR push** in `aur-update.sh`: full clone (not `--depth=1`) + retry with `git pull --rebase` when the push is rejected. Belt-and-suspenders in case the race happens anyway.

Verified: `bash -n scripts/aur-update.sh` ok.

Takes effect from the next release (v0.1.20), which will also bring AUR back in sync. No re-cut of v0.1.19 is needed — the feature is already in the published releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release pipeline reliability so tag-triggered releases run one at a time and won’t cancel an in-progress release.
  * Made update publishing more resilient by retrying failed pushes and automatically syncing with the latest remote changes before retrying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
