### PR TITLE
docs(site): full-height home hero + fix white overscroll on macOS

### DIFF
--- a/docs/_content.html
+++ b/docs/_content.html
@@ -93,6 +93,11 @@
       * {
         box-sizing: border-box;
       }
+      html {
+        /* base layer behind body so macOS rubber-band overscroll reveals the
+           dark theme, not the default white background */
+        background: #050505;
+      }
       body {
         margin: 0;
         font-family: "JetBrains Mono", monospace;

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -9,6 +9,11 @@
       * {
         box-sizing: border-box;
       }
+      html {
+        /* base layer behind body so macOS rubber-band overscroll reveals the
+           dark theme, not the default white background */
+        background: #050505;
+      }
       body {
         margin: 0;
         font-family: "JetBrains Mono", monospace;
@@ -276,8 +281,20 @@
   margin: 0 0 18px;
 }
 .topbar { display: none; }
-/* home hero, centered */
-.home .hero { text-align: center; border: none; background: none; padding: 8px 0 0; }
+/* home hero: fills the first viewport and centers vertically, so the demo and
+   everything below only appear once the visitor scrolls. */
+.home .content { padding-top: 0; }
+.home .hero {
+  text-align: center;
+  border: none;
+  background: none;
+  min-height: 100vh;
+  min-height: 100svh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 0 0 8px;
+}
 .home .hero > div { justify-content: center; }
 .home .actions { justify-content: center; }
 .home .doc-section { text-align: left; }
@@ -288,6 +305,12 @@
   }
   body.nav-open .sidebar { transform: translateX(0); }
   .content { margin-left: 0; padding-top: 66px; }
+  /* keep the full-screen home hero below the fixed mobile topbar */
+  .home .content { padding-top: 66px; }
+  .home .hero {
+    min-height: calc(100vh - 66px);
+    min-height: calc(100svh - 66px);
+  }
   .topbar {
     display: flex;
     align-items: center;

--- a/scripts/build-docs.py
+++ b/scripts/build-docs.py
@@ -161,8 +161,20 @@ LAYOUT_CSS = """
   margin: 0 0 18px;
 }
 .topbar { display: none; }
-/* home hero, centered */
-.home .hero { text-align: center; border: none; background: none; padding: 8px 0 0; }
+/* home hero: fills the first viewport and centers vertically, so the demo and
+   everything below only appear once the visitor scrolls. */
+.home .content { padding-top: 0; }
+.home .hero {
+  text-align: center;
+  border: none;
+  background: none;
+  min-height: 100vh;
+  min-height: 100svh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 0 0 8px;
+}
 .home .hero > div { justify-content: center; }
 .home .actions { justify-content: center; }
 .home .doc-section { text-align: left; }
@@ -173,6 +185,12 @@ LAYOUT_CSS = """
   }
   body.nav-open .sidebar { transform: translateX(0); }
   .content { margin-left: 0; padding-top: 66px; }
+  /* keep the full-screen home hero below the fixed mobile topbar */
+  .home .content { padding-top: 66px; }
+  .home .hero {
+    min-height: calc(100vh - 66px);
+    min-height: calc(100svh - 66px);
+  }
   .topbar {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Two small landing tweaks requested on the live site.

## 1. More air on the home page

The home hero now fills the first viewport and centers vertically: the title, subtitle and `docker run` command sit centered on load, and the **Demo Preview** section (and everything below) only appears once the visitor scrolls. Mobile keeps the hero below the fixed topbar via a `calc(100svh - 66px)` offset.

## 2. Fix the white overscroll flash on macOS

On macOS, rubber-band overscroll past the top/bottom revealed the `<html>` element's default **white** background under the dark theme, which looked inconsistent. Gave `<html>` a dark base background (`#050505`) so the overscroll area stays dark. Applies site-wide.

## Notes

- CSS only — the home-hero rules are `.home`-scoped (LAYOUT_CSS in `scripts/build-docs.py`); the overscroll fix is in the shared `<style>` source (`docs/_content.html`). Regenerated with `python3 scripts/build-docs.py`; the 8 page HTML files are unchanged, only `docs/assets/style.css` regenerated.
- `100svh` with a `100vh` fallback avoids mobile URL-bar jump.
- Verified the diff is scoped to `docs/_content.html`, `docs/assets/style.css`, `scripts/build-docs.py`; local server serves all routes 200.
