### PR TITLE
test(ci): make the tmux version matrix representative (#126)

### DIFF
--- a/docker/test-versions-inner.sh
+++ b/docker/test-versions-inner.sh
@@ -1,76 +1,157 @@
 #!/bin/sh
+#
+# Per-version tmux compatibility check, run inside the sandbox image by
+# scripts/test-tmux-versions.sh. For each tmux version passed as an argument it
+# builds and installs that tmux from source, then exercises lazy-tmux against a
+# REALISTIC session and asserts the save/list round-trip is faithful.
+#
+# A version is reported supported (✓) only when:
+#   * save and list run with a zero exit code AND no error output, and
+#   * the saved snapshot reflects the live session (window and pane counts).
+#
+# This is deliberately stricter than the old check, which started a single
+# `sleep 30` pane, swallowed all save/list output, and marked ✓ on a bare
+# `grep vtest`. That hid real failures (see issues #125 / #126): a version could
+# fail on a real multi-window, multi-pane, attached session yet still pass.
+#
+# Output contract (consumed by scripts/parse-output.sh and format-comment.sh):
+# exactly one "  tmux <version>  ✓" or "  tmux <version>  ✗" line per version on
+# stdout. Failure diagnostics go to stderr so they appear in the raw CI log
+# without polluting the parsed summary.
 
-for version in "$@"; do
+set -u
+
+# The fixture below builds a session with three windows; window 0 holds two
+# panes, so four panes total.
+EXPECT_WINDOWS=3
+
+log() { printf '      %s\n' "$1" >&2; }
+
+# Build and install one tmux version from source, replacing any currently
+# installed tmux. Returns non-zero (with a diagnostic) on any failure.
+build_tmux() {
+    version=$1
     url="https://github.com/tmux/tmux/releases/download/${version}/tmux-${version}.tar.gz"
 
-    old_tmux=$(which tmux 2>/dev/null) || true
-    if [ -n "$old_tmux" ]; then
-        rm -f "$old_tmux"
-    fi
+    old_tmux=$(command -v tmux 2>/dev/null) || true
+    [ -n "$old_tmux" ] && rm -f "$old_tmux"
     rm -f /usr/local/bin/tmux* /usr/local/share/man/man1/tmux.1
     rm -rf /tmp/tmux-* /tmp/tmux-*.tar.gz
     pkill -9 tmux 2>/dev/null || true
     sleep 1
 
-    cd /tmp || { printf "  tmux %-7s  ✗ (cd /tmp failed)\n" "$version"; continue; }
-    if ! curl -fsSL "$url" -o tmux.tar.gz 2>/dev/null; then
-        printf "  tmux %-7s  ✗\n" "$version"
-        cd / || true
-        continue
-    fi
-
-    if ! tar -xzf tmux.tar.gz 2>/dev/null; then
-        printf "  tmux %-7s  ✗\n" "$version"
-        cd / || true
-        continue
-    fi
-
-    cd "tmux-${version}" || { printf "  tmux %-7s  ✗ (cd tmux-%s failed)\n" "$version" "$version"; continue; }
-    if ! ./configure >/dev/null 2>&1; then
-        printf "  tmux %-7s  ✗\n" "$version"
-        cd / || true
-        continue
-    fi
-
-    if ! make -j"$(nproc)" >/dev/null 2>&1; then
-        printf "  tmux %-7s  ✗\n" "$version"
-        cd / || true
-        continue
-    fi
-
-    if ! make install >/dev/null 2>&1; then
-        printf "  tmux %-7s  ✗\n" "$version"
-        cd / || true
-        continue
-    fi
-
+    cd /tmp || { log "cd /tmp failed"; return 1; }
+    curl -fsSL "$url" -o tmux.tar.gz 2>/dev/null || { log "download failed: $url"; return 1; }
+    tar -xzf tmux.tar.gz 2>/dev/null || { log "extract failed"; return 1; }
+    cd "tmux-${version}" || { log "cd tmux-${version} failed"; return 1; }
+    ./configure >/dev/null 2>&1 || { log "configure failed"; return 1; }
+    make -j"$(nproc)" >/dev/null 2>&1 || { log "make failed"; return 1; }
+    make install >/dev/null 2>&1 || { log "make install failed"; return 1; }
     cd / || true
 
-    actual_version=$(tmux -V 2>&1 | grep -o '[0-9][0-9.]*[a-z]*' | head -1)
-    if [ "$actual_version" != "$version" ]; then
-        printf "  tmux %-7s  ✗\n" "$version"
-        continue
+    actual=$(tmux -V 2>&1 | grep -o '[0-9][0-9.]*[a-z]*' | head -1)
+    [ "$actual" = "$version" ] || { log "version mismatch: wanted $version, got '$actual'"; return 1; }
+    return 0
+}
+
+# Build a session that resembles a real user's, not a single throwaway pane:
+# multiple windows, multiple panes, real shell panes running long-lived
+# foreground programs, and a best-effort attached client.
+build_fixture() {
+    tmux kill-server 2>/dev/null || true
+    rm -rf "$HOME/.local/share/lazy-tmux"
+
+    # window 0 "editor": two shell panes, each running a long-lived program.
+    tmux new-session -d -s vtest -n editor -x 200 -y 50 || { log "new-session failed"; return 1; }
+    tmux send-keys -t vtest:editor 'vim' C-m
+    tmux split-window -h -t vtest:editor || { log "split-window failed"; return 1; }
+    tmux send-keys -t vtest:editor.1 'tail -f /dev/null' C-m
+
+    # window 1 "top": a long-lived foreground program.
+    tmux new-window -t vtest -n top || { log "new-window top failed"; return 1; }
+    tmux send-keys -t vtest:top 'top' C-m
+
+    # window 2 "shell": a plain interactive shell.
+    tmux new-window -t vtest -n shell || { log "new-window shell failed"; return 1; }
+
+    # Best-effort: attach a client through a pseudo-tty so the session reports
+    # as (attached), mirroring a real session. Never fatal if unavailable.
+    if command -v script >/dev/null 2>&1 && command -v setsid >/dev/null 2>&1; then
+        setsid sh -c 'script -q -c "tmux attach -t vtest" /dev/null' >/dev/null 2>&1 &
     fi
 
-    if ! tmux new-session -d -s vtest 'sleep 30' 2>/dev/null; then
-        printf "  tmux %-7s  ✗\n" "$version"
-        continue
-    fi
-    sleep 1
+    sleep 2  # let the foreground programs come up
+    return 0
+}
 
-    if ! lazy-tmux save --all --scrollback >/dev/null 2>&1; then
-        tmux kill-server 2>/dev/null || true
-        rm -rf ~/.local/share/lazy-tmux
-        printf "  tmux %-7s  ✗\n" "$version"
-        continue
+# Save the fixture and assert the snapshot is faithful. Diagnostics to stderr.
+check_roundtrip() {
+    live_windows=$(tmux list-windows -t vtest 2>/dev/null | wc -l | tr -d ' ')
+    live_panes=$(tmux list-panes -s -t vtest 2>/dev/null | wc -l | tr -d ' ')
+
+    # Run save WITHOUT swallowing output: any stderr or non-zero exit fails.
+    save_err=$(lazy-tmux save --all --scrollback 2>&1 >/dev/null)
+    save_rc=$?
+    if [ "$save_rc" -ne 0 ] || [ -n "$save_err" ]; then
+        log "save failed (rc=$save_rc): ${save_err:-<no output>}"
+        return 1
     fi
 
-    if lazy-tmux list 2>/dev/null | grep -q vtest; then
+    list_out=$(lazy-tmux list 2>&1)
+    list_rc=$?
+    if [ "$list_rc" -ne 0 ]; then
+        log "list failed (rc=$list_rc): ${list_out:-<no output>}"
+        return 1
+    fi
+
+    vtest_line=$(printf '%s\n' "$list_out" | grep '^vtest')
+    if [ -z "$vtest_line" ]; then
+        log "vtest missing from list output: ${list_out:-<empty>}"
+        return 1
+    fi
+
+    # list format: "<name>\t<timestamp>\t<W>w/<P>p" (see cmd/lazy-tmux/list.go).
+    counts=$(printf '%s' "$vtest_line" | awk -F'\t' '{print $3}')
+    saved_windows=$(printf '%s' "$counts" | sed 's/w.*//')
+    saved_panes=$(printf '%s' "$counts" | sed 's|.*/||; s/p$//')
+
+    case "$saved_windows" in
+        ''|*[!0-9]*) log "unparseable window count in: $vtest_line"; return 1 ;;
+    esac
+    case "$saved_panes" in
+        ''|*[!0-9]*) log "unparseable pane count in: $vtest_line"; return 1 ;;
+    esac
+
+    if [ "$saved_windows" -lt "$live_windows" ]; then
+        log "saved windows ($saved_windows) < live ($live_windows); line: $vtest_line"
+        return 1
+    fi
+    if [ "$saved_panes" -lt "$live_panes" ]; then
+        log "saved panes ($saved_panes) < live ($live_panes); line: $vtest_line"
+        return 1
+    fi
+    if [ "$saved_windows" -lt "$EXPECT_WINDOWS" ]; then
+        log "saved windows ($saved_windows) < expected $EXPECT_WINDOWS; line: $vtest_line"
+        return 1
+    fi
+
+    return 0
+}
+
+check_version() {
+    version=$1
+
+    build_tmux "$version" || return 1
+    build_fixture || return 1
+    check_roundtrip
+}
+
+for version in "$@"; do
+    if check_version "$version"; then
         printf "  tmux %-7s  ✓\n" "$version"
     else
         printf "  tmux %-7s  ✗\n" "$version"
     fi
