### PR TITLE
fix(install): truncate progress bar label to terminal width

### DIFF
--- a/docs/install.sh
+++ b/docs/install.sh
@@ -16,6 +16,7 @@ fi
 YELLOW=''
 RESET=''
 sleep_ok=0
+term_cols=80
 if [ "$ui" -eq 1 ]; then
   YELLOW=$(printf '\033[33m')
   RESET=$(printf '\033[0m')
@@ -24,11 +25,23 @@ if [ "$ui" -eq 1 ]; then
   if sleep 0.01 2>/dev/null; then
     sleep_ok=1
   fi
+  # Terminal width, so a frame never wraps (a wrapped line defeats \r + \033[K
+  # and leaves the previous frame's tail on screen). Fall back to 80 columns.
+  _cols=$(tput cols 2>/dev/null) || _cols=''
+  case $_cols in
+    *[!0-9]* | '') ;;
+    *) term_cols=$_cols ;;
+  esac
 fi
 
 BAR_WIDTH=40
 bar_cur=0
 bar_active=0
+# Columns consumed before the label: the bar (BAR_WIDTH), a space, "%3d%%" (4)
+# and two trailing spaces = BAR_WIDTH + 7, plus 1 column of slack so the cursor
+# never lands in the last column (where some terminals auto-wrap). Budgets how
+# much of the label fits on one row.
+BAR_PREFIX_WIDTH=$(( BAR_WIDTH + 8 ))
 
 draw_bar() { # <percent> <label>
   _pct=$1
@@ -44,7 +57,13 @@ draw_bar() { # <percent> <label>
     _bar="${_bar}･"
     _i=$(( _i + 1 ))
   done
-  printf '\r%s%s%s %3d%%  %s\033[K' "$YELLOW" "$_bar" "$RESET" "$_pct" "$_label"
+  # Clamp the label to what's left on the row so the line never wraps. Labels
+  # are ASCII, so a byte-precision cut ('%.*s') matches the display width.
+  _max=$(( term_cols - BAR_PREFIX_WIDTH ))
+  if [ "$_max" -lt 0 ]; then
+    _max=0
+  fi
+  printf '\r%s%s%s %3d%%  %.*s\033[K' "$YELLOW" "$_bar" "$RESET" "$_pct" "$_max" "$_label"
 }
 
 step() { # <target percent> <label>
@@ -233,7 +252,10 @@ else
   chmod 0755 "$install_dir/$bin_name"
 fi
 
-bar_done "Installed lazy-tmux to ${install_dir}/${bin_name}"
+# Keep the bar's final label short (it would otherwise be the longest line and
+# wrap); print the full install path on its own line below the finished bar.
+bar_done "Installed lazy-tmux"
+note "→ ${install_dir}/${bin_name}"
 
 if [ "$fzf_only" -eq 1 ] && ! command -v fzf >/dev/null 2>&1; then
   note "Note: fzf-only build requires fzf in PATH."


### PR DESCRIPTION
## What

Fixes the trailing artifacts the install progress bar left on screen when the
line wrapped.

Closes #154.

## Why

Each frame is drawn with `\r…\033[K` (carriage return + clear-to-end-of-line),
which only clears the current terminal row. The final label
`Installed lazy-tmux to <install_dir>/lazy-tmux`, together with the 40-char bar
and the percent counter, is longer than the terminal width, so the line wraps.
After a wrap `\r` returns only to the start of the last visual row and `\033[K`
clears only that row, leaving the wrapped tails of earlier frames on screen:

```
■■■…■･･  95%  Installed lazy-tmux to /home/antonmoss/.local/bin/lazy-tmu■■■…■･  98%  Installed …lazy-tmu■■■… 100%  Installed …lazy-tmu■■■… 100%  Installed …lazy-tmux
```

## How

- Detect the terminal width once (`tput cols`, fallback 80 columns; only when
  the bar UI is active).
- Clamp the label with `printf '%.*s'` so a frame never exceeds the row,
  budgeting `BAR_WIDTH + 8` columns for the bar/percent prefix plus 1 column of
  slack. Labels are ASCII, so a byte-precision cut matches the display width.
- Keep the bar's final label short (`Installed lazy-tmux`) and print the full
  install path on its own line below the finished bar, so the path is never
  truncated.

This makes every step robust to long labels, not just the final one.

## Testing

- `sh -n docs/install.sh` passes.
- Simulated `draw_bar` at 100% with the long install label in a 50-column
  terminal: the visible line is 49 chars — fits with one column of slack, no
  wrap. In a normal terminal the short final label fits and the full path
  prints intact on the next line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal progress display so it adapts to the available width and avoids wrapping.
  * Shortened the completed installation message and moved the full install path to a separate note line for clearer output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->