### PR TITLE
fix(tmux): tolerate base-index/pane-base-index mismatch on restore (#137)

### DIFF
--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -506,28 +507,29 @@ func (client *Client) RestoreSession(sessionSnapshot snapshot.SessionSnapshot) e
 		}
 	}
 
-	focusWin, focusPane := resolveRestoreFocus(sessionSnapshot, windows)
-
-	_, err = client.Output(
-		"select-window",
-		"-t",
-		sessionWindowTarget(sessionSnapshot.SessionName, focusWin),
+	// Focus a window/pane that actually exists in the restored session. The
+	// recorded indices come from the snapshot and may not match what the
+	// restoring server created — when base-index / pane-base-index differ
+	// between save and restore, the recorded window 0 / pane 0 need not exist —
+	// so resolve against the live layout. Focus is cosmetic: a select failure
+	// must never abort an otherwise-successful restore, which is how `bootstrap`
+	// used to die with "can't find window: 0".
+	win, pane, ok := client.resolveLiveFocus(
+		sessionSnapshot.SessionName,
+		sessionSnapshot,
+		windows,
 	)
-	if err != nil {
-		return fmt.Errorf("select window: %w", err)
-	}
-
-	_, err = client.Output(
-		"select-pane",
-		"-t",
-		sessionPaneTarget(
-			sessionSnapshot.SessionName,
-			focusWin,
-			focusPane,
-		),
-	)
-	if err != nil {
-		return fmt.Errorf("select pane: %w", err)
+	if ok {
+		_, _ = client.Output(
+			"select-window",
+			"-t",
+			sessionWindowTarget(sessionSnapshot.SessionName, win),
+		)
+		_, _ = client.Output(
+			"select-pane",
+			"-t",
+			sessionPaneTarget(sessionSnapshot.SessionName, win, pane),
+		)
 	}
 
 	client.waitForRestoredCommands(sessionSnapshot.SessionName, windows)
@@ -1122,6 +1124,63 @@ func stripOptionPair(args []string, opt string) []string {
 	}
 
 	return out
+}
+
+// resolveLiveFocus picks a window/pane to focus that actually exists in the
+// just-restored session. It starts from the snapshot's recorded focus (via
+// resolveRestoreFocus) but falls back to the first live window/pane whenever the
+// recorded index is absent — which happens when the restoring server's
+// base-index / pane-base-index differ from the saved snapshot. The bool is false
+// when the session has no live windows to focus.
+func (client *Client) resolveLiveFocus(
+	session string,
+	sessionSnapshot snapshot.SessionSnapshot,
+	windows []snapshot.Window,
+) (int, int, bool) {
+	liveWindows := client.liveIndexes("list-windows", sessionTarget(session), "#{window_index}")
+	if len(liveWindows) == 0 {
+		return 0, 0, false
+	}
+
+	wantWin, wantPane := resolveRestoreFocus(sessionSnapshot, windows)
+
+	win := wantWin
+	if !slices.Contains(liveWindows, win) {
+		win = liveWindows[0]
+	}
+
+	pane := wantPane
+	livePanes := client.liveIndexes(
+		"list-panes",
+		sessionWindowTarget(session, win),
+		"#{pane_index}",
+	)
+	if len(livePanes) > 0 && !slices.Contains(livePanes, pane) {
+		pane = livePanes[0]
+	}
+
+	return win, pane, true
+}
+
+// liveIndexes runs a tmux list command and parses the integer index it formats,
+// one per line. It returns nil on any error so callers can fall back gracefully.
+func (client *Client) liveIndexes(listCmd, target, format string) []int {
+	out, err := client.Output(listCmd, "-t", target, "-F", format)
+	if err != nil {
+		return nil
+	}
+
+	var indexes []int
+	for _, line := range splitLines(out) {
+		n, convErr := strconv.Atoi(strings.TrimSpace(line))
+		if convErr != nil {
+			continue
+		}
+
+		indexes = append(indexes, n)
+	}
+
+	return indexes
 }
 
 func (client *Client) createdFirstWindowIndex(session string) (int, error) {

--- a/internal/tmux/integration_test.go
+++ b/internal/tmux/integration_test.go
@@ -75,6 +75,50 @@ func TestRestoreToleratesBaseIndexMismatch(t *testing.T) {
 	}
 }
 
+// TestRestoreToleratesPaneBaseIndexMismatch covers the `bootstrap` crash where a
+// snapshot captured under base-index/pane-base-index 0 is restored on a server
+// configured with base-index 1 and pane-base-index 1 (a common user config). The
+// recorded window 0 / pane 0 need not exist after restore, so focusing them used
+// to fail hard ("can't find window: 0" / "can't find pane: 0") and abort the
+// whole restore. The restore must now succeed and leave the session alive.
+func TestRestoreToleratesPaneBaseIndexMismatch(t *testing.T) {
+	testutil.IsolatedTmux(t)
+
+	// Reconfigure the isolated server to index windows and panes from 1, so the
+	// snapshot's 0-based indices won't all map onto restored objects.
+	testutil.Tmux(t, "set-option", "-g", "base-index", "1")
+	testutil.Tmux(t, "set-option", "-g", "pane-base-index", "1")
+
+	client := tmux.NewClient("tmux")
+
+	const name = "home"
+
+	snap := snapshot.SessionSnapshot{
+		Version:     snapshot.FormatVersion,
+		SessionName: name,
+		CurrentWin:  0,
+		CurrentPane: 0,
+		Windows: []snapshot.Window{
+			{
+				Index: 0, Name: "w0", IsActive: true, ActivePane: 0,
+				Panes: []snapshot.Pane{{Index: 0, CurrentPath: "/tmp", IsActive: true}},
+			},
+			{
+				Index: 1, Name: "w1", ActivePane: 0,
+				Panes: []snapshot.Pane{{Index: 0, CurrentPath: "/tmp", IsActive: true}},
+			},
+		},
+	}
+
+	if err := client.RestoreSession(snap); err != nil {
+		t.Fatalf("restore under base-index/pane-base-index 1 must not fail: %v", err)
+	}
+
+	if _, err := testutil.TmuxTry("has-session", "-t", "="+name); err != nil {
+		t.Fatalf("session should be alive after restore: %v", err)
+	}
+}
+
 // TestRestoreWaitsForCommandsToStart is the end-to-end counterpart to issue
 // #106: against a real tmux server, once RestoreSession returns the pane must
 // actually be running its restored command rather than sitting at the shell.


### PR DESCRIPTION
Resolves #137.

`lazy-tmux bootstrap` (and `restore`) crashed when the snapshot's index base didn't match the restoring server:

```
lazy-tmux: bootstrap session: restore session: select window: tmux select-window -t =home:0: exit status 1 (can't find window: 0)
```

## Root cause

After recreating the windows, `RestoreSession` selected the focus window/pane using indices from the **snapshot** and treated a failed `select-window`/`select-pane` as fatal. When a snapshot saved under `base-index 0` / `pane-base-index 0` is restored on a server using `base-index 1` / `pane-base-index 1` (a common user config), the recorded window 0 / pane 0 need not exist, so the focus `select-*` failed and aborted the whole restore — even though the session was otherwise fully restored.

This is the complement of #103 / #105 (fixed in #115 for the "snapshot window 1, current_window 0" direction); the `pane-base-index` case was never covered and focus selection was never resilient.

## Fix

- **Resolve focus against the live layout:** `resolveLiveFocus` queries `list-windows` / `list-panes` and falls back to the first existing window/pane when the recorded index is absent.
- **Best-effort focus:** the `select-window`/`select-pane` calls no longer return an error — focus is cosmetic and must never abort an otherwise-successful restore.

## Validation

Reproduced first, then fixed (isolated tmux socket, untouched real session):

- **Before:** save a 3-window session under `base-index 0`, restore on a server with `base-index 1` + `pane-base-index 1` → `select-pane -t =home:0.0: can't find pane: 0` (window variant → `can't find window: 0`).
- **After:** the same restore succeeds; windows `[0,1,2]` restored, focus lands on an existing pane.

New integration test `TestRestoreToleratesPaneBaseIndexMismatch` (real tmux with `base-index`/`pane-base-index` 1) fails before this change and passes after. `make integration-test` → 113 tests pass; `make golangci-lint` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session restore reliability when window or pane numbering differs from the server’s configured defaults.
  * Restore now continues even if the originally selected window or pane can’t be matched exactly, reducing failed restores.
  * Focus is now restored more gracefully by choosing the closest available window or pane when needed.
* **Tests**
  * Added coverage for restoring sessions across numbering mismatches to confirm the session stays alive after restore.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->