### PR TITLE
feat(sandbox): pick the tmux version when launching the sandbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,14 @@ docker-hub:
 	podman tag lazy-tmux:$$SANDBOX_TAG alchemmist/lazy-tmux:$$SANDBOX_TAG; \
 	podman push alchemmist/lazy-tmux:$$SANDBOX_TAG
 
+# Build and drop into the interactive sandbox. Pick the tmux version with
+# TMUX_VERSION (defaults to 3.6a); each version gets its own cached image tag.
+#   make sandbox                  # tmux 3.6a
+#   make sandbox TMUX_VERSION=3.5a
+TMUX_VERSION ?= 3.6a
 sandbox:
-	podman build -t lazy-tmux:local -f docker/sandbox.Dockerfile .
-	podman run -it --rm lazy-tmux:local
+	podman build --build-arg TMUX_VERSION=$(TMUX_VERSION) -t lazy-tmux:local-$(TMUX_VERSION) -f docker/sandbox.Dockerfile .
+	podman run -it --rm lazy-tmux:local-$(TMUX_VERSION)
 
 test-sup-versions:
 	chmod +x scripts/test-tmux-versions.sh

--- a/docker/sandbox.Dockerfile
+++ b/docker/sandbox.Dockerfile
@@ -32,7 +32,12 @@ ENV SHELL=/usr/bin/zsh
 
 COPY docker/install-tmux.sh .
 
-RUN TMUX_VERSION=3.6a ./install-tmux.sh
+# Which tmux release to build into the sandbox. Override per build, e.g.
+#   make sandbox TMUX_VERSION=3.5a
+#   podman build --build-arg TMUX_VERSION=3.4 -f docker/sandbox.Dockerfile .
+ARG TMUX_VERSION=3.6a
+
+RUN TMUX_VERSION=${TMUX_VERSION} ./install-tmux.sh
 
 WORKDIR /root
 


### PR DESCRIPTION
Resolves #145

Lets you launch the interactive sandbox with any tmux version instead of the hardcoded 3.6a — handy for reproducing version-specific behaviour (e.g. #125 on 3.5a).

## Usage

```sh
make sandbox                   # tmux 3.6a (unchanged default)
make sandbox TMUX_VERSION=3.5a # any released tmux version
```

Each version gets its own image tag (`lazy-tmux:local-<ver>`), so switching back and forth reuses the cache instead of rebuilding.

## Changes

- `docker/sandbox.Dockerfile`: `ARG TMUX_VERSION=3.6a`, passed to the existing `install-tmux.sh` (which already builds any version from source) — `RUN TMUX_VERSION=${TMUX_VERSION} ./install-tmux.sh`.
- `Makefile`: `sandbox` forwards `--build-arg TMUX_VERSION=$(TMUX_VERSION)` and tags per version; `TMUX_VERSION ?= 3.6a`.
- The published docker-hub image is unaffected — `make docker-hub` builds with the default ARG (3.6a).

## Verified

- `make -n sandbox TMUX_VERSION=3.5a` → `podman build --build-arg TMUX_VERSION=3.5a -t lazy-tmux:local-3.5a …` + `podman run -it --rm lazy-tmux:local-3.5a`; default stays 3.6a.
- The `TMUX_VERSION` build arg flows through to the `RUN` step (confirmed with a minimal build). `install-tmux.sh` is the existing, already-proven build path (the same one the current sandbox uses).