-
     tmux kill-server 2>/dev/null || true
-    rm -rf ~/.local/share/lazy-tmux
+    rm -rf "$HOME/.local/share/lazy-tmux"
 done

--- a/docker/test-versions-inner.sh
+++ b/docker/test-versions-inner.sh
@@ -24,6 +24,7 @@ set -u
 # The fixture below builds a session with three windows; window 0 holds two
 # panes, so four panes total.
 EXPECT_WINDOWS=3
+EXPECT_PANES=4
 
 log() { printf '      %s\n' "$1" >&2; }
 
@@ -41,7 +42,7 @@ build_tmux() {
     sleep 1
 
     cd /tmp || { log "cd /tmp failed"; return 1; }
-    curl -fsSL "$url" -o tmux.tar.gz 2>/dev/null || { log "download failed: $url"; return 1; }
+    curl -fsSL --connect-timeout 15 --max-time 300 "$url" -o tmux.tar.gz 2>/dev/null || { log "download failed: $url"; return 1; }
     tar -xzf tmux.tar.gz 2>/dev/null || { log "extract failed"; return 1; }
     cd "tmux-${version}" || { log "cd tmux-${version} failed"; return 1; }
     ./configure >/dev/null 2>&1 || { log "configure failed"; return 1; }
@@ -132,6 +133,13 @@ check_roundtrip() {
     fi
     if [ "$saved_windows" -lt "$EXPECT_WINDOWS" ]; then
         log "saved windows ($saved_windows) < expected $EXPECT_WINDOWS; line: $vtest_line"
+        return 1
+    fi
+    # Absolute floor mirroring EXPECT_WINDOWS: if the live pane query failed,
+    # live_panes is 0 and the >= live check is vacuous, so assert against the
+    # known fixture size too.
+    if [ "$saved_panes" -lt "$EXPECT_PANES" ]; then
+        log "saved panes ($saved_panes) < expected $EXPECT_PANES; line: $vtest_line"
         return 1
     fi
 

--- a/scripts/test-tmux-versions.sh
+++ b/scripts/test-tmux-versions.sh
@@ -18,6 +18,11 @@ fi
 
 filtered=""
 for v in $versions; do
+    # Skip pre-releases / release candidates (e.g. 3.7-rc): their tarballs are
+    # not published under this URL scheme, so they only produce noisy ✗ rows.
+    case "$v" in
+        *-*) continue ;;
+    esac
     major=$(echo "$v" | cut -d. -f1)
     minor=$(echo "$v" | cut -d. -f2 | sed 's/[^0-9]//g')
     minor=${minor:-0}


### PR DESCRIPTION
Resolves #126.

The tmux version-support matrix reported almost every version as supported (✓), including ones where lazy-tmux actually fails on real sessions (#125). The per-version check in `docker/test-versions-inner.sh` was too shallow to be trusted:

1. it started a single trivial session — `tmux new-session -d -s vtest 'sleep 30'`: one window, one pane, no real shell;
2. it ran `lazy-tmux save --all --scrollback >/dev/null 2>&1`, **swallowing all output** and checking only the exit code;
3. it marked ✓ on a bare `lazy-tmux list | grep -q vtest`.

So a ✓ only ever meant "a trivial `sleep 30` session round-trips", not "lazy-tmux works".

## Changes

Reworked the per-version check so a ✓ means a realistic round-trip actually succeeds:

- **Realistic fixture** (`build_fixture`): 3 windows, 4 panes across real shell panes running long-lived foreground programs (`vim`, `top`, `tail -f`), plus a best-effort **attached** client through a pseudo-tty (`script`/`setsid`, never fatal). This mirrors the kind of session that fails in #125 (multi-window, attached) instead of a single throwaway pane.
- **No swallowed errors** (`check_roundtrip`): `save` runs without redirecting output away; any non-zero exit **or** any stderr fails the version. Same for `list`.
- **Faithful-snapshot assertion**: instead of just matching the session name, it parses the `list` output (`<name>\t<ts>\t<W>w/<P>p`) and requires the saved window/pane counts to be at least the live counts (and at least the 3 windows the fixture creates). A version that silently drops windows/panes now fails.
- **Diagnostics to stderr**: on failure it logs *why* (`save failed (rc=…): …`, `vtest missing from list output: …`, count mismatches). These land in the raw CI log / the bot's "Full test output" without polluting the parsed summary.

The pass/fail stdout contract (`  tmux <version>  ✓` / `✗`) consumed by `scripts/parse-output.sh` and `scripts/format-comment.sh` is unchanged, so the comparison comment keeps working.

## Validation

Validated the script logic end-to-end against a real tmux (3.6b) on an isolated socket + temp data dir (no system tmux touched), reusing the actual `build_fixture`/`check_roundtrip` functions:

- **Good path** — realistic 3-window / 4-pane session: `save`/`list` clean, counts match → **✓** (no false negative on a working tmux).
- **Failure path** — no session: `save`/`list` produce nothing → diagnostic `vtest missing from list output` on stderr → **✗** (correctly red).

`sh -n docker/test-versions-inner.sh` passes.

## Effect on the matrix

With the stricter check, every supported tmux version (2.9 … 3.6b) **still passes** in the sandbox — the published lazy-tmux genuinely round-trips a realistic 3-window / 4-pane session there. So this PR doesn't turn anything red; its value is that a ✓ now *means* "a realistic save/list round-trip works", not "a single `sleep 30` pane round-trips". A future regression that breaks multi-window save would now be caught, where the old check would have stayed green.

The reporter's failure in #125 is environment-specific (their tmux build / config) and is **not reproduced** in the Ubuntu sandbox, so it stays green here; catching that specific case is tracked separately in #125.

Also drops pre-release tags (e.g. `3.7-rc`) from the version list — their tarballs aren't published under the stable URL, so they only produced a noisy `download failed` / ✗ row.

Note the matrix builds and installs the **published** lazy-tmux (via `install.sh` in `docker/sandbox.Dockerfile`), not the PR's source — so it validates the shipped tool against each tmux version. Making it build from repo source (so it gates PR code and doesn't depend on the live site for `install.sh`) is a separate improvement worth a follow-up issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tmux version testing reliability with stricter save/list round-trip validation and clearer pass/fail output.
  * Enhanced release-version selection by skipping pre-release and release-candidate tags (hyphenated versions).
* **Chores**
  * Updated the automated tmux test flow to use a more realistic multi-window/pane session fixture and to ensure clean state between test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->