### PR TITLE
docs(site): clean up code block styling (#150)

### DIFF
--- a/docs/_content.html
+++ b/docs/_content.html
@@ -235,17 +235,30 @@
       }
       pre {
         margin: 0;
-        padding: 12px;
+        padding: 14px 16px;
         border: 1px solid var(--line);
         background: #060606;
         overflow-x: auto;
         color: #ececec;
-        font-size: 15px;
-        scrollbar-width: none;
-        -ms-overflow-style: none;
+        font-size: 14px;
+        line-height: 1.55;
+        scrollbar-width: thin;
+        scrollbar-color: var(--line) transparent;
       }
       pre::-webkit-scrollbar {
-        display: none;
+        height: 8px;
+      }
+      pre::-webkit-scrollbar-thumb {
+        background: var(--line);
+      }
+      /* code inside a pre is a raw block, not an inline chip */
+      pre code {
+        background: none;
+        border: 0;
+        border-radius: 0;
+        padding: 0;
+        font-size: inherit;
+        color: inherit;
       }
       .muted {
         color: var(--muted);
@@ -262,9 +275,10 @@
       }
       code {
         color: #fff;
-        background: rgba(255, 255, 255, 0.1);
-        border-radius: 5px;
-        padding: 1px 5px;
+        background: rgba(255, 255, 255, 0.08);
+        border: 1px solid var(--line);
+        border-radius: 4px;
+        padding: 1px 6px;
         font-size: 0.9em;
         font-family: "JetBrains Mono", monospace;
       }

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -151,17 +151,30 @@
       }
       pre {
         margin: 0;
-        padding: 12px;
+        padding: 14px 16px;
         border: 1px solid var(--line);
         background: #060606;
         overflow-x: auto;
         color: #ececec;
-        font-size: 15px;
-        scrollbar-width: none;
-        -ms-overflow-style: none;
+        font-size: 14px;
+        line-height: 1.55;
+        scrollbar-width: thin;
+        scrollbar-color: var(--line) transparent;
       }
       pre::-webkit-scrollbar {
-        display: none;
+        height: 8px;
+      }
+      pre::-webkit-scrollbar-thumb {
+        background: var(--line);
+      }
+      /* code inside a pre is a raw block, not an inline chip */
+      pre code {
+        background: none;
+        border: 0;
+        border-radius: 0;
+        padding: 0;
+        font-size: inherit;
+        color: inherit;
       }
       .muted {
         color: var(--muted);
@@ -178,9 +191,10 @@
       }
       code {
         color: #fff;
-        background: rgba(255, 255, 255, 0.1);
-        border-radius: 5px;
-        padding: 1px 5px;
+        background: rgba(255, 255, 255, 0.08);
+        border: 1px solid var(--line);
+        border-radius: 4px;
+        padding: 1px 6px;
         font-size: 0.9em;
         font-family: "JetBrains Mono", monospace;
       }


### PR DESCRIPTION
Resolves #150

Cleans up how code blocks render on the site.

## Fixes
- **Nested chip:** block code is `<pre><code>`, but the inline-`code` rule (background pill + border-radius + smaller font) was also hitting the inner `<code>`, so each block had a lighter rounded pill inside the dark `<pre>`. Added a `pre code` reset so blocks are raw; the chip styling stays for **inline** `<code>` only.
- **Hidden scroll:** replaced `scrollbar-width: none` / hidden webkit scrollbar with a thin, theme-coloured one, so long lines (e.g. the `curl … | sh` install command) visibly scroll.
- Minor: padding `14px 16px`, line-height `1.55`, inline code gets a subtle border.

CSS only — regenerated with `python3 scripts/build-docs.py`; the page HTML is unchanged (only `docs/assets/style.css`). Local server serves all routes 200.
