### PR TITLE
test(ci): build lazy-tmux from source for the version matrix (#134)

### DIFF
--- a/docker/version-test.Dockerfile
+++ b/docker/version-test.Dockerfile
@@ -1,0 +1,42 @@
+# Image for the tmux version-support matrix (scripts/test-tmux-versions.sh).
+#
+# Unlike docker/sandbox.Dockerfile — the public demo image, which installs the
+# published lazy-tmux via the website install script — this builds lazy-tmux
+# from the repository source. That way the matrix validates the code under
+# review (not a released binary) and does not depend on lazy-tmux.xyz being up.
+
+# --- build stage: compile lazy-tmux from source ---
+FROM golang:1.26 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+# Static build so the binary runs on the ubuntu runtime stage as-is.
+RUN CGO_ENABLED=0 go build -o /out/lazy-tmux ./cmd/lazy-tmux
+
+# --- runtime stage: toolchain to build each tmux release at runtime ---
+FROM ubuntu:26.04
+ENV DEBIAN_FRONTEND=noninteractive
+
+# build-essential … bison: compile tmux from source inside the container.
+# vim, procps: the realistic fixture runs vim/top as long-lived pane programs.
+# util-linux: script/setsid for the best-effort attached client.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libevent-dev \
+    libncurses-dev \
+    bison \
+    pkg-config \
+    wget \
+    curl \
+    git \
+    ca-certificates \
+    util-linux \
+    vim \
+    procps \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /out/lazy-tmux /usr/local/bin/lazy-tmux
+
+COPY docker/test-versions-inner.sh /test-versions-inner.sh
+RUN chmod +x /test-versions-inner.sh

--- a/scripts/test-tmux-versions.sh
+++ b/scripts/test-tmux-versions.sh
@@ -3,7 +3,10 @@
 IMAGE="lazy-tmux:version-test"
 
 printf "\nBuilding test image (once)...\n"
-docker build -t "$IMAGE" -f docker/sandbox.Dockerfile . >/dev/null 2>&1
+# Build the matrix image from docker/version-test.Dockerfile, which compiles
+# lazy-tmux from this repo's source (not the published binary). Keep stderr so a
+# build failure surfaces instead of silently yielding an image without the binary.
+docker build -t "$IMAGE" -f docker/version-test.Dockerfile . >/dev/null
 
 printf "Fetching tmux releases from GitHub...\n"
 versions=$(curl -sf "https://api.github.com/repos/tmux/tmux/releases?per_page=100" \


### PR DESCRIPTION
Resolves #134.

The tmux version matrix installed lazy-tmux with `curl -fsSL https://lazy-tmux.xyz/install.sh | sh` (in `docker/sandbox.Dockerfile`), which meant it:

1. **tested the published binary, not the PR's code** — `test-pr` and `test-main` installed the same released build, so the matrix couldn't catch a regression in a PR; and
2. **depended on the live website** — when `lazy-tmux.xyz` was briefly down during the docs migration, every version failed with `lazy-tmux: not found` (install.sh returned a 404 page).

## Changes

- **`docker/version-test.Dockerfile`** (new): multi-stage build — `golang:1.26` compiles `./cmd/lazy-tmux` from the checked-out source (static, `CGO_ENABLED=0`), then an `ubuntu:26.04` runtime stage with the tmux build toolchain (`build-essential`, `libevent-dev`, …), plus `vim`/`procps` for the fixture programs and `util-linux` for the attached client. The source-built binary lands on `PATH`.
- **`scripts/test-tmux-versions.sh`**: builds from `docker/version-test.Dockerfile` instead of `docker/sandbox.Dockerfile`, and keeps build stderr (drops `2>&1`) so an image-build failure surfaces instead of silently producing a binary-less image.
- **`docker/sandbox.Dockerfile` is untouched** — the public demo image (`make sandbox` / `make docker-hub`) keeps installing the released binary.

Net: the matrix now validates the code under review and no longer depends on the site being up.

## Validation

Built the image with podman and ran one version end-to-end through the real inner script:

- image builds (both stages); the source-built `lazy-tmux` runs in the runtime stage (`lazy-tmux list` → exit 0);
- `/test-versions-inner.sh 3.6a` → compiles tmux 3.6a from source, runs the realistic fixture against the **source-built** binary → `tmux 3.6a  ✓`.

`sh -n scripts/test-tmux-versions.sh` passes.

## Note

Composes with #127 (the realistic fixture + RC filter): this PR copies `docker/test-versions-inner.sh` into the image, so once #127 lands the matrix runs the strict fixture against the source-built binary. The two PRs touch different regions of `test-tmux-versions.sh` and don't conflict.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version compatibility testing so build failures are surfaced clearly instead of being hidden.
  * The test image now uses the locally built app binary, helping ensure version checks reflect the current codebase.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->