### PR TITLE
chore: mark docs/ sources as code for Linguist/CodeQL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# The docs site lives under docs/, which Linguist treats as "documentation" and
+# excludes from language stats by default. Its sources are a real TypeScript/React
+# app, so mark them as code: this makes GitHub's language stats and CodeQL see the
+# TypeScript. Static assets and the lockfile stay out of the stats.
+docs/src/** linguist-documentation=false
+docs/vite.config.ts linguist-documentation=false
+docs/package-lock.json linguist-generated=true
+docs/public/** linguist-vendored=true


### PR DESCRIPTION
## What

Adds `.gitattributes` so GitHub Linguist counts the docs site sources as
TypeScript code instead of "documentation".

## Why

After the Gravity UI migration, `docs/` is a real TypeScript/React app, but
Linguist treats everything under `docs/` as documentation and drops it from the
repo's language stats. As a result GitHub reports only `Go, Shell, Makefile,
Dockerfile` and **does not see TypeScript at all**.

That blocks enabling JavaScript/TypeScript scanning in CodeQL Default Setup —
the API rejects it with *"One or more languages you selected are not present in
the repository"* (HTTP 422).

This also explains the CI failure right after merging #157: the CodeQL run that
started at merge time still had `python` in its language matrix (from the
now-deleted `scripts/build-docs.py`) and failed with "no Python source code".
GitHub has since auto-updated the matrix to `[actions, go]`, so that failure is
already resolved; this PR is the follow-up to additionally cover the new TS code.

## Effect

- `docs/src/**` and `docs/vite.config.ts` → treated as code (TypeScript shows up
  in language stats; Go stays the dominant language — TS is ~1.3k lines vs Go's
  ~225 KB).
- `docs/package-lock.json` → marked generated.
- `docs/public/**` (install.sh, assets, CNAME) → marked vendored, kept out of
  stats.

## Follow-up (after merge)

Once this is on `main` and Linguist re-indexes, enable `javascript-typescript`
in CodeQL Default Setup so the docs code is scanned too.
