### PR TITLE
feat(cli): add 'config gen' and 'config show' (#152)

### DIFF
--- a/cmd/lazy-tmux/config_cmd.go
+++ b/cmd/lazy-tmux/config_cmd.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/alchemmist/lazy-tmux/internal/config"
+)
+
+func runConfig(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		configHelp(stderr)
+		return 1
+	}
+
+	switch args[0] {
+	case "gen":
+		return runConfigGen(args[1:], stdout, stderr)
+	case "show":
+		return runConfigShow(args[1:], stdout, stderr)
+	case "-h", "--help", "help":
+		configHelp(stdout)
+		return 0
+	default:
+		writeErr(stderr, fmt.Errorf("unknown config subcommand: %s", args[0]))
+		configHelp(stderr)
+
+		return 1
+	}
+}
+
+func runConfigGen(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("config gen", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+
+	path := flags.String("path", "", "config file path (default: the path lazy-tmux reads)")
+	force := flags.Bool("force", false, "overwrite an existing file")
+
+	err := flags.Parse(args)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			configHelp(stdout)
+			return 0
+		}
+
+		writeErr(stderr, fmt.Errorf("parse flags: %w", err))
+
+		return 1
+	}
+
+	written, err := config.GenerateConfig(*path, *force)
+	if err != nil {
+		writeErr(stderr, fmt.Errorf("config gen: %w", err))
+		return 1
+	}
+
+	_, _ = fmt.Fprintf(stdout, "wrote config to %s\n", written)
+
+	return 0
+}
+
+func runConfigShow(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("config show", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+
+	err := flags.Parse(args)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			configHelp(stdout)
+			return 0
+		}
+
+		writeErr(stderr, fmt.Errorf("parse flags: %w", err))
+
+		return 1
+	}
+
+	cfg, ok := loadConfig(stderr)
+	if !ok {
+		return 1
+	}
+
+	// Report which file (if any) the effective config came from.
+	source := "built-in defaults (no config file path)"
+
+	path := config.DefaultConfigPath()
+	if path != "" {
+		_, statErr := os.Stat(path)
+		if statErr == nil {
+			source = path
+		} else {
+			source = path + " (not found — using built-in defaults)"
+		}
+	}
+
+	_, _ = fmt.Fprintf(stdout, "# config source: %s\n\n", source)
+	_, _ = fmt.Fprint(stdout, cfg.Render())
+
+	return 0
+}
+
+func configHelp(w io.Writer) {
+	_, _ = fmt.Fprint(w, `Usage: lazy-tmux config <subcommand>
+
+Subcommands:
+  gen [--path FILE] [--force]   Write a base config file (default: the path lazy-tmux reads)
+  show                          Print the effective config lazy-tmux actually reads
+`)
+}

