### PR TITLE
fix: make save --all visible + expand ~ in tmux_bin (#125)

### DIFF
--- a/cmd/lazy-tmux/cli_test.go
+++ b/cmd/lazy-tmux/cli_test.go
@@ -132,6 +132,30 @@ func TestCLISaveScrollbackLinesValidation(t *testing.T) {
 	}
 }
 
+func TestCLITmuxBinFlagExpandsHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home dir: %v", err)
+	}
+
+	// A bogus ~-prefixed tmux binary: exec must fail with the EXPANDED path,
+	// proving --tmux-bin gets ~ expansion (exec doesn't do shell expansion).
+	code, _, errOut := run(
+		t, "save", "--all", "--tmux-bin", "~/no-such-tmux-xyz", "--data-dir", t.TempDir(),
+	)
+	if code != 1 {
+		t.Fatalf("expected exit 1, got %d (stderr=%q)", code, errOut)
+	}
+
+	if strings.Contains(errOut, "~/no-such-tmux-xyz") {
+		t.Fatalf("--tmux-bin kept a literal ~: %q", errOut)
+	}
+
+	if !strings.Contains(errOut, filepath.Join(home, "no-such-tmux-xyz")) {
+		t.Fatalf("expected expanded path in error, got %q", errOut)
+	}
+}
+
 func TestCLISetupPrintsKeybinds(t *testing.T) {
 	code, out, _ := run(t, "setup")
 	if code != 0 {

--- a/cmd/lazy-tmux/integration_test.go
+++ b/cmd/lazy-tmux/integration_test.go
@@ -161,8 +161,10 @@ func TestSaveAllAndForget(t *testing.T) {
 	testutil.Tmux(t, "new-session", "-d", "-s", "one")
 	testutil.Tmux(t, "new-session", "-d", "-s", "two")
 
-	if code, _, errOut := run(t, "save", "--all", "--data-dir", dir); code != 0 {
+	if code, out, errOut := run(t, "save", "--all", "--data-dir", dir); code != 0 {
 		t.Fatalf("save --all: exit %d stderr=%q", code, errOut)
+	} else if !strings.Contains(out, "saved 2 session(s)") {
+		t.Fatalf("save --all should report the saved count, got %q", out)
 	}
 
 	for _, n := range []string{"one", "two"} {
@@ -187,6 +189,24 @@ func TestSaveAllAndForget(t *testing.T) {
 
 	if !strings.Contains(out, "two") {
 		t.Fatalf("remaining session missing from list: %q", out)
+	}
+}
+
+// TestSaveAllNoSessionsReports covers issue #125: `save --all` must not be a
+// silent no-op when there are no sessions (which is what happens when lazy-tmux
+// is talking to a different/empty tmux than the user). It should say so.
+func TestSaveAllNoSessionsReports(t *testing.T) {
+	testutil.IsolatedTmux(t) // server is running but has no sessions
+
+	dir := t.TempDir()
+
+	code, out, errOut := run(t, "save", "--all", "--data-dir", dir)
+	if code != 0 {
+		t.Fatalf("save --all: exit %d stderr=%q", code, errOut)
+	}
+
+	if !strings.Contains(out, "no running tmux sessions found") {
+		t.Fatalf("save --all with no sessions should report it, got %q", out)
 	}
 }
 

--- a/cmd/lazy-tmux/save.go
+++ b/cmd/lazy-tmux/save.go
@@ -63,7 +63,20 @@ func runSave(args []string, stdout, stderr io.Writer) int {
 
 	switch {
 	case *all:
-		err = tmuxApp.SaveAll()
+		var saved int
+		saved, err = tmuxApp.SaveAll()
+		if err == nil {
+			if saved == 0 {
+				// Don't leave the user staring at silence (issue #125): a likely
+				// cause is lazy-tmux talking to a different tmux than theirs
+				// (e.g. tmux is a shell alias) — point them at tmux_bin.
+				_, _ = fmt.Fprintln(stdout,
+					"no running tmux sessions found "+
+						"(if you do have sessions, set tmux_bin / --tmux-bin to your tmux binary)")
+			} else {
+				_, _ = fmt.Fprintf(stdout, "saved %d session(s)\n", saved)
+			}
+		}
 	case strings.TrimSpace(*session) != "":
 		err = tmuxApp.SaveSession(strings.TrimSpace(*session))
 	default:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -55,7 +55,9 @@ type App struct {
 }
 
 func New(cfg config.Config) *App {
-	client := tmux.NewClient(cfg.TmuxBin)
+	// Expand a leading ~ so both tmux_bin (TOML) and --tmux-bin (flag) accept
+	// "~/bin/tmux.appimage"; exec does not do shell tilde expansion.
+	client := tmux.NewClient(config.ExpandHome(cfg.TmuxBin))
 	client.SetRestoreTimeout(cfg.RestoreTimeout)
 	client.SetRestoreAllowlist(cfg.RestoreAllowlist)
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -66,20 +66,22 @@ func New(cfg config.Config) *App {
 	}
 }
 
-func (a *App) SaveAll() error {
+// SaveAll snapshots every running tmux session and returns how many were saved
+// (0 when no tmux server is running or it has no sessions).
+func (a *App) SaveAll() (int, error) {
 	sessions, err := a.tmux.ListSessions()
 	if err != nil {
-		return fmt.Errorf("list sessions: %w", err)
+		return 0, fmt.Errorf("list sessions: %w", err)
 	}
 
 	for _, name := range sessions {
 		err := a.SaveSession(name)
 		if err != nil {
-			return err
+			return 0, err
 		}
 	}
 
-	return nil
+	return len(sessions), nil
 }
 
 func (a *App) SaveSession(session string) error {
@@ -185,7 +187,9 @@ func (a *App) runDaemonSaveAll() error {
 		return a.saveAllFn()
 	}
 
-	return a.SaveAll()
+	_, err := a.SaveAll()
+
+	return err
 }
 
 func (a *App) captureShellScrollback(snap *snapshot.SessionSnapshot) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -182,8 +182,10 @@ func TestSaveAllRestoreSleepWakeup(t *testing.T) {
 	testutil.Tmux(t, "new-session", "-d", "-s", "s1")
 	testutil.Tmux(t, "new-session", "-d", "-s", "s2")
 
-	if err := a.SaveAll(); err != nil {
+	if n, err := a.SaveAll(); err != nil {
 		t.Fatalf("save all: %v", err)
+	} else if n != 2 {
+		t.Fatalf("save all should report 2 saved sessions, got %d", n)
 	}
 
 	if !snapshotExists(dir, "s1") || !snapshotExists(dir, "s2") {
@@ -258,7 +260,9 @@ func TestRunDaemonSavesAll(t *testing.T) {
 	saves := 0
 	a.saveAllFn = func() error {
 		saves++
-		return a.SaveAll()
+		_, err := a.SaveAll()
+
+		return err
 	}
 
 	ch := make(chan time.Time, 1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -129,7 +129,9 @@ type fileScrollbackConf struct {
 // withFile returns a copy of cfg with every value set in file applied on top.
 func (cfg Config) withFile(file fileConfig) Config {
 	if file.TmuxBin != nil {
-		cfg.TmuxBin = *file.TmuxBin
+		// Expand a leading ~ so e.g. tmux_bin = "~/bin/tmux.appimage" works
+		// (matches data_dir handling).
+		cfg.TmuxBin = expandHome(*file.TmuxBin)
 	}
 
 	if file.DataDir != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,11 +131,11 @@ func (cfg Config) withFile(file fileConfig) Config {
 	if file.TmuxBin != nil {
 		// Expand a leading ~ so e.g. tmux_bin = "~/bin/tmux.appimage" works
 		// (matches data_dir handling).
-		cfg.TmuxBin = expandHome(*file.TmuxBin)
+		cfg.TmuxBin = ExpandHome(*file.TmuxBin)
 	}
 
 	if file.DataDir != nil {
-		cfg.DataDir = expandHome(*file.DataDir)
+		cfg.DataDir = ExpandHome(*file.DataDir)
 	}
 
 	if file.SaveInterval != nil {
@@ -186,9 +186,10 @@ func (d *duration) UnmarshalText(text []byte) error {
 	return nil
 }
 
-// expandHome resolves a leading ~ in a config-provided path to the user's home
-// directory, so data_dir = "~/snapshots" works as expected.
-func expandHome(path string) string {
+// ExpandHome resolves a leading ~ in a path to the user's home directory, so
+// e.g. "~/snapshots" (data_dir) or "~/bin/tmux.appimage" (tmux_bin, including
+// the --tmux-bin flag) works as expected.
+func ExpandHome(path string) string {
 	if path == "~" || strings.HasPrefix(path, "~/") {
 		home, err := os.UserHomeDir()
 		if err == nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -148,6 +148,24 @@ func TestLoadFromExpandsHomeInDataDir(t *testing.T) {
 	}
 }
 
+func TestLoadFromExpandsHomeInTmuxBin(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home dir: %v", err)
+	}
+
+	path := writeConfig(t, "tmux_bin = \"~/bin/tmux.appimage\"\n")
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if want := filepath.Join(home, "bin/tmux.appimage"); cfg.TmuxBin != want {
+		t.Fatalf("home expansion: got %q want %q", cfg.TmuxBin, want)
+	}
+}
+
 func TestLoadFromMalformedFileErrors(t *testing.T) {
 	path := writeConfig(t, "this is not = valid = toml\n")
 


### PR DESCRIPTION
Resolves #125.

## Root cause

`lazy-tmux save --all` was a **silent no-op** on a server where `tmux` is a shell **alias** (`tmux: aliased to ~/bin/tmux.appimage`). lazy-tmux runs `tmux` as a subprocess (`exec.Command("tmux", …)`), and subprocesses **don't see shell aliases** — so it ran a different `tmux` from `PATH`, talked to a different/empty tmux server, found **zero sessions**, and returned silently. That looked identical to a successful save, hence the confusion in #125 (and it reproduced even on v0.1.24, which already has the `\037` fix).

## Changes

- **`save --all` is no longer silent.** It reports `saved N session(s)`, or on zero:
  `no running tmux sessions found (if you do have sessions, set tmux_bin / --tmux-bin to your tmux binary)`.
  So the "lazy-tmux is using the wrong tmux" situation is immediately visible instead of looking like success.
- **`SaveAll` returns the saved count.**
- **`tmux_bin` now expands a leading `~`** (like `data_dir` already did), so `tmux_bin = "~/bin/tmux.appimage"` works — previously the `~` was kept literally.

## Fix for the affected server

Point lazy-tmux at the real tmux binary, e.g.:

```toml
# ~/.config/lazy-tmux/lazy-tmux.toml
tmux_bin = "~/bin/tmux.appimage"
```

(or `--tmux-bin …` per command). Then lazy-tmux uses the same tmux — and thus the same server — as the interactive shell.

## Tests

- `TestSaveAllNoSessionsReports` — `save --all` with no sessions prints the hint (integration).
- `TestSaveAllAndForget` / `TestSaveAllRestoreSleepWakeup` — assert the `saved N` count.
- `TestLoadFromExpandsHomeInTmuxBin` — `~` expansion for `tmux_bin`.

`make golangci-lint` clean; `make integration-test` 119 pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `save --all` now reports how many sessions were saved.
  * Configuration now expands `~` in the tmux binary path.

* **Bug Fixes**
  * `save --all` now clearly warns when no tmux sessions are running instead of appearing to succeed.
  * Saving all sessions now stops on the first failure and returns a clearer error when session listing fails.

* **Tests**
  * Added coverage for the no-session save-all case and updated existing save-all checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->