### PR TITLE
feat(cli): add version command, sourced from the git tag (#65)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,8 @@ builds:
     binary: lazy-tmux
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
     goos:
       - linux
       - darwin
@@ -24,6 +26,8 @@ builds:
     binary: lazy-tmux
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
     tags:
       - lazy_fzf
     goos:

--- a/cmd/lazy-tmux/main.go
+++ b/cmd/lazy-tmux/main.go
@@ -10,6 +10,7 @@ import (
 var exitFunc = os.Exit
 
 var commands = map[string]func(args []string, stdout, stderr io.Writer) int{
+	"version":   runVersionCmd,
 	"save":      runSave,
 	"restore":   runRestore,
 	"picker":    runPicker,
@@ -23,6 +24,7 @@ var commands = map[string]func(args []string, stdout, stderr io.Writer) int{
 }
 
 var helpFuncs = map[string]func(io.Writer){
+	"version":   versionHelp,
 	"save":      saveHelp,
 	"restore":   restoreHelp,
 	"picker":    pickerHelp,
@@ -46,7 +48,7 @@ func runCLI(args []string, stdout, stderr io.Writer) int {
 	}
 
 	cmdName := args[0]
-	if cmdName == "version" || cmdName == "-v" || cmdName == "--version" {
+	if cmdName == "-v" || cmdName == "--version" {
 		return runVersion(stdout)
 	}
 

--- a/cmd/lazy-tmux/main.go
+++ b/cmd/lazy-tmux/main.go
@@ -46,6 +46,10 @@ func runCLI(args []string, stdout, stderr io.Writer) int {
 	}
 
 	cmdName := args[0]
+	if cmdName == "version" || cmdName == "-v" || cmdName == "--version" {
+		return runVersion(stdout)
+	}
+
 	if cmdName == "help" || cmdName == "-h" || cmdName == "--help" {
 		if len(args) > 1 {
 			help, ok := helpFuncs[args[1]]
@@ -96,6 +100,7 @@ Commands:
   daemon     Periodically save all sessions
   list       List saved sessions
   setup      Print config keybinds for tmux
+  version    Print the version
 
 Run 'lazy-tmux <command> -h' for more details.
 `)

--- a/cmd/lazy-tmux/version.go
+++ b/cmd/lazy-tmux/version.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+	"runtime/debug"
+)
+
+// version is injected at release time via -ldflags "-X main.version=<tag>"
+// (goreleaser passes the git tag). It is intentionally empty for plain
+// `go build` / `go install`, where resolveVersion derives the version from the
+// embedded build info instead — so the version is never hand-maintained in
+// source and the git tag is the single source of truth.
+var version = ""
+
+// resolveVersion returns the build's version, preferring the ldflags-injected
+// release version, then the module version recorded by `go install ...@vX.Y.Z`,
+// then the VCS revision for local builds, and finally "dev".
+func resolveVersion() string {
+	if version != "" {
+		return version
+	}
+
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "dev"
+	}
+
+	if v := info.Main.Version; v != "" && v != "(devel)" {
+		return v
+	}
+
+	var revision, modified string
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			revision = setting.Value
+		case "vcs.modified":
+			modified = setting.Value
+		}
+	}
+
+	if revision == "" {
+		return "dev"
+	}
+
+	if len(revision) > 12 {
+		revision = revision[:12]
+	}
+
+	if modified == "true" {
+		return "dev+" + revision + "-dirty"
+	}
+
+	return "dev+" + revision
+}
+
+func runVersion(stdout io.Writer) int {
+	_, _ = fmt.Fprintf(
+		stdout,
+		"lazy-tmux %s (%s/%s, %s)\n",
+		resolveVersion(),
+		runtime.GOOS,
+		runtime.GOARCH,
+		runtime.Version(),
+	)
+
+	return 0
+}

--- a/cmd/lazy-tmux/version.go
+++ b/cmd/lazy-tmux/version.go
@@ -56,6 +56,27 @@ func resolveVersion() string {
 	return "dev+" + revision
 }
 
+// runVersionCmd is the `version` subcommand entry (it also honors -h/--help so
+// it behaves like the other commands). The bare -v/--version flags are handled
+// directly in runCLI.
+func runVersionCmd(args []string, stdout, _ io.Writer) int {
+	for _, arg := range args {
+		if arg == "-h" || arg == "--help" {
+			versionHelp(stdout)
+			return 0
+		}
+	}
+
+	return runVersion(stdout)
+}
+
+func versionHelp(w io.Writer) {
+	_, _ = fmt.Fprint(w, `Usage: lazy-tmux version
+
+Print the version (also: lazy-tmux --version, lazy-tmux -v)
+`)
+}
+
 func runVersion(stdout io.Writer) int {
 	_, _ = fmt.Fprintf(
 		stdout,

--- a/cmd/lazy-tmux/version_test.go
+++ b/cmd/lazy-tmux/version_test.go
@@ -22,6 +22,21 @@ func TestCLIVersionVariants(t *testing.T) {
 	}
 }
 
+func TestCLIVersionHelp(t *testing.T) {
+	// `help version` and `version -h` both reach the version help, like any
+	// other command.
+	for _, args := range [][]string{{"help", "version"}, {"version", "-h"}, {"version", "--help"}} {
+		code, out, _ := run(t, args...)
+		if code != 0 {
+			t.Fatalf("%v: expected exit 0, got %d", args, code)
+		}
+
+		if !strings.Contains(out, "Usage: lazy-tmux version") {
+			t.Fatalf("%v: expected version help, got %q", args, out)
+		}
+	}
+}
+
 func TestResolveVersionPrefersLdflags(t *testing.T) {
 	orig := version
 	t.Cleanup(func() { version = orig })

--- a/cmd/lazy-tmux/version_test.go
+++ b/cmd/lazy-tmux/version_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCLIVersionVariants(t *testing.T) {
+	for _, arg := range []string{"version", "-v", "--version"} {
+		code, out, errOut := run(t, arg)
+		if code != 0 {
+			t.Fatalf("%s: expected exit 0, got %d", arg, code)
+		}
+
+		if !strings.HasPrefix(out, "lazy-tmux ") {
+			t.Fatalf("%s: expected 'lazy-tmux <version>' line, got %q", arg, out)
+		}
+
+		if errOut != "" {
+			t.Fatalf("%s: expected empty stderr, got %q", arg, errOut)
+		}
+	}
+}
+
+func TestResolveVersionPrefersLdflags(t *testing.T) {
+	orig := version
+	t.Cleanup(func() { version = orig })
+
+	version = "1.2.3"
+	if got := resolveVersion(); got != "1.2.3" {
+		t.Fatalf("expected injected version, got %q", got)
+	}
+}
+
+func TestResolveVersionFallbackNonEmpty(t *testing.T) {
+	orig := version
+	t.Cleanup(func() { version = orig })
+
+	// With no injected version, resolveVersion must still return something
+	// usable (module version, VCS revision, or "dev") rather than empty.
+	version = ""
+	if got := resolveVersion(); got == "" {
+		t.Fatal("resolveVersion returned empty without an injected version")
+	}
+}

--- a/docs/_content.html
+++ b/docs/_content.html
@@ -600,6 +600,10 @@
               <td>List saved sessions</td>
             </tr>
             <tr>
+              <td><code>version</code> (<code>--version</code>, <code>-v</code>)</td>
+              <td>Print the version</td>
+            </tr>
+            <tr>
               <td><code>wakeup --session NAME</code></td>
               <td>Restore a saved session (lazy load) that is not currently running</td>
             </tr>

--- a/docs/cli/index.html
+++ b/docs/cli/index.html
@@ -106,6 +106,10 @@
               <td>List saved sessions</td>
             </tr>
             <tr>
+              <td><code>version</code> (<code>--version</code>, <code>-v</code>)</td>
+              <td>Print the version</td>
+            </tr>
+            <tr>
               <td><code>wakeup --session NAME</code></td>
               <td>Restore a saved session (lazy load) that is not currently running</td>
             </tr>


### PR DESCRIPTION
Resolves #65.

Adds `lazy-tmux version` (and `--version` / `-v`). The design goal was **zero manual version sync** — the version is never hardcoded in source; the git tag is the single source of truth.

## How the version is resolved (no hand-maintenance)

`resolveVersion()` (in `cmd/lazy-tmux/version.go`) picks, in order:

1. **Release builds** — goreleaser injects the tag at build time via `-ldflags "-s -w -X main.version={{ .Version }}"`, so a `v0.1.23` tag → `0.1.23`. Nothing to update by hand.
2. **`go install …/cmd/lazy-tmux@vX.Y.Z`** — reads the module version from `runtime/debug.ReadBuildInfo()`.
3. **Local builds (`make build`)** — falls back to the embedded VCS info (Go's pseudo-version: base + timestamp + commit, with a `-dirty`/`+dirty` marker), e.g. `v0.1.24-0.20260628…-61b48de75f20+dirty`. No tag required.
4. Last resort: `dev`.

Output format: `lazy-tmux <version> (<os>/<arch>, <go>)`.

## Changes

- `cmd/lazy-tmux/version.go` — `version` var (ldflags target) + `resolveVersion()` + `runVersion()`.
- `cmd/lazy-tmux/main.go` — handle `version` / `-v` / `--version` in `runCLI`; list `version` in usage.
- `.goreleaser.yaml` — `ldflags` on both builds.
- Docs: `version` row in the CLI table.
- Tests: `version`/`-v`/`--version` round-trip, ldflags precedence, non-empty fallback.

This also fixes the Homebrew formula test, which already called `--version`.

## Verified

- `make build` → `lazy-tmux v0.1.24-0.…-<commit>+dirty (darwin/arm64, go1.26.4)`
- `go build -ldflags "-X main.version=0.1.23"` → `lazy-tmux 0.1.23 (...)`
- `version`, `-v`, `--version` all work; unknown commands still error.
- `make golangci-lint` clean; `make test` 116 pass (incl. new version tests); `make build-all` + `go test -tags lazy_fzf ./...` both green (the fzf path that broke an earlier release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a built-in `version` command with `-v` and `--version` aliases.
  * Supports `version` help output and prints version, build platform, and Go runtime details.
  * Release artifacts now embed the application version automatically.

* **Documentation**
  * Updated CLI reference docs to include the new `version` command and aliases.

* **Tests**
  * Added automated coverage for `version` invocation variants and help-mode behavior, plus version fallback resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->