--- a/cmd/lazy-tmux/config_cmd.go
+++ b/cmd/lazy-tmux/config_cmd.go
@@ -51,6 +51,11 @@ func runConfigGen(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
+	if flags.NArg() != 0 {
+		writeErr(stderr, fmt.Errorf("unexpected arguments: %v", flags.Args()))
+		return 1
+	}
+
 	written, err := config.GenerateConfig(*path, *force)
 	if err != nil {
 		writeErr(stderr, fmt.Errorf("config gen: %w", err))
@@ -75,6 +80,11 @@ func runConfigShow(args []string, stdout, stderr io.Writer) int {
 
 		writeErr(stderr, fmt.Errorf("parse flags: %w", err))
 
+		return 1
+	}
+
+	if flags.NArg() != 0 {
+		writeErr(stderr, fmt.Errorf("unexpected arguments: %v", flags.Args()))
 		return 1
 	}
 

--- a/cmd/lazy-tmux/config_cmd_test.go
+++ b/cmd/lazy-tmux/config_cmd_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCLIConfigGenAndShow(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lazy-tmux.toml")
+
+	// gen writes the file.
+	if code, out, errOut := run(t, "config", "gen", "--path", path); code != 0 {
+		t.Fatalf("config gen: exit %d stderr=%q", code, errOut)
+	} else if !strings.Contains(out, "wrote config to "+path) {
+		t.Fatalf("config gen output: %q", out)
+	}
+
+	// gen again without --force must refuse.
+	if code, _, _ := run(t, "config", "gen", "--path", path); code != 1 {
+		t.Fatalf("config gen over existing should fail, got exit %d", code)
+	}
+
+	// show reads that file and prints the source + effective values.
+	t.Setenv("LAZY_TMUX_CONFIG", path)
+
+	code, out, _ := run(t, "config", "show")
+	if code != 0 {
+		t.Fatalf("config show: exit %d", code)
+	}
+
+	if !strings.Contains(out, "config source: "+path) || !strings.Contains(out, "tmux_bin") {
+		t.Fatalf("config show output: %q", out)
+	}
+}
+
+func TestCLIConfigUnknownSubcommand(t *testing.T) {
+	code, _, errOut := run(t, "config", "bogus")
+	if code != 1 {
+		t.Fatalf("expected exit 1, got %d", code)
+	}
+
+	if !strings.Contains(errOut, "unknown config subcommand: bogus") {
+		t.Fatalf("unexpected stderr: %q", errOut)
+	}
+}
+
+func TestCLIConfigHelp(t *testing.T) {
+	for _, args := range [][]string{{"help", "config"}, {"config", "-h"}, {"config"}} {
+		_, outOrErr := captureConfig(t, args)
+		if !strings.Contains(outOrErr, "lazy-tmux config <subcommand>") {
+			t.Fatalf("%v: expected config help, got %q", args, outOrErr)
+		}
+	}
+}
+
+// captureConfig runs args and returns the combined stdout+stderr, since bare
+// `config` prints help to stderr while `help config` / `config -h` use stdout.
+func captureConfig(t *testing.T, args []string) (int, string) {
+	t.Helper()
+
+	code, out, errOut := run(t, args...)
+
+	return code, out + errOut
+}

--- a/cmd/lazy-tmux/config_cmd_test.go
+++ b/cmd/lazy-tmux/config_cmd_test.go
@@ -34,6 +34,19 @@ func TestCLIConfigGenAndShow(t *testing.T) {
 	}
 }
 
+func TestCLIConfigRejectsExtraArgs(t *testing.T) {
+	for _, args := range [][]string{{"config", "gen", "extra"}, {"config", "show", "extra"}} {
+		code, _, errOut := run(t, args...)
+		if code != 1 {
+			t.Fatalf("%v: expected exit 1, got %d", args, code)
+		}
+
+		if !strings.Contains(errOut, "unexpected arguments") {
+			t.Fatalf("%v: expected unexpected-args error, got %q", args, errOut)
+		}
+	}
+}
+
 func TestCLIConfigUnknownSubcommand(t *testing.T) {
 	code, _, errOut := run(t, "config", "bogus")
 	if code != 1 {

--- a/cmd/lazy-tmux/main.go
+++ b/cmd/lazy-tmux/main.go
@@ -21,6 +21,7 @@ var commands = map[string]func(args []string, stdout, stderr io.Writer) int{
 	"wakeup":    runWakeup,
 	"sleep":     runSleep,
 	"forget":    runForget,
+	"config":    runConfig,
 }
 
 var helpFuncs = map[string]func(io.Writer){
@@ -35,6 +36,7 @@ var helpFuncs = map[string]func(io.Writer){
 	"wakeup":    func(w io.Writer) { printSessionHelp("wakeup", true, w) },
 	"sleep":     sleepHelp,
 	"forget":    func(w io.Writer) { printSessionHelp("forget", false, w) },
+	"config":    configHelp,
 }
 
 func main() {
@@ -102,6 +104,7 @@ Commands:
   daemon     Periodically save all sessions
   list       List saved sessions
   setup      Print config keybinds for tmux
+  config     Generate (gen) or show the config file
   version    Print the version
 
 Run 'lazy-tmux <command> -h' for more details.

--- a/docs/_content.html
+++ b/docs/_content.html
@@ -604,6 +604,13 @@
               <td>Print the version</td>
             </tr>
             <tr>
+              <td><code>config gen</code> / <code>config show</code></td>
+              <td>
+                Write a base config file, or print the effective config
+                lazy-tmux actually reads
+              </td>
+            </tr>
+            <tr>
               <td><code>wakeup --session NAME</code></td>
               <td>Restore a saved session (lazy load) that is not currently running</td>
             </tr>

--- a/docs/cli/index.html
+++ b/docs/cli/index.html
@@ -110,6 +110,13 @@
               <td>Print the version</td>
             </tr>
             <tr>
+              <td><code>config gen</code> / <code>config show</code></td>
+              <td>
+                Write a base config file, or print the effective config
+                lazy-tmux actually reads
+              </td>
+            </tr>
+            <tr>
               <td><code>wakeup --session NAME</code></td>
               <td>Restore a saved session (lazy load) that is not currently running</td>
             </tr>

--- a/internal/config/default.toml
+++ b/internal/config/default.toml
@@ -1,14 +1,16 @@
-# Example lazy-tmux configuration.
+# lazy-tmux configuration.
 #
-# Copy to one of (first match wins):
+# lazy-tmux reads this file from (first match wins):
 #   $LAZY_TMUX_CONFIG
 #   $XDG_CONFIG_HOME/lazy-tmux/lazy-tmux.toml
 #   ~/.config/lazy-tmux/lazy-tmux.toml
 #
 # Every key is optional; omitted keys fall back to the built-in defaults.
 # Command-line flags override anything set here.
+# Run `lazy-tmux config show` to see the effective config actually being read.
 
-# tmux binary to invoke.
+# tmux binary to invoke. A leading ~ is expanded. Set this if your tmux is a
+# shell alias or lives outside PATH (e.g. "~/bin/tmux.appimage").
 tmux_bin = "tmux"
 
 # Directory where session snapshots are stored. A leading ~ is expanded.

--- a/internal/config/gen.go
+++ b/internal/config/gen.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// DefaultConfigTemplate is the commented base config written by `config gen`.
+// It is the single source of truth for the documented config schema.
+//
+//go:embed default.toml
+var DefaultConfigTemplate string
+
+// GenerateConfig writes the default config template to path (or DefaultConfigPath
+// when path is empty), creating parent directories. Unless force is set it
+// refuses to overwrite an existing file. It returns the path written.
+func GenerateConfig(path string, force bool) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		path = DefaultConfigPath()
+	}
+
+	if strings.TrimSpace(path) == "" {
+		return "", errors.New("could not determine a config path (pass --path or set $HOME)")
+	}
+
+	if !force {
+		_, statErr := os.Stat(path)
+
+		switch {
+		case statErr == nil:
+			return path, fmt.Errorf("%s already exists (use --force to overwrite)", path)
+		case !errors.Is(statErr, fs.ErrNotExist):
+			return path, fmt.Errorf("stat %s: %w", path, statErr)
+		}
+	}
+
+	dir := filepath.Dir(path)
+	if dir != "" {
+		mkErr := os.MkdirAll(dir, 0o755)
+		if mkErr != nil {
+			return path, fmt.Errorf("create %s: %w", dir, mkErr)
+		}
+	}
+
+	writeErr := os.WriteFile(path, []byte(DefaultConfigTemplate), 0o644)
+	if writeErr != nil {
+		return path, fmt.Errorf("write %s: %w", path, writeErr)
+	}
+
+	return path, nil
+}
+
+// Render returns the effective configuration as TOML, mirroring the file format
+// (durations as strings, scrollback table), so it shows exactly what lazy-tmux
+// resolved.
+func (c Config) Render() string {
+	var buf strings.Builder
+
+	fmt.Fprintf(&buf, "tmux_bin        = %s\n", strconv.Quote(c.TmuxBin))
+	fmt.Fprintf(&buf, "data_dir        = %s\n", strconv.Quote(c.DataDir))
+	fmt.Fprintf(&buf, "save_interval   = %s\n", strconv.Quote(c.SaveInterval.String()))
+	fmt.Fprintf(&buf, "restore_timeout = %s\n", strconv.Quote(c.RestoreTimeout.String()))
+
+	if c.RestoreAllowlist == nil {
+		buf.WriteString("# restore_allowlist not set (every command is restored)\n")
+	} else {
+		quoted := make([]string, len(c.RestoreAllowlist))
+		for i, cmd := range c.RestoreAllowlist {
+			quoted[i] = strconv.Quote(cmd)
+		}
+
+		fmt.Fprintf(&buf, "restore_allowlist = [%s]\n", strings.Join(quoted, ", "))
+	}
+
+	buf.WriteString("\n[scrollback]\n")
+	fmt.Fprintf(&buf, "enabled = %t\n", c.Scrollback.Enabled)
+	fmt.Fprintf(&buf, "lines   = %d\n", c.Scrollback.Lines)
+
+	return buf.String()
+}

--- a/internal/config/gen_test.go
+++ b/internal/config/gen_test.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateConfigWritesLoadableTemplate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sub", "lazy-tmux.toml")
+
+	written, err := GenerateConfig(path, false)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	if written != path {
+		t.Fatalf("path: got %q want %q", written, path)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	if string(data) != DefaultConfigTemplate {
+		t.Fatal("generated content != embedded template")
+	}
+
+	// The shipped template must itself parse cleanly.
+	if _, err := LoadFrom(path); err != nil {
+		t.Fatalf("generated config does not load: %v", err)
+	}
+}
+
+func TestGenerateConfigRefusesOverwriteWithoutForce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lazy-tmux.toml")
+
+	if _, err := GenerateConfig(path, false); err != nil {
+		t.Fatalf("first generate: %v", err)
+	}
+
+	if _, err := GenerateConfig(path, false); err == nil {
+		t.Fatal("second generate without --force should fail")
+	}
+
+	if _, err := GenerateConfig(path, true); err != nil {
+		t.Fatalf("generate with --force: %v", err)
+	}
+}
+
+func TestRenderEffectiveConfig(t *testing.T) {
+	cfg := Default()
+	out := cfg.Render()
+
+	for _, want := range []string{
+		`tmux_bin        = "tmux"`,
+		"save_interval",
+		"[scrollback]",
+		"restore_allowlist not set",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("render missing %q in:\n%s", want, out)
+		}
+	}
+
+	cfg.RestoreAllowlist = []string{"nvim", "vim"}
+	if got := cfg.Render(); !strings.Contains(got, `restore_allowlist = ["nvim", "vim"]`) {
+		t.Fatalf("render allowlist wrong:\n%s", got)
+	}
+}


### PR DESCRIPTION
Resolves #152.

Adds a `config` command group:

## `lazy-tmux config gen [--path FILE] [--force]`
Writes a commented base config to the path lazy-tmux actually reads (`$LAZY_TMUX_CONFIG` → `$XDG_CONFIG_HOME/lazy-tmux/lazy-tmux.toml` → `~/.config/lazy-tmux/lazy-tmux.toml`), creating parent dirs. Refuses to overwrite an existing file unless `--force`.

## `lazy-tmux config show`
Prints the **effective** config the program actually loaded — resolved values (e.g. `data_dir` expanded to an absolute path, durations as strings) — plus which file it came from. Useful for debugging "which tmux / data_dir is it really using", e.g. the tmux-alias case in #125:

```
# config source: /home/user/.config/lazy-tmux/lazy-tmux.toml

tmux_bin        = "/home/user/bin/tmux.appimage"
data_dir        = "/home/user/.local/share/lazy-tmux"
save_interval   = "5m0s"
restore_timeout = "5s"
# restore_allowlist not set (every command is restored)

[scrollback]
enabled = false
lines   = 5000
```

## DRY

The base template is a single embedded source of truth (`internal/config/default.toml` via `//go:embed`). The redundant root `lazy-tmux.example.toml` (not referenced anywhere) is removed — `config gen` is now the way to get one. `config` routes through normal command/help dispatch (`lazy-tmux help config`, `config -h`).

## Tests

- `config gen`: content equals the template, the template itself loads cleanly, overwrite refused without `--force`, `--force` overwrites.
- `Render`: effective-config output (incl. allowlist set/unset).
- CLI: `config gen` + `config show` round-trip, unknown subcommand errors, help.

`make golangci-lint` clean; `make test` 123 pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `config` command with `gen` (create base config) and `show` (print the effective config) subcommands.
  * `config show` now reports the config source and outputs the final configuration lazy-tmux uses.
* **Documentation**
  * Updated CLI reference docs and configuration comments to describe config lookup, overrides, and `tmux_bin`.
* **Bug Fixes**
  * Prevents overwriting an existing config unless `--force` is provided.
  * Adds clearer validation for help, unknown subcommands, and extra trailing arguments.
* **Tests**
  * Added end-to-end CLI and config rendering/generation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->