### PR TITLE
fix(setup): single percent in display-popup keybind (#148)

### DIFF
--- a/cmd/lazy-tmux/cli_test.go
+++ b/cmd/lazy-tmux/cli_test.go
@@ -143,6 +143,16 @@ func TestCLISetupPrintsKeybinds(t *testing.T) {
 			t.Fatalf("setup output missing %q: %q", want, out)
 		}
 	}
+
+	// The popup keybind must use single percent signs (printed verbatim, not via
+	// Fprintf) — regression guard for the doubled "75%%"/"85%%" bug.
+	if !strings.Contains(out, "-w 75% -h 85%") {
+		t.Fatalf("expected single-percent popup geometry, got %q", out)
+	}
+
+	if strings.Contains(out, "%%") {
+		t.Fatalf("setup output has a doubled percent sign: %q", out)
+	}
 }
 
 func TestCLIListEmptyStore(t *testing.T) {

--- a/cmd/lazy-tmux/setup.go
+++ b/cmd/lazy-tmux/setup.go
@@ -23,10 +23,12 @@ func runSetup(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	const daemonCmd = "run-shell -b 'lazy-tmux daemon --interval 3m --scrollback" +
+	const daemonCmd = "run-shell -b 'lazy-tmux daemon --interval 3m --scrollback " +
 		">/tmp/lazy-tmux.log 2>&1 || tmux display-message \"lazy-tmux daemon already running\"'"
 
-	const popupKey = "bind-key f display-popup -w 75%% -h 85%% -E 'lazy-tmux picker'"
+	// These lines are printed verbatim (Fprintln, not Fprintf), so percent signs
+	// must be single — tmux wants `-w 75% -h 85%`.
+	const popupKey = "bind-key f display-popup -w 75% -h 85% -E 'lazy-tmux picker'"
 
 	const saveKey = "bind-key C-s run-shell 'lazy-tmux save --all --scrollback && " +
 		"tmux display-message \"All sessions saved successfully!\"'"


### PR DESCRIPTION
Resolves #148

The `lazy-tmux setup` popup keybind is a plain `const` printed with `fmt.Fprintln` (no formatting), so the printf-style `75%%`/`85%%` were emitted literally. Fixed to single `%`:

```
bind-key f display-popup -w 75% -h 85% -E 'lazy-tmux picker'
```

Also added the missing space in the daemon line (`--scrollback >/tmp/...` — string-literal concatenation had dropped it).

Verified the real `lazy-tmux setup` output; `TestCLISetupPrintsKeybinds` now asserts `-w 75% -h 85%` and rejects any `%%`. `make golangci-lint` clean.
