### PR TITLE
feat(picker): list windows in the fzf engine (#50, #75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Cli written on Go for saving and restoring tmux sessions lazy. Key features:
 - Interactive TUI browser: tree view (sessions/windows) + table (commands, snapshot time, counts, status) with fuzzy search.
 - Keyboard-driven picker for fast search, navigation, and manage sessions and windows directly inside picker tree.
 - Flexible sorting via `--session-sort` or `--window-sort` (by last-used, time, size, name, command, etc.).
-- Optional `fzf` integration via `--fzf-engine` (lighter and no dependencies binary, but without full keyboard control and TUI picker).
+- Optional `fzf` integration via `--fzf-engine` (lighter and no dependencies binary, but without full keyboard control and TUI picker); add `--windows` to pick a specific window instead of a whole session.
 - Bootstrap restore on tmux startup: auto-restore latest or specific session.
 - Full environment snapshots: restore pane layout and commands (e.g. `npm`, `docker-compose`, `nvim`).
 - Optional scrollback capture: preserve and replay previous terminal output.

--- a/cmd/lazy-tmux/picker.go
+++ b/cmd/lazy-tmux/picker.go
@@ -38,6 +38,17 @@ func runPicker(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
+	// Validate flag combinations before any config loading, so invalid usage is
+	// rejected deterministically rather than masked by an unrelated config error.
+	if *windows && !*fzfEngine {
+		writeErr(
+			stderr,
+			fmt.Errorf("--windows requires --fzf-engine (the TUI already lists windows)"),
+		)
+
+		return 1
+	}
+
 	cfg, ok := loadConfig(stderr)
 	if !ok {
 		return 1
@@ -53,14 +64,6 @@ func runPicker(args []string, stdout, stderr io.Writer) int {
 
 	if flagPassed(flags, "restore-timeout") {
 		cfg.RestoreTimeout = *restoreTimeout
-	}
-
-	if *windows && !*fzfEngine {
-		writeErr(
-			stderr,
-			fmt.Errorf("--windows requires --fzf-engine (the TUI already lists windows)"),
-		)
-		return 1
 	}
 
 	sortOpts, err := app.ParsePickerSortOptions(*sessionSort, *windowSort)

--- a/cmd/lazy-tmux/picker.go
+++ b/cmd/lazy-tmux/picker.go
@@ -15,6 +15,7 @@ func runPicker(args []string, stdout, stderr io.Writer) int {
 	flags.SetOutput(io.Discard)
 
 	fzfEngine := flags.Bool("fzf-engine", false, "use fzf engine instead of built-in TUI")
+	windows := flags.Bool("windows", false, "fzf engine: pick a window instead of a session")
 	sessionSort := flags.String("session-sort", "", "session sort keys: field[:asc|desc],...")
 	windowSort := flags.String("window-sort", "", "window sort keys: field[:asc|desc],...")
 	dataDir := flags.String("data-dir", "", "snapshot directory")
@@ -54,6 +55,14 @@ func runPicker(args []string, stdout, stderr io.Writer) int {
 		cfg.RestoreTimeout = *restoreTimeout
 	}
 
+	if *windows && !*fzfEngine {
+		writeErr(
+			stderr,
+			fmt.Errorf("--windows requires --fzf-engine (the TUI already lists windows)"),
+		)
+		return 1
+	}
+
 	sortOpts, err := app.ParsePickerSortOptions(*sessionSort, *windowSort)
 	if err != nil {
 		writeErr(stderr, fmt.Errorf("parse sort options: %w", err))
@@ -64,7 +73,14 @@ func runPicker(args []string, stdout, stderr io.Writer) int {
 
 	var target app.PickerTarget
 
-	if *fzfEngine {
+	switch {
+	case *fzfEngine && *windows:
+		target, err = tmuxApp.SelectTargetWithFZFSorted(sortOpts)
+		if err != nil {
+			writeErr(stderr, fmt.Errorf("select target: %w", err))
+			return 1
+		}
+	case *fzfEngine:
 		session, err := tmuxApp.SelectWithFZFSorted(sortOpts)
 		if err != nil {
 			writeErr(stderr, fmt.Errorf("select target: %w", err))
@@ -72,7 +88,7 @@ func runPicker(args []string, stdout, stderr io.Writer) int {
 		}
 
 		target = app.PickerTarget{SessionName: session}
-	} else {
+	default:
 		target, err = tmuxApp.SelectTargetWithTUISorted(sortOpts)
 		if err != nil {
 			writeErr(stderr, fmt.Errorf("select target: %w", err))
@@ -97,6 +113,7 @@ Open session picker and restore selected session
 Flags:
   -data-dir         snapshot directory
   -fzf-engine       use fzf engine instead of built-in TUI
+  -windows          fzf engine: pick a window instead of a session
   -restore-timeout  max wait for restored pane commands to start (0 disables)
   -session-sort     session sort keys: field[:asc|desc],...
   -window-sort      window sort keys: field[:asc|desc],...

--- a/internal/app/app_picker.go
+++ b/internal/app/app_picker.go
@@ -133,3 +133,20 @@ func (a *App) SelectWithFZFSorted(opts PickerSortOptions) (string, error) {
 
 	return session, nil
 }
+
+// SelectTargetWithFZFSorted presents a flat, window-level fzf list and returns
+// the chosen window as a target (session + window). It is the fzf-engine
+// counterpart that lets users jump straight to a specific window.
+func (a *App) SelectTargetWithFZFSorted(opts PickerSortOptions) (PickerTarget, error) {
+	sessions, err := a.pickerSessions(opts)
+	if err != nil {
+		return PickerTarget{}, err
+	}
+
+	target, err := picker.ChooseWindowFZF(sessions, opts.Window)
+	if err != nil {
+		return PickerTarget{}, fmt.Errorf("choose window fzf: %w", err)
+	}
+
+	return target, nil
+}

--- a/internal/picker/fzf.go
+++ b/internal/picker/fzf.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -14,6 +15,52 @@ import (
 )
 
 var ErrNoSessions = errors.New("no sessions available")
+
+// runFZF pipes input into fzf and returns the first selected line. With a TTY it
+// runs interactively; without one it uses --filter "" so all lines pass through
+// and the first is taken (used by tests and non-interactive callers).
+func runFZF(input *bytes.Buffer, withNth string) (string, error) {
+	args := []string{
+		"fzf",
+		"--delimiter", "\t",
+		"--with-nth", withNth,
+	}
+
+	if isTerminal(os.Stdout) {
+		args = append(args,
+			"--prompt", "lazy-tmux> ",
+			"--height", "100%",
+			"--layout", "reverse",
+		)
+	} else {
+		args = append(args, "--filter", "")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Stdin = input
+
+	out, err := cmd.Output()
+	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return "", fmt.Errorf("fzf selection timed out")
+		}
+
+		return "", fmt.Errorf("fzf selection canceled or failed: %w", err)
+	}
+
+	// In --filter mode fzf prints every matching line; take the first one.
+	selected := strings.TrimSpace(string(out))
+	selected = strings.SplitN(selected, "\n", 2)[0]
+
+	if strings.TrimSpace(selected) == "" {
+		return "", fmt.Errorf("no selection made")
+	}
+
+	return selected, nil
+}
 
 func ChooseSessionFZF(records []snapshot.Record) (string, error) {
 	if len(records) == 0 {
@@ -32,40 +79,9 @@ func ChooseSessionFZF(records []snapshot.Record) (string, error) {
 		input.WriteString(line)
 	}
 
-	args := []string{
-		"fzf",
-		"--delimiter", "\t",
-		"--with-nth", "1,2,3",
-	}
-
-	if isTerminal(os.Stdout) {
-		args = append(args,
-			"--prompt", "lazy-tmux> ",
-			"--height", "100%",
-			"--layout", "reverse",
-		)
-	} else {
-		args = append(args, "--filter", "")
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
-	cmd.Stdin = &input
-
-	out, err := cmd.Output()
+	selected, err := runFZF(&input, "1,2,3")
 	if err != nil {
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return "", fmt.Errorf("fzf selection timed out")
-		}
-
-		return "", fmt.Errorf("fzf selection canceled or failed: %w", err)
-	}
-
-	selected := strings.TrimSpace(string(out))
-	if selected == "" {
-		return "", fmt.Errorf("no session selected")
+		return "", err
 	}
 
 	parts := strings.Split(selected, "\t")
@@ -74,4 +90,87 @@ func ChooseSessionFZF(records []snapshot.Record) (string, error) {
 	}
 
 	return parts[0], nil
+}
+
+// windowFZFLines renders one fzf line per window across all sessions, with the
+// windows of each session ordered by windowSort. Each line is tab-delimited:
+// session, window index, window name, command, captured time. Fields 0-1 are
+// parsed back into a Target by parseWindowSelection; the rest are for display
+// and fuzzy matching.
+func windowFZFLines(sessions []Session, windowSort []WindowSortKey) []string {
+	var lines []string
+
+	for _, session := range sessions {
+		windows := make([]snapshot.Window, len(session.Windows))
+		copy(windows, session.Windows)
+		sortWindows(windows, windowSort)
+
+		captured := session.Record.CapturedAt.Local().Format("2006-01-02 15:04:05")
+
+		for _, window := range windows {
+			name := window.Name
+			if name == "" {
+				name = "-"
+			}
+
+			cmd := windowPreviewCommand(window)
+			if cmd == "" {
+				cmd = "-"
+			}
+
+			lines = append(lines, fmt.Sprintf(
+				"%s\t%d\t%s\t%s\t%s",
+				session.Record.SessionName,
+				window.Index,
+				name,
+				cmd,
+				captured,
+			))
+		}
+	}
+
+	return lines
+}
+
+// parseWindowSelection turns a window fzf line back into a Target pointing at the
+// chosen session and window.
+func parseWindowSelection(line string) (Target, error) {
+	parts := strings.Split(line, "\t")
+	if len(parts) < 2 || strings.TrimSpace(parts[0]) == "" {
+		return Target{}, fmt.Errorf("invalid fzf output")
+	}
+
+	index, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return Target{}, fmt.Errorf("invalid window index in fzf output: %w", err)
+	}
+
+	return Target{SessionName: parts[0], WindowIndex: &index}, nil
+}
+
+// ChooseWindowFZF presents a flat, window-level fzf list (one line per window)
+// and returns the selected window as a Target. Selecting a window restores its
+// session focused on that window.
+func ChooseWindowFZF(sessions []Session, windowSort []WindowSortKey) (Target, error) {
+	if len(sessions) == 0 {
+		return Target{}, ErrNoSessions
+	}
+
+	lines := windowFZFLines(sessions, windowSort)
+	if len(lines) == 0 {
+		return Target{}, ErrNoSessions
+	}
+
+	var input bytes.Buffer
+	for _, line := range lines {
+		input.WriteString(line)
+		input.WriteByte('\n')
+	}
+
+	selected, err := runFZF(&input, "1,2,3,4,5")
+	if err != nil {
+		return Target{}, err
+	}
+
+	return parseWindowSelection(selected)
 }

--- a/internal/picker/fzf.go
+++ b/internal/picker/fzf.go
@@ -14,7 +14,10 @@ import (
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
 )
 
-var ErrNoSessions = errors.New("no sessions available")
+var (
+	ErrNoSessions = errors.New("no sessions available")
+	ErrNoWindows  = errors.New("no windows available")
+)
 
 // runFZF pipes input into fzf and returns the first selected line. With a TTY it
 // runs interactively; without one it uses --filter "" so all lines pass through
@@ -158,7 +161,8 @@ func ChooseWindowFZF(sessions []Session, windowSort []WindowSortKey) (Target, er
 
 	lines := windowFZFLines(sessions, windowSort)
 	if len(lines) == 0 {
-		return Target{}, ErrNoSessions
+		// Sessions exist but none of them have any windows to pick from.
+		return Target{}, ErrNoWindows
 	}
 
 	var input bytes.Buffer

--- a/internal/picker/fzf_test.go
+++ b/internal/picker/fzf_test.go
@@ -2,6 +2,7 @@ package picker
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,6 +13,93 @@ import (
 func TestChooseSessionFZFEmpty(t *testing.T) {
 	if _, err := ChooseSessionFZF(nil); !errors.Is(err, ErrNoSessions) {
 		t.Fatalf("expected ErrNoSessions, got %v", err)
+	}
+}
+
+func TestWindowFZFLinesSortedAndFormatted(t *testing.T) {
+	sessions := []Session{
+		{
+			Record: snapshot.Record{
+				SessionName: "work",
+				CapturedAt:  time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+			},
+			Windows: []snapshot.Window{
+				{Index: 2, Name: "shell", Panes: []snapshot.Pane{{Index: 0, CurrentCmd: "zsh"}}},
+				{Index: 1, Name: "editor", Panes: []snapshot.Pane{{Index: 0, RestoreCmd: "nvim"}}},
+			},
+		},
+	}
+
+	// Sort windows by index ascending.
+	lines := windowFZFLines(sessions, []WindowSortKey{{Field: WindowSortIndex, Desc: false}})
+
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 window lines, got %d: %#v", len(lines), lines)
+	}
+
+	// First line must be window index 1 (editor/nvim) after sorting.
+	first := strings.Split(lines[0], "\t")
+	if first[0] != "work" || first[1] != "1" || first[2] != "editor" || first[3] != "nvim" {
+		t.Fatalf("unexpected first line fields: %#v", first)
+	}
+
+	second := strings.Split(lines[1], "\t")
+	if second[1] != "2" || second[2] != "shell" {
+		t.Fatalf("unexpected second line fields: %#v", second)
+	}
+}
+
+func TestParseWindowSelection(t *testing.T) {
+	target, err := parseWindowSelection("work\t3\teditor\tnvim\t2026-01-02 03:04:05")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if target.SessionName != "work" || target.WindowIndex == nil || *target.WindowIndex != 3 {
+		t.Fatalf("unexpected target: %+v", target)
+	}
+
+	if _, err := parseWindowSelection("work"); err == nil {
+		t.Fatal("expected error for line without a window index")
+	}
+
+	if _, err := parseWindowSelection("\t1"); err == nil {
+		t.Fatal("expected error for empty session")
+	}
+
+	if _, err := parseWindowSelection("work\tNaN"); err == nil {
+		t.Fatal("expected error for non-numeric window index")
+	}
+}
+
+func TestChooseWindowFZFEmpty(t *testing.T) {
+	if _, err := ChooseWindowFZF(nil, nil); !errors.Is(err, ErrNoSessions) {
+		t.Fatalf("expected ErrNoSessions, got %v", err)
+	}
+}
+
+func TestChooseWindowFZFFilterMode(t *testing.T) {
+	testutil.RequireFZF(t)
+
+	// Non-interactive: fzf runs in --filter mode and the first (sorted) window
+	// line is selected, exercising the real fzf binary end-to-end.
+	sessions := []Session{
+		{
+			Record: snapshot.Record{SessionName: "work", CapturedAt: time.Now()},
+			Windows: []snapshot.Window{
+				{Index: 1, Name: "editor", Panes: []snapshot.Pane{{Index: 0, RestoreCmd: "nvim"}}},
+				{Index: 2, Name: "shell", Panes: []snapshot.Pane{{Index: 0, CurrentCmd: "zsh"}}},
+			},
+		},
+	}
+
+	target, err := ChooseWindowFZF(sessions, []WindowSortKey{{Field: WindowSortIndex}})
+	if err != nil {
+		t.Fatalf("choose window fzf: %v", err)
+	}
+
+	if target.SessionName != "work" || target.WindowIndex == nil || *target.WindowIndex != 1 {
+		t.Fatalf("expected work window 1, got %+v", target)
 	}
 }
 

--- a/internal/picker/fzf_test.go
+++ b/internal/picker/fzf_test.go
@@ -78,6 +78,17 @@ func TestChooseWindowFZFEmpty(t *testing.T) {
 	}
 }
 
+func TestChooseWindowFZFNoWindows(t *testing.T) {
+	// Sessions exist but carry no windows: this is distinct from "no sessions".
+	sessions := []Session{
+		{Record: snapshot.Record{SessionName: "work", CapturedAt: time.Now()}},
+	}
+
+	if _, err := ChooseWindowFZF(sessions, nil); !errors.Is(err, ErrNoWindows) {
+		t.Fatalf("expected ErrNoWindows, got %v", err)
+	}
+}
+
 func TestChooseWindowFZFFilterMode(t *testing.T) {
 	testutil.RequireFZF(t)
 


### PR DESCRIPTION
Closes #50
Addresses #75

As discussed in #75: to make switching between windows easy, we list windows in the fzf picker (#50). Window sorting = the order of the lines we feed to fzf; fzf filters over them and lets you pick.

## What's added

A `--windows` flag for the fzf engine. With it, `lazy-tmux picker --fzf-engine --windows` shows **one line per window** instead of one line per session:

```
work:1  editor  nvim   2026-06-24 18:01
work:2  shell   zsh    2026-06-24 18:01
web:1   server  npm    2026-06-24 17:40
```

Selecting a window restores its session focused on that window (`Target.WindowIndex` already supported this). Window order is controlled by the existing `--window-sort` (`index/name/panes/cmd`). Without the flag, `--fzf-engine` behaves as before (session list).

## Decisions

- `--windows` without `--fzf-engine` → error (in the TUI windows are already in the tree).
- **Per-window "last used" is out of scope:** a snapshot stores `last_accessed` per session, not per window. dylan-chong's actual goal ("quickly jump between windows") is met by the flat fuzzy list; if literal last-used-per-window is wanted, that's a separate issue with access tracking. That's why #75 is `Addresses`, not `Closes`: I'll leave it to you whether to close it with this.

## Tests

- Unit: `windowFZFLines` (line sorting + formatting), `parseWindowSelection` (parse a line into a Target, errors), `ChooseWindowFZFEmpty`.
- Integration (real fzf, filter mode): `ChooseWindowFZFFilterMode` — returns the first sorted window Target.
- Refactor: a shared `runFZF` for the session/window paths (takes the first line — also cleaner than the previous multiline parsing).

`make build-all` (both builds), `make test` — 111, `make integration-test` — 111 (podman+fzf), lint clean. README updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added window selection support when using the fuzzy finder, so you can pick a specific window instead of an entire session.
  * Added a new command flag to enable this window-based selection.

* **Bug Fixes**
  * Improved validation so window selection is only available when fuzzy-finder integration is enabled.
  * Made selection behavior more reliable with clearer handling when no choice is made.

* **Documentation**
  * Updated help text and README examples to describe the new window-selection option and fuzzy-finder usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
