### PR TITLE
ci(pages): deploy the docs/ site via GitHub Actions (#128)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,50 @@
+name: Deploy docs to GitHub Pages
+
+# The site lives in docs/ and Pages is configured to deploy from GitHub Actions
+# (Settings → Pages → Source: GitHub Actions). This workflow publishes docs/ as
+# the site root.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+# Grant the deployment read access to the repo and permission to publish to
+# Pages via OIDC.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; never cancel an in-progress publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Stage docs/ as the site root (drop the generator source)
+        run: |
+          mkdir -p _site
+          cp -R docs/. _site/
+          # _content.html is the build-docs.py source, not a published page.
+          rm -f _site/_content.html
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Resolves #128.

`lazy-tmux.xyz` returns **404**: #124 moved the site into `docs/`, and the Pages source was switched from *Deploy from branch* to *GitHub Actions*, but there was no workflow to actually publish anything. The custom domain was dropped too (Pages API reported `cname: null`).

## What this adds

`.github/workflows/pages.yml` — a standard Pages deployment:

- **build job:** stages `docs/` into `_site/` as the site root and removes `docs/_content.html` (the `build-docs.py` source, not a published page), then uploads it with `actions/upload-pages-artifact`.
- **deploy job:** publishes via `actions/deploy-pages` into the `github-pages` environment.
- `docs/CNAME` ships inside the artifact, so the `lazy-tmux.xyz` custom domain is re-established on the first deploy.
- Triggers on pushes to `main` touching `docs/**` (and manual `workflow_dispatch`), serialized via a `pages` concurrency group with `cancel-in-progress: false`.

## Validation

- `python3 -c "yaml.safe_load(...)"` — workflow YAML parses.
- Dry-ran the staging step against the real `docs/`: `_site/` gets `index.html`, all section folders, `assets/`, `install.sh` and `CNAME` (= `lazy-tmux.xyz`); `_content.html` is dropped.

`docs/` is already on `main` (merged in #124), so merging this workflow triggers the first deploy (the push touches the workflow file) and should bring the site — and the custom domain — back. It can also be kicked manually via *Run workflow* once merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated GitHub Pages publishing for the documentation site.
  * Documentation updates now deploy on changes to the docs content or manually when needed.
  * The publishing process includes safer deployment handling and prepares the site before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->