### PR TITLE
fix(aur): point PKGBUILD source at the unversioned release asset (#141)

### DIFF
--- a/scripts/aur-update.sh
+++ b/scripts/aur-update.sh
@@ -73,9 +73,13 @@ grep -q "sha256sums_aarch64 = ${sha_arm64_fzf}" "$srcinfo" || { echo "AUR update
 
 # Guard against the issue #141 regression: the download URL must point at the
 # real (unversioned) release asset, not lazy-tmux_<ver>_linux_*.tar.gz (404).
-grep -q "releases/download/v${ver}/lazy-tmux_linux_amd64.tar.gz" "$srcinfo" || { echo "AUR update failed: versioned asset URL in .SRCINFO (issue #141)" >&2; exit 1; }
+grep -q "releases/download/v${ver}/lazy-tmux_linux_amd64.tar.gz" "$srcinfo" || { echo "AUR update failed: missing unversioned amd64 asset URL in .SRCINFO (issue #141)" >&2; exit 1; }
 grep -qE "releases/download/v${ver}/lazy-tmux_[0-9]" "$srcinfo" && { echo "AUR update failed: .SRCINFO still has a versioned asset URL (issue #141)" >&2; exit 1; }
-grep -q 'releases/download/v${pkgver}/lazy-tmux_linux_amd64.tar.gz' "$pkgbuild" || { echo "AUR update failed: versioned asset URL in PKGBUILD (issue #141)" >&2; exit 1; }
+grep -q 'releases/download/v${pkgver}/lazy-tmux_linux_amd64.tar.gz' "$pkgbuild" || { echo "AUR update failed: missing unversioned amd64 asset URL in PKGBUILD (issue #141)" >&2; exit 1; }
+# Reject any source_* entry whose URL filename still carries the version
+# (the variable form lazy-tmux_${pkgver}_ or a literal digit), so a single
+# unversioned amd64 entry can't mask a still-broken arm64/fzf one.
+grep -qE 'releases/download/v\$\{pkgver\}/lazy-tmux_(\$\{pkgver\}_|[0-9])' "$pkgbuild" && { echo "AUR update failed: PKGBUILD still has a versioned asset URL (issue #141)" >&2; exit 1; }
 
 git -C "$workdir" add PKGBUILD .SRCINFO
 if git -C "$workdir" diff --cached --quiet; then

--- a/scripts/aur-update.sh
+++ b/scripts/aur-update.sh
@@ -46,9 +46,21 @@ sed -i "s/^pkgver=.*/pkgver=${ver}/" "$pkgbuild"
 sed -i "s/^sha256sums_x86_64=.*/sha256sums_x86_64=('${sha_amd64}' '${sha_amd64_fzf}')/" "$pkgbuild"
 sed -i "s/^sha256sums_aarch64=.*/sha256sums_aarch64=('${sha_arm64}' '${sha_arm64_fzf}')/" "$pkgbuild"
 
+# The release assets are named WITHOUT the version (goreleaser name_template is
+# "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"), so the download URL filename must
+# not carry ${pkgver} — only the local alias (before "::") and the v${pkgver}
+# path tag keep it. Strip a stray version from the URL-side filename (issue #141).
+# Single-quoted so ${pkgver} stays a literal PKGBUILD variable.
+sed -i 's#\(/releases/download/v${pkgver}/\)lazy-tmux_${pkgver}_#\1lazy-tmux_#g' "$pkgbuild"
+
 sed -i "s/^\tpkgver = .*/\tpkgver = ${ver}/" "$srcinfo"
 sed -i "s#releases/download/v[0-9.\-]\+/lazy-tmux_#releases/download/v${ver}/lazy-tmux_#g" "$srcinfo"
 sed -i "s#lazy-tmux_[0-9.\-]\+_#lazy-tmux_${ver}_#g" "$srcinfo"
+
+# Same as PKGBUILD: the download URL filename must be unversioned. The previous
+# sed bumps the version everywhere (correct for the local alias), so strip it
+# back off only the URL-side filename, right after the v${ver} path (issue #141).
+sed -i -E "s#(/releases/download/v${ver}/)lazy-tmux_[0-9][0-9.\-]*_#\1lazy-tmux_#g" "$srcinfo"
 
 perl -0777 -i -pe "s/sha256sums_x86_64 = .*\n\tsha256sums_x86_64 = .*/sha256sums_x86_64 = ${sha_amd64}\n\tsha256sums_x86_64 = ${sha_amd64_fzf}/" "$srcinfo"
 perl -0777 -i -pe "s/sha256sums_aarch64 = .*\n\tsha256sums_aarch64 = .*/sha256sums_aarch64 = ${sha_arm64}\n\tsha256sums_aarch64 = ${sha_arm64_fzf}/" "$srcinfo"
@@ -58,6 +70,12 @@ grep -q "sha256sums_x86_64 = ${sha_amd64}" "$srcinfo" || { echo "AUR update fail
 grep -q "sha256sums_x86_64 = ${sha_amd64_fzf}" "$srcinfo" || { echo "AUR update failed: sha256sums_x86_64 (fzf)" >&2; exit 1; }
 grep -q "sha256sums_aarch64 = ${sha_arm64}" "$srcinfo" || { echo "AUR update failed: sha256sums_aarch64 (main)" >&2; exit 1; }
 grep -q "sha256sums_aarch64 = ${sha_arm64_fzf}" "$srcinfo" || { echo "AUR update failed: sha256sums_aarch64 (fzf)" >&2; exit 1; }
+
+# Guard against the issue #141 regression: the download URL must point at the
+# real (unversioned) release asset, not lazy-tmux_<ver>_linux_*.tar.gz (404).
+grep -q "releases/download/v${ver}/lazy-tmux_linux_amd64.tar.gz" "$srcinfo" || { echo "AUR update failed: versioned asset URL in .SRCINFO (issue #141)" >&2; exit 1; }
+grep -qE "releases/download/v${ver}/lazy-tmux_[0-9]" "$srcinfo" && { echo "AUR update failed: .SRCINFO still has a versioned asset URL (issue #141)" >&2; exit 1; }
+grep -q 'releases/download/v${pkgver}/lazy-tmux_linux_amd64.tar.gz' "$pkgbuild" || { echo "AUR update failed: versioned asset URL in PKGBUILD (issue #141)" >&2; exit 1; }
 
 git -C "$workdir" add PKGBUILD .SRCINFO
 if git -C "$workdir" diff --cached --quiet; then


### PR DESCRIPTION
Resolves #141 (reported by @ksharizard).

The AUR package failed to install: the `PKGBUILD` download URL was

```
.../releases/download/v${pkgver}/lazy-tmux_${pkgver}_linux_<arch>.tar.gz
```

but goreleaser names release assets **without** the version (`name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"` → `lazy-tmux_linux_<arch>.tar.gz`), so the URL `404`'d.

## Fix

`scripts/aur-update.sh` now strips the version from the **URL-side** filename (the part after `::`) in both the `PKGBUILD` and the expanded `.SRCINFO`, while keeping:
- the versioned **local alias** (before `::`), which the `package_*` functions reference, and
- the `v${pkgver}` **path tag**.

It also verifies the URL is unversioned (and fails loudly otherwise) so this can't regress.

```diff
  source_x86_64=(
-   "lazy-tmux_${pkgver}_linux_amd64.tar.gz::https://github.com/alchemmist/lazy-tmux/releases/download/v${pkgver}/lazy-tmux_${pkgver}_linux_amd64.tar.gz"
+   "lazy-tmux_${pkgver}_linux_amd64.tar.gz::https://github.com/alchemmist/lazy-tmux/releases/download/v${pkgver}/lazy-tmux_linux_amd64.tar.gz"
  )
```

## Verified

- `https://github.com/alchemmist/lazy-tmux/releases/download/v0.1.22/lazy-tmux_linux_amd64.tar.gz` → **200**; the old versioned URL → **404**.
- Ran the full `aur-update.sh` sed sequence end-to-end under **GNU sed** (ubuntu, matching CI) against the live AUR `PKGBUILD`/`.SRCINFO` with a version bump: the URL filename comes out unversioned, the local alias stays versioned, and all `.SRCINFO` checks pass.
- `bash -n scripts/aur-update.sh` passes.

## Note on the live AUR package

This fixes the automation for the **next release**. The currently-published AUR package (v0.1.22) stays broken until either a new release runs the fixed script, or a corrected `PKGBUILD`/`.SRCINFO` is pushed to AUR directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how package metadata download URLs are updated so the asset filename remains unversioned while preserving the correct versioned path.
  * Added stricter URL rewriting to remove any leftover version suffixes near the releases path.
  * Introduced pre-commit validation checks for both metadata and build scripts to block versioned asset filenames and ensure the expected unversioned amd64 URLs are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->