### PR TITLE
feat(picker): cohesive themed UI with mouse support

### DIFF
--- a/cmd/lazy-tmux/cli_test.go
+++ b/cmd/lazy-tmux/cli_test.go
@@ -174,6 +174,12 @@ func TestCLISetupPrintsKeybinds(t *testing.T) {
 		t.Fatalf("expected single-percent popup geometry, got %q", out)
 	}
 
+	// The popup must be borderless (-B): the picker draws its own frame, so the
+	// tmux popup border would be a redundant double border.
+	if !strings.Contains(out, "display-popup -B ") {
+		t.Fatalf("expected borderless popup (-B), got %q", out)
+	}
+
 	if strings.Contains(out, "%%") {
 		t.Fatalf("setup output has a doubled percent sign: %q", out)
 	}

--- a/cmd/lazy-tmux/setup.go
+++ b/cmd/lazy-tmux/setup.go
@@ -27,8 +27,9 @@ func runSetup(args []string, stdout, stderr io.Writer) int {
 		">/tmp/lazy-tmux.log 2>&1 || tmux display-message \"lazy-tmux daemon already running\"'"
 
 	// These lines are printed verbatim (Fprintln, not Fprintf), so percent signs
-	// must be single — tmux wants `-w 75% -h 85%`.
-	const popupKey = "bind-key f display-popup -w 75% -h 85% -E 'lazy-tmux picker'"
+	// must be single — tmux wants `-w 75% -h 85%`. `-B` drops the popup's own
+	// border since the picker draws its own frame (avoids a double border).
+	const popupKey = "bind-key f display-popup -B -w 75% -h 85% -E 'lazy-tmux picker'"
 
 	const saveKey = "bind-key C-s run-shell 'lazy-tmux save --all --scrollback && " +
 		"tmux display-message \"All sessions saved successfully!\"'"

--- a/docs/src/pages/TmuxSetup.tsx
+++ b/docs/src/pages/TmuxSetup.tsx
@@ -38,7 +38,7 @@ export function TmuxSetup() {
           Feel free to open your config and edit any parameters. For example you
           can configure picker popup size:
         </p>
-        <CodeBlock>{`bind-key f display-popup -w 65% -h 75% -E 'lazy-tmux picker'`}</CodeBlock>
+        <CodeBlock>{`bind-key f display-popup -B -w 65% -h 75% -E 'lazy-tmux picker'`}</CodeBlock>
 
         <p>Or edit time interval:</p>
         <CodeBlock>{`run-shell -b 'lazy-tmux daemon --interval 5m --scrollback > /tmp/lazy-tmux.log 2>&1 || tmux display-message "lazy-tmux daemon already running"'`}</CodeBlock>

--- a/go.mod
+++ b/go.mod
@@ -7,13 +7,13 @@ require (
 	charm.land/bubbletea/v2 v2.0.7
 	charm.land/lipgloss/v2 v2.0.4
 	github.com/BurntSushi/toml v1.6.0
+	github.com/charmbracelet/x/ansi v0.11.7
 )
 
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654 // indirect
-	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect

--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -9,7 +9,6 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2"
 )
 
 type pickerRow struct {
@@ -24,22 +23,22 @@ type pickerRow struct {
 }
 
 type pickerModel struct {
-	sessions      []Session
-	windowSort    []WindowSortKey
-	visible       []pickerRow
-	queryInput    textinput.Model
-	viewport      viewport.Model
-	selectedStyle lipgloss.Style
-	selected      Target
-	cancelled     bool
-	cursor        int
-	width         int
-	height        int
-	actions       Actions
-	statusMsg     string
-	mode          pickerMode
-	promptInput   textinput.Model
-	pending       Target
+	sessions    []Session
+	windowSort  []WindowSortKey
+	visible     []pickerRow
+	queryInput  textinput.Model
+	viewport    viewport.Model
+	theme       pickerTheme
+	selected    Target
+	cancelled   bool
+	cursor      int
+	width       int
+	height      int
+	actions     Actions
+	statusMsg   string
+	mode        pickerMode
+	promptInput textinput.Model
+	pending     Target
 }
 
 type pickerMode int
@@ -56,22 +55,29 @@ const (
 const scrollMargin = 2
 
 func newPickerModel(sessions []Session, windowSort []WindowSortKey, actions Actions) pickerModel {
+	theme := newPickerTheme()
+
 	input := textinput.New()
 	input.Placeholder = ""
-	input.Prompt = "> "
+	input.Prompt = "❯ "
+
+	inputStyles := input.Styles()
+	inputStyles.Focused.Prompt = theme.prompt
+	inputStyles.Blurred.Prompt = theme.prompt
+	input.SetStyles(inputStyles)
 	input.Focus()
 
 	viewPort := viewport.New()
 
 	model := pickerModel{
-		sessions:      sessions,
-		windowSort:    windowSort,
-		queryInput:    input,
-		viewport:      viewPort,
-		selectedStyle: lipgloss.NewStyle().Foreground(lipgloss.Color("212")).Bold(true),
-		cursor:        0,
-		actions:       actions,
-		mode:          modeBrowse,
+		sessions:   sessions,
+		windowSort: windowSort,
+		queryInput: input,
+		viewport:   viewPort,
+		theme:      theme,
+		cursor:     0,
+		actions:    actions,
+		mode:       modeBrowse,
 	}
 	model.applyFilter()
 
@@ -91,87 +97,49 @@ func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.renderViewport()
 
 		return m, nil
+	case tea.MouseWheelMsg:
+		if m.mode != modeBrowse {
+			return m, nil
+		}
+
+		switch msg.Button {
+		case tea.MouseWheelUp:
+			m.movePrevSelectable()
+		case tea.MouseWheelDown:
+			m.moveNextSelectable()
+		}
+
+		m.ensureCursorVisible()
+		m.renderViewport()
+
+		return m, nil
+	case tea.MouseClickMsg:
+		if m.mode != modeBrowse || msg.Button != tea.MouseLeft {
+			return m, nil
+		}
+
+		idx, ok := m.rowAtY(msg.Y)
+		if !ok {
+			return m, nil
+		}
+
+		if idx == m.cursor {
+			m.selected = m.visible[idx].target
+			return m, tea.Quit
+		}
+
+		m.cursor = idx
+		m.ensureCursorVisible()
+		m.renderViewport()
+
+		return m, nil
 	case tea.KeyPressMsg:
 		if m.mode != modeBrowse {
 			return m.handlePromptKey(msg)
 		}
 
-		switch msg.String() {
-		case "ctrl+c", "ctrl+q", "esc":
-			m.cancelled = true
-			return m, tea.Quit
-		case "ctrl+d":
-			err := m.deleteCurrentWindow()
-			if err != nil {
-				m.setStatus(err.Error())
-			} else {
-				m.clearStatus()
-			}
-
-			m.reload()
-			m.renderViewport()
-
-			return m, nil
-		case "alt+d":
-			m.confirmDeleteSession()
-			return m, nil
-		case "ctrl+r":
-			m.renameCurrentWindow()
-			return m, nil
-		case "alt+r":
-			m.renameCurrentSession()
-			return m, nil
-		case "alt+n":
-			m.newSession()
-			return m, nil
-		case "ctrl+n":
-			m.newWindow()
-			return m, nil
-		case "alt+w":
-			err := m.wakeupSession()
-			if err != nil {
-				m.setStatus(err.Error())
-			} else {
-				m.clearStatus()
-			}
-
-			m.reload()
-			m.renderViewport()
-
-			return m, nil
-		case "alt+s":
-			err := m.sleepSession()
-			if err != nil {
-				m.setStatus(err.Error())
-			} else {
-				m.clearStatus()
-			}
-
-			m.reload()
-			m.renderViewport()
-
-			return m, nil
-		case "ctrl+k":
-			m.movePrevSelectable()
-			m.ensureCursorVisible()
-			m.renderViewport()
-
-			return m, nil
-		case "ctrl+j":
-			m.moveNextSelectable()
-			m.ensureCursorVisible()
-			m.renderViewport()
-
-			return m, nil
-		case "enter":
-			if len(m.visible) == 0 {
-				return m, nil
-			}
-
-			if m.cursor >= 0 && m.cursor < len(m.visible) && m.visible[m.cursor].selectable {
-				m.selected = m.visible[m.cursor].target
-				return m, tea.Quit
-			}
+		if next, cmd, handled := m.handleBrowseKey(msg); handled {
+			return next, cmd
 		}
 	}
 
@@ -190,39 +158,151 @@ func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m pickerModel) View() tea.View {
-	var builder strings.Builder
-	if m.mode == modeBrowse {
-		builder.WriteString(m.queryInput.View())
-	} else {
-		builder.WriteString(m.promptInput.View())
+	width := m.width
+	if width <= 0 {
+		width = 80
 	}
 
-	builder.WriteString("\n")
+	var buf strings.Builder
 
+	// Top border: title + session/window counts.
+	sessions, windows := m.counts()
+	right := m.theme.count.Render(fmt.Sprintf("%d sessions · %d windows", sessions, windows))
+	buf.WriteString(m.theme.frameTop("lazy-tmux", right, width))
+	buf.WriteString("\n")
+
+	// Search input (or the active action prompt).
+	input := m.queryInput.View()
+	if m.mode != modeBrowse {
+		input = m.promptInput.View()
+	}
+
+	buf.WriteString(m.theme.frameLine(input, width))
+	buf.WriteString("\n")
+
+	// Column header, aligned with the row name column (2 leading cells).
 	layout := buildPickerTableLayout(m.tableContentWidth())
-
-	builder.WriteString("  ")
-	builder.WriteString(layout.header())
-	builder.WriteString("\n")
+	buf.WriteString(m.theme.frameLine("  "+layout.styledHeader(m.theme), width))
+	buf.WriteString("\n")
 
 	if m.statusMsg != "" {
-		builder.WriteString(m.statusMsg)
-		builder.WriteString("\n")
+		buf.WriteString(m.theme.frameLine(m.theme.statusErr.Render(m.statusMsg), width))
+		buf.WriteString("\n")
 	}
 
 	if len(m.visible) == 0 {
-		builder.WriteString("No sessions or windows match query\n")
-		view := tea.NewView(builder.String())
-		view.AltScreen = true
-
-		return view
+		buf.WriteString(
+			m.theme.frameLine(m.theme.faint.Render("No sessions or windows match query"), width),
+		)
+		buf.WriteString("\n")
+	} else {
+		for line := range strings.SplitSeq(m.viewport.View(), "\n") {
+			buf.WriteString(m.theme.frameLine(line, width))
+			buf.WriteString("\n")
+		}
 	}
 
-	builder.WriteString(m.viewport.View())
-	view := tea.NewView(builder.String())
+	// Bottom border: key hints.
+	buf.WriteString(m.theme.frameBottom(m.helpHints(), width))
+
+	view := tea.NewView(buf.String())
 	view.AltScreen = true
+	view.MouseMode = tea.MouseModeCellMotion
 
 	return view
+}
+
+func (m pickerModel) counts() (sessions, windows int) {
+	for i := range m.sessions {
+		windows += len(m.sessions[i].Windows)
+	}
+
+	return len(m.sessions), windows
+}
+
+func (m pickerModel) helpHints() string {
+	pairs := []struct{ key, label string }{
+		{"↵", "select"},
+		{"^j/^k", "move"},
+		{"^d", "del"},
+		{"^r", "rename"},
+		{"^n", "new"},
+		{"esc", "quit"},
+	}
+
+	parts := make([]string, 0, len(pairs))
+	for _, p := range pairs {
+		parts = append(parts, m.theme.helpKey.Render(p.key)+" "+m.theme.helpText.Render(p.label))
+	}
+
+	return strings.Join(parts, m.theme.helpText.Render("  ·  "))
+}
+
+// handleBrowseKey dispatches a key press while browsing. The bool reports
+// whether the key was consumed; unconsumed keys fall through to the search
+// input so typing still filters the list.
+func (m pickerModel) handleBrowseKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, bool) {
+	switch msg.String() {
+	case "ctrl+c", "ctrl+q", "esc":
+		m.cancelled = true
+		return m, tea.Quit, true
+	case "ctrl+d":
+		m.applyActionResult(m.deleteCurrentWindow())
+		return m, nil, true
+	case "alt+d":
+		m.confirmDeleteSession()
+		return m, nil, true
+	case "ctrl+r":
+		m.renameCurrentWindow()
+		return m, nil, true
+	case "alt+r":
+		m.renameCurrentSession()
+		return m, nil, true
+	case "alt+n":
+		m.newSession()
+		return m, nil, true
+	case "ctrl+n":
+		m.newWindow()
+		return m, nil, true
+	case "alt+w":
+		m.applyActionResult(m.wakeupSession())
+		return m, nil, true
+	case "alt+s":
+		m.applyActionResult(m.sleepSession())
+		return m, nil, true
+	case "ctrl+k":
+		m.movePrevSelectable()
+		m.ensureCursorVisible()
+		m.renderViewport()
+
+		return m, nil, true
+	case "ctrl+j":
+		m.moveNextSelectable()
+		m.ensureCursorVisible()
+		m.renderViewport()
+
+		return m, nil, true
+	case "enter":
+		if m.cursor >= 0 && m.cursor < len(m.visible) && m.visible[m.cursor].selectable {
+			m.selected = m.visible[m.cursor].target
+			return m, tea.Quit, true
+		}
+	}
+
+	return m, nil, false
+}
+
+// applyActionResult surfaces an action error as a status message (or clears it),
+// then reloads sessions and re-renders.
+func (m *pickerModel) applyActionResult(err error) {
+	if err != nil {
+		m.setStatus(err.Error())
+	} else {
+		m.clearStatus()
+	}
+
+	m.reload()
+	m.renderViewport()
 }
 
 func (m *pickerModel) resize() {
@@ -230,14 +310,10 @@ func (m *pickerModel) resize() {
 		return
 	}
 
-	m.viewport.SetWidth(max(1, m.width-1))
+	m.viewport.SetWidth(m.contentWidth())
 
-	inputHeight := lipgloss.Height(m.queryInput.View())
-	if m.mode != modeBrowse {
-		inputHeight = lipgloss.Height(m.promptInput.View())
-	}
-
-	reserved := inputHeight + 1 + m.statusHeight()
+	// Reserved chrome rows: top border, input, header, bottom border (+ status).
+	reserved := 4 + m.statusHeight()
 	m.viewport.SetHeight(max(1, m.height-reserved))
 }
 
@@ -264,36 +340,60 @@ func (m *pickerModel) renderViewport() {
 	}
 
 	layout := buildPickerTableLayout(m.tableContentWidth())
+	barWidth := max(0, m.contentWidth()-2) // room for the stripe + a space
 	lines := make([]string, 0, len(m.visible))
 
 	for rowIndex, row := range m.visible {
-		pointer := "  "
 		if rowIndex == m.cursor && row.selectable {
-			pointer = "> "
+			body := layout.row(row)
+
+			if pad := barWidth - len([]rune(body)); pad > 0 {
+				body += strings.Repeat(" ", pad)
+			}
+
+			lines = append(lines, m.theme.stripe.Render("▌")+m.theme.selBar.Render(" "+body))
+
+			continue
 		}
 
-		line := pointer + layout.row(row)
-		if rowIndex == m.cursor && row.selectable {
-			line = m.selectedStyle.Render(line)
-		}
-
-		lines = append(lines, line)
+		lines = append(lines, "  "+layout.styledRow(row, m.theme))
 	}
 
 	m.viewport.SetContent(strings.Join(lines, "\n"))
 }
 
-func (m *pickerModel) tableContentWidth() int {
-	width := m.viewport.Width()
-	if width <= 0 {
-		width = m.width
-	}
-
+// contentWidth is the usable width inside the frame's side borders and gutter
+// spaces (│ … │), i.e. the width each inner line is padded to.
+func (m *pickerModel) contentWidth() int {
+	width := m.width
 	if width <= 0 {
 		width = 80
 	}
 
-	return max(1, width-2) // keep room for line pointer ("> ")
+	return max(1, width-4) // 2 borders + 2 gutter spaces
+}
+
+// tableContentWidth is the width available to the column table, after the 2
+// leading cells reserved for the selection stripe / row indent.
+func (m *pickerModel) tableContentWidth() int {
+	return max(1, m.contentWidth()-2)
+}
+
+// rowAtY maps a mouse Y coordinate to a selectable row index. The list starts
+// below the top border, input and header (and the optional status line).
+func (m *pickerModel) rowAtY(mouseY int) (int, bool) {
+	rowStart := 3 + m.statusHeight() // top border + input + header [+ status]
+
+	if mouseY < rowStart {
+		return 0, false
+	}
+
+	idx := m.viewport.YOffset() + (mouseY - rowStart)
+	if idx < 0 || idx >= len(m.visible) || !m.visible[idx].selectable {
+		return 0, false
+	}
+
+	return idx, true
 }
 
 func (m *pickerModel) ensureCursorVisible() {

--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -347,7 +347,7 @@ func (m *pickerModel) renderViewport() {
 		if rowIndex == m.cursor && row.selectable {
 			body := layout.row(row)
 
-			if pad := barWidth - len([]rune(body)); pad > 0 {
+			if pad := barWidth - displayWidth(body); pad > 0 {
 				body += strings.Repeat(" ", pad)
 			}
 

--- a/internal/picker/relative_test.go
+++ b/internal/picker/relative_test.go
@@ -1,0 +1,36 @@
+//go:build !lazy_fzf
+
+package picker
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRelativeTime(t *testing.T) {
+	now := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name string
+		then time.Time
+		want string
+	}{
+		{"zero", time.Time{}, ""},
+		{"future clamps to just now", now.Add(time.Hour), "just now"},
+		{"seconds", now.Add(-30 * time.Second), "just now"},
+		{"minutes", now.Add(-5 * time.Minute), "5m ago"},
+		{"hours", now.Add(-3 * time.Hour), "3h ago"},
+		{"days", now.Add(-2 * 24 * time.Hour), "2d ago"},
+		{"weeks", now.Add(-2 * 7 * 24 * time.Hour), "2w ago"},
+		{"months", now.Add(-60 * 24 * time.Hour), "2mo ago"},
+		{"years", now.Add(-400 * 24 * time.Hour), "1y ago"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := relativeTime(tc.then, now); got != tc.want {
+				t.Fatalf("relativeTime(%v) = %q, want %q", tc.then, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/picker/rows.go
+++ b/internal/picker/rows.go
@@ -34,7 +34,7 @@ func filteredTreeRows(sessions []Session, query string, windowSort []WindowSortK
 		rows = append(rows, pickerRow{
 			target:     Target{SessionName: sess.Record.SessionName},
 			item:       sess.Record.SessionName,
-			captured:   sess.Record.CapturedAt.Local().Format("2006-01-02 15:04:05"),
+			captured:   sess.Record.CapturedAt.Local().Format("06-01-02 15:04"),
 			wins:       fmt.Sprintf("%d", sess.Record.Windows),
 			state:      sessionStateIcon(sess.Restored),
 			selectable: false,

--- a/internal/picker/rows.go
+++ b/internal/picker/rows.go
@@ -5,6 +5,7 @@ package picker
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
 )
@@ -34,7 +35,7 @@ func filteredTreeRows(sessions []Session, query string, windowSort []WindowSortK
 		rows = append(rows, pickerRow{
 			target:     Target{SessionName: sess.Record.SessionName},
 			item:       sess.Record.SessionName,
-			captured:   sess.Record.CapturedAt.Local().Format("06-01-02 15:04"),
+			captured:   relativeTime(sess.Record.CapturedAt, time.Now()),
 			wins:       fmt.Sprintf("%d", sess.Record.Windows),
 			state:      sessionStateIcon(sess.Restored),
 			selectable: false,
@@ -61,6 +62,33 @@ func filteredTreeRows(sessions []Session, query string, windowSort []WindowSortK
 	}
 
 	return rows
+}
+
+// relativeTime renders a capture time as a compact, scannable age such as
+// "just now", "3m ago", "2h ago", "5d ago" or "4mo ago".
+func relativeTime(then, now time.Time) string {
+	if then.IsZero() {
+		return ""
+	}
+
+	delta := max(now.Sub(then), 0)
+
+	switch {
+	case delta < time.Minute:
+		return "just now"
+	case delta < time.Hour:
+		return fmt.Sprintf("%dm ago", int(delta.Minutes()))
+	case delta < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(delta.Hours()))
+	case delta < 7*24*time.Hour:
+		return fmt.Sprintf("%dd ago", int(delta.Hours())/24)
+	case delta < 30*24*time.Hour:
+		return fmt.Sprintf("%dw ago", int(delta.Hours())/(24*7))
+	case delta < 365*24*time.Hour:
+		return fmt.Sprintf("%dmo ago", int(delta.Hours())/(24*30))
+	default:
+		return fmt.Sprintf("%dy ago", int(delta.Hours())/(24*365))
+	}
 }
 
 func sessionStateIcon(restored bool) string {

--- a/internal/picker/table.go
+++ b/internal/picker/table.go
@@ -60,7 +60,7 @@ var pickerColumnSpecs = []pickerColumnSpec{
 	{
 		ID:       "captured",
 		Title:    "Captured",
-		MinWidth: 14,
+		MinWidth: 10,
 		Priority: 2,
 		Value: func(r pickerRow) string {
 			return r.captured

--- a/internal/picker/table.go
+++ b/internal/picker/table.go
@@ -278,7 +278,7 @@ func (l pickerTableLayout) renderWith(
 
 		val = truncateString(val, col.width)
 
-		pad := col.width - len([]rune(val))
+		pad := col.width - displayWidth(val)
 		if idx != len(l.columns)-1 && pad > 0 {
 			val += strings.Repeat(" ", pad)
 		}
@@ -310,7 +310,7 @@ func (l pickerTableLayout) render(valueFor func(spec pickerColumnSpec) string) s
 
 		out.WriteString(val)
 
-		pad := col.width - len([]rune(val))
+		pad := col.width - displayWidth(val)
 		if pad > 0 {
 			out.WriteString(strings.Repeat(" ", pad))
 		}

--- a/internal/picker/table.go
+++ b/internal/picker/table.go
@@ -44,18 +44,17 @@ var pickerColumnSpecs = []pickerColumnSpec{
 	{
 		ID:       "cmd",
 		Title:    "Cmd",
-		MinWidth: 12,
+		MinWidth: 18,
 		Priority: 1,
 		Value: func(r pickerRow) string {
 			return r.cmd
 		},
 	},
 	{
-		ID:         "captured",
-		Title:      "Captured",
-		MinWidth:   16,
-		Priority:   2,
-		TrimPrefix: "202",
+		ID:       "captured",
+		Title:    "Captured",
+		MinWidth: 14,
+		Priority: 2,
 		Value: func(r pickerRow) string {
 			return r.captured
 		},

--- a/internal/picker/table.go
+++ b/internal/picker/table.go
@@ -11,12 +11,17 @@ import (
 
 type pickerColumnID string
 
+// pickerColumnGap is the blank gutter rendered between adjacent columns so they
+// stay visually separated even when each is at its minimum width.
+const pickerColumnGap = 2
+
 type pickerColumnSpec struct {
 	ID         pickerColumnID
 	Title      string
 	MinWidth   int
 	Priority   int
 	Required   bool
+	Grow       bool // absorbs leftover width; non-growing columns stay at MinWidth
 	Value      func(pickerRow) string
 	TrimPrefix string
 }
@@ -37,6 +42,7 @@ var pickerColumnSpecs = []pickerColumnSpec{
 		MinWidth: 10,
 		Priority: 0,
 		Required: true,
+		Grow:     true,
 		Value: func(r pickerRow) string {
 			return r.item
 		},
@@ -44,8 +50,9 @@ var pickerColumnSpecs = []pickerColumnSpec{
 	{
 		ID:       "cmd",
 		Title:    "Cmd",
-		MinWidth: 18,
+		MinWidth: 14,
 		Priority: 1,
+		Grow:     true,
 		Value: func(r pickerRow) string {
 			return r.cmd
 		},
@@ -133,16 +140,38 @@ func buildPickerTableLayout(totalWidth int) pickerTableLayout {
 	}
 
 	if extra > 0 {
-		for i := range columns {
-			columns[i].width += extra / len(columns)
-		}
-
-		for i := 0; i < extra%len(columns); i++ {
-			columns[i].width++
-		}
+		growColumns(columns, extra)
 	}
 
 	return pickerTableLayout{columns: columns}
+}
+
+// growColumns hands the leftover width to the growable columns only (the name
+// and command), keeping the narrow meta columns at their minimum width. If no
+// column is growable it falls back to spreading the width across all of them.
+func growColumns(columns []pickerColumnLayout, extra int) {
+	growers := make([]int, 0, len(columns))
+
+	for i := range columns {
+		if columns[i].spec.Grow {
+			growers = append(growers, i)
+		}
+	}
+
+	if len(growers) == 0 {
+		for i := range columns {
+			growers = append(growers, i)
+		}
+	}
+
+	share := extra / len(growers)
+	for _, i := range growers {
+		columns[i].width += share
+	}
+
+	for k := 0; k < extra%len(growers); k++ {
+		columns[growers[k]].width++
+	}
 }
 
 func shrinkColumnsToFit(columns []pickerColumnLayout, totalWidth int) {
@@ -166,7 +195,16 @@ func tableWidth(columns []pickerColumnLayout) int {
 		width += col.width
 	}
 
-	return width
+	return width + gapWidth(len(columns))
+}
+
+// gapWidth is the total width taken by the gutters between n columns.
+func gapWidth(columns int) int {
+	if columns <= 1 {
+		return 0
+	}
+
+	return pickerColumnGap * (columns - 1)
 }
 
 func widestShrinkableColumn(columns []pickerColumnLayout) int {
@@ -193,7 +231,7 @@ func minTableWidth(specs []pickerColumnSpec) int {
 		width += spec.MinWidth
 	}
 
-	return width
+	return width + gapWidth(len(specs))
 }
 
 func (l pickerTableLayout) header() string {
@@ -246,6 +284,10 @@ func (l pickerTableLayout) renderWith(
 		}
 
 		out.WriteString(style.Render(val))
+
+		if idx != len(l.columns)-1 {
+			out.WriteString(strings.Repeat(" ", pickerColumnGap))
+		}
 	}
 
 	return out.String()
@@ -272,6 +314,8 @@ func (l pickerTableLayout) render(valueFor func(spec pickerColumnSpec) string) s
 		if pad > 0 {
 			out.WriteString(strings.Repeat(" ", pad))
 		}
+
+		out.WriteString(strings.Repeat(" ", pickerColumnGap))
 	}
 
 	return out.String()

--- a/internal/picker/table.go
+++ b/internal/picker/table.go
@@ -5,6 +5,8 @@ package picker
 import (
 	"sort"
 	"strings"
+
+	"charm.land/lipgloss/v2"
 )
 
 type pickerColumnID string
@@ -201,6 +203,53 @@ func (l pickerTableLayout) header() string {
 
 func (l pickerTableLayout) row(row pickerRow) string {
 	return l.render(func(spec pickerColumnSpec) string { return spec.Value(row) })
+}
+
+// styledHeader renders the column titles in the faint header style.
+func (l pickerTableLayout) styledHeader(theme pickerTheme) string {
+	return l.renderWith(func(spec pickerColumnSpec) (string, lipgloss.Style) {
+		return spec.Title, theme.headerCell
+	})
+}
+
+// styledRow renders a row with the name column bright (bold for session
+// headers) and the meta columns dimmed.
+func (l pickerTableLayout) styledRow(row pickerRow, theme pickerTheme) string {
+	return l.renderWith(func(spec pickerColumnSpec) (string, lipgloss.Style) {
+		if spec.ID == "item" {
+			if row.selectable {
+				return spec.Value(row), theme.name
+			}
+
+			return spec.Value(row), theme.session
+		}
+
+		return spec.Value(row), theme.meta
+	})
+}
+
+func (l pickerTableLayout) renderWith(
+	cell func(spec pickerColumnSpec) (string, lipgloss.Style),
+) string {
+	var out strings.Builder
+
+	for idx, col := range l.columns {
+		val, style := cell(col.spec)
+		if col.spec.TrimPrefix != "" {
+			val = strings.TrimPrefix(val, col.spec.TrimPrefix)
+		}
+
+		val = truncateString(val, col.width)
+
+		pad := col.width - len([]rune(val))
+		if idx != len(l.columns)-1 && pad > 0 {
+			val += strings.Repeat(" ", pad)
+		}
+
+		out.WriteString(style.Render(val))
+	}
+
+	return out.String()
 }
 
 func (l pickerTableLayout) render(valueFor func(spec pickerColumnSpec) string) string {

--- a/internal/picker/theme.go
+++ b/internal/picker/theme.go
@@ -9,12 +9,12 @@ import (
 )
 
 // The picker palette is aligned with the "moss-dark" terminal theme: a muted,
-// desaturated set of pastels on near-black. Sage green is the single accent
-// (title, cursor, selected stripe, restored-state mark); red is reserved for
-// errors. This keeps the picker feeling native in the terminal and in tune with
-// the monochrome lazy-tmux brand.
+// desaturated set of pastels on near-black. Amber is the browse-mode accent
+// (title, cursor, selected stripe, key hints); red is reserved for errors. This
+// keeps the picker feeling native in the terminal and in tune with the
+// monochrome lazy-tmux brand. (Per-mode accents are tracked in #163.)
 const (
-	colAccent  = "#87af87" // sage green — accent
+	colAccent  = "#d7875f" // amber/orange (moss-dark "yellow") — browse-mode accent
 	colText    = "#d0d0d0" // primary text (session / window names)
 	colMeta    = "#9e9e9e" // dimmed meta columns (cmd, captured, …)
 	colFaint   = "#585858" // tree branches, header labels, separators

--- a/internal/picker/theme.go
+++ b/internal/picker/theme.go
@@ -80,13 +80,19 @@ func (t pickerTheme) frameBottom(hints string, width int) string {
 //	with right:  ╭─ left ──────── right ─╮   (head 3 + Lₗ + 1 + fill + 1 + Lᵣ + 3)
 //	without:     ╰─ left ───────────────╯   (head 3 + Lₗ + 1 + fill + 2)
 func (t pickerTheme) frameBar(left, right rune, leftLabel, rightLabel string, width int) string {
-	var buf strings.Builder
-
-	buf.WriteString(t.border.Render(string(left) + "─ "))
-	buf.WriteString(leftLabel)
-
+	// Clamp the labels so they can never push the line past width on a narrow
+	// terminal (only the dashed fill would otherwise absorb the overflow, and a
+	// fill of zero still leaves an over-wide line that breaks the frame math).
 	if rightLabel != "" {
-		fill := max(0, width-8-lipgloss.Width(leftLabel)-lipgloss.Width(rightLabel))
+		budget := max(0, width-8) // head 3 + 2 inner spaces + tail 3
+		rightLabel = clampWidth(rightLabel, budget)
+		leftLabel = clampWidth(leftLabel, budget-displayWidth(rightLabel))
+
+		var buf strings.Builder
+
+		fill := max(0, budget-displayWidth(leftLabel)-displayWidth(rightLabel))
+		buf.WriteString(t.border.Render(string(left) + "─ "))
+		buf.WriteString(leftLabel)
 		buf.WriteString(t.border.Render(" " + strings.Repeat("─", fill) + " "))
 		buf.WriteString(rightLabel)
 		buf.WriteString(t.border.Render(" ─" + string(right)))
@@ -94,7 +100,14 @@ func (t pickerTheme) frameBar(left, right rune, leftLabel, rightLabel string, wi
 		return buf.String()
 	}
 
-	fill := max(0, width-6-lipgloss.Width(leftLabel))
+	budget := max(0, width-6) // head 3 + 1 inner space + tail 2
+	leftLabel = clampWidth(leftLabel, budget)
+
+	var buf strings.Builder
+
+	fill := max(0, budget-displayWidth(leftLabel))
+	buf.WriteString(t.border.Render(string(left) + "─ "))
+	buf.WriteString(leftLabel)
 	buf.WriteString(t.border.Render(" " + strings.Repeat("─", fill) + "─" + string(right)))
 
 	return buf.String()
@@ -104,14 +117,10 @@ func (t pickerTheme) frameBar(left, right rune, leftLabel, rightLabel string, wi
 // space gutter on each side, padding the content to the available width.
 func (t pickerTheme) frameLine(content string, width int) string {
 	inner := max(0, width-4) // 2 borders + 2 gutter spaces
-	pad := max(0, inner-lipgloss.Width(content))
+	content = clampWidth(content, inner)
+	pad := max(0, inner-displayWidth(content))
 
-	return t.border.Render(
-		"│",
-	) + " " + content + strings.Repeat(
-		" ",
-		pad,
-	) + " " + t.border.Render(
-		"│",
-	)
+	side := t.border.Render("│")
+
+	return side + " " + content + strings.Repeat(" ", pad) + " " + side
 }

--- a/internal/picker/theme.go
+++ b/internal/picker/theme.go
@@ -1,0 +1,117 @@
+//go:build !lazy_fzf
+
+package picker
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
+
+// The picker palette is aligned with the "moss-dark" terminal theme: a muted,
+// desaturated set of pastels on near-black. Sage green is the single accent
+// (title, cursor, selected stripe, restored-state mark); red is reserved for
+// errors. This keeps the picker feeling native in the terminal and in tune with
+// the monochrome lazy-tmux brand.
+const (
+	colAccent  = "#87af87" // sage green — accent
+	colText    = "#d0d0d0" // primary text (session / window names)
+	colMeta    = "#9e9e9e" // dimmed meta columns (cmd, captured, …)
+	colFaint   = "#585858" // tree branches, header labels, separators
+	colBorder  = "#444444" // frame
+	colSelBg   = "#303030" // selected-row background bar
+	colSelText = "#f0f0f0" // selected-row text
+	colError   = "#d75f5f" // error status
+	colCount   = "#9e9e9e" // header counts
+)
+
+type pickerTheme struct {
+	border     lipgloss.Style
+	title      lipgloss.Style
+	count      lipgloss.Style
+	prompt     lipgloss.Style
+	headerCell lipgloss.Style
+	name       lipgloss.Style
+	session    lipgloss.Style
+	meta       lipgloss.Style
+	faint      lipgloss.Style
+	stripe     lipgloss.Style
+	selBar     lipgloss.Style
+	statusErr  lipgloss.Style
+	helpKey    lipgloss.Style
+	helpText   lipgloss.Style
+}
+
+func newPickerTheme() pickerTheme {
+	return pickerTheme{
+		border:     lipgloss.NewStyle().Foreground(lipgloss.Color(colBorder)),
+		title:      lipgloss.NewStyle().Foreground(lipgloss.Color(colAccent)).Bold(true),
+		count:      lipgloss.NewStyle().Foreground(lipgloss.Color(colCount)),
+		prompt:     lipgloss.NewStyle().Foreground(lipgloss.Color(colAccent)),
+		headerCell: lipgloss.NewStyle().Foreground(lipgloss.Color(colFaint)),
+		name:       lipgloss.NewStyle().Foreground(lipgloss.Color(colText)),
+		session:    lipgloss.NewStyle().Foreground(lipgloss.Color(colText)).Bold(true),
+		meta:       lipgloss.NewStyle().Foreground(lipgloss.Color(colMeta)),
+		faint:      lipgloss.NewStyle().Foreground(lipgloss.Color(colFaint)),
+		stripe:     lipgloss.NewStyle().Foreground(lipgloss.Color(colAccent)),
+		selBar: lipgloss.NewStyle().
+			Background(lipgloss.Color(colSelBg)).
+			Foreground(lipgloss.Color(colSelText)),
+		statusErr: lipgloss.NewStyle().Foreground(lipgloss.Color(colError)),
+		helpKey:   lipgloss.NewStyle().Foreground(lipgloss.Color(colAccent)),
+		helpText:  lipgloss.NewStyle().Foreground(lipgloss.Color(colFaint)),
+	}
+}
+
+// frameTop draws the top border with an embedded title on the left and an
+// optional count on the right, e.g. "╭─ title ─── right ─╮".
+func (t pickerTheme) frameTop(title, right string, width int) string {
+	return t.frameBar('╭', '╮', t.title.Render(title), right, width)
+}
+
+// frameBottom draws the bottom border with embedded key hints on the left.
+func (t pickerTheme) frameBottom(hints string, width int) string {
+	return t.frameBar('╰', '╯', hints, "", width)
+}
+
+// frameBar builds one horizontal border line with pre-styled left/right labels
+// and a dashed fill sized so the whole line is exactly width cells wide.
+//
+//	with right:  ╭─ left ──────── right ─╮   (head 3 + Lₗ + 1 + fill + 1 + Lᵣ + 3)
+//	without:     ╰─ left ───────────────╯   (head 3 + Lₗ + 1 + fill + 2)
+func (t pickerTheme) frameBar(left, right rune, leftLabel, rightLabel string, width int) string {
+	var buf strings.Builder
+
+	buf.WriteString(t.border.Render(string(left) + "─ "))
+	buf.WriteString(leftLabel)
+
+	if rightLabel != "" {
+		fill := max(0, width-8-lipgloss.Width(leftLabel)-lipgloss.Width(rightLabel))
+		buf.WriteString(t.border.Render(" " + strings.Repeat("─", fill) + " "))
+		buf.WriteString(rightLabel)
+		buf.WriteString(t.border.Render(" ─" + string(right)))
+
+		return buf.String()
+	}
+
+	fill := max(0, width-6-lipgloss.Width(leftLabel))
+	buf.WriteString(t.border.Render(" " + strings.Repeat("─", fill) + "─" + string(right)))
+
+	return buf.String()
+}
+
+// frameLine wraps one inner content line with the side borders and a single
+// space gutter on each side, padding the content to the available width.
+func (t pickerTheme) frameLine(content string, width int) string {
+	inner := max(0, width-4) // 2 borders + 2 gutter spaces
+	pad := max(0, inner-lipgloss.Width(content))
+
+	return t.border.Render(
+		"│",
+	) + " " + content + strings.Repeat(
+		" ",
+		pad,
+	) + " " + t.border.Render(
+		"│",
+	)
+}

--- a/internal/picker/utils.go
+++ b/internal/picker/utils.go
@@ -2,19 +2,44 @@
 
 package picker
 
-func truncateString(input string, maxRunes int) string {
-	if maxRunes < 0 {
-		maxRunes = 0
+import "github.com/charmbracelet/x/ansi"
+
+// displayWidth returns the rendered cell width of s, counting full-width glyphs
+// (CJK, emoji) as 2 and ignoring ANSI escape sequences. This is the single
+// width helper the picker's layout and padding math relies on so selected and
+// unselected rows stay aligned for the same data.
+func displayWidth(s string) int {
+	return ansi.StringWidth(s)
+}
+
+// clampWidth truncates s (ANSI-aware) so its rendered width does not exceed
+// maxWidth. Styling escape sequences are preserved.
+func clampWidth(text string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return ""
 	}
 
-	runes := []rune(input)
-	if len(runes) <= maxRunes {
+	if displayWidth(text) <= maxWidth {
+		return text
+	}
+
+	return ansi.Truncate(text, maxWidth, "")
+}
+
+// truncateString trims input to maxWidth rendered cells, appending an ellipsis
+// when there is room for one.
+func truncateString(input string, maxWidth int) string {
+	if maxWidth < 0 {
+		maxWidth = 0
+	}
+
+	if displayWidth(input) <= maxWidth {
 		return input
 	}
 
-	if maxRunes <= 3 {
-		return string(runes[:maxRunes])
+	if maxWidth <= 3 {
+		return ansi.Truncate(input, maxWidth, "")
 	}
 
-	return string(runes[:maxRunes-3]) + "..."
+	return ansi.Truncate(input, maxWidth, "...")
 }


### PR DESCRIPTION
## What

A visual refresh of the TUI picker. Same screen, same behavior — but it now
looks like a cohesive, designed interface instead of a list with a filter.

## Why

The picker was functional but plain: a raw input line, an unstyled header, and a
magenta-highlighted row that clashed with the rest of the project. This brings it
in line with the monochrome lazy-tmux brand and makes it feel native in the
terminal.

## Changes

- **Framed layout.** The picker renders inside a bordered box with a title
  (`lazy-tmux`), live `N sessions · M windows` counts, a styled column header,
  and a key-hint footer.
- **Centralized theme (`internal/picker/theme.go`).** One place for the palette,
  aligned with the brand (near-black + light text) and the *moss-dark* terminal
  colors: a sage-green accent, red reserved for errors. Easy to retune.
- **Selected row.** A muted bar with a green left stripe, replacing the old
  bold-magenta line.
- **Per-column styling.** Bright names (bold for session headers), dimmed meta
  columns, faint tree branches and header labels — clearer visual hierarchy.
- **Mouse support.** Wheel moves the cursor between selectable rows; a left click
  selects a row, and clicking the already-selected row confirms it.

## Out of scope (unchanged on purpose)

Column layout, sorting, filtering, the session/window tree, and every in-place
action (`^d`/`alt+d`/`^r`/`alt+r`/`^n`/`alt+n`/`alt+w`/`alt+s`) keep their exact
structure and semantics. The `lazy_fzf` build is untouched. This is purely a
rendering + mouse change.

## How it looks

```
╭─ lazy-tmux ───────────────────────────────────────── 3 sessions · 6 windows ─╮
│ ❯                                                                            │
│   Session / Window    Cmd            Captured           Wins      State       │
│   work                                2026-01-01         3         ✓          │
│     ├─ [1] main       zsh                                                     │
│ ▌   ├─ [2] logs       zsh                                                     │
│     ╰─ [3] server     zsh                                                     │
│   api                                 2026-01-01         2                    │
╰─ ↵ select  ·  ^j/^k move  ·  ^d del  ·  ^r rename  ·  ^n new  ·  esc quit ────╯
```

## Verification

- `make build` / `make build-fzf` — both variants compile.
- `make golangci-lint` — clean.
- `make test` — 127 tests pass (integration tests skipped without
  `ENABLE_INTEGRATION_TESTS`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refreshed the terminal picker with a moss-dark, framed layout, theme-driven selection indicator, and improved status/empty/action-mode prompts.
  * Added mouse wheel navigation and click-to-select (browse mode), plus refined viewport spacing and row targeting.
  * Enhanced table rendering with theme-based headers/rows, smarter column width growth, and “captured” relative time (e.g., “3m ago”).
* **Bug Fixes**
  * Improved browse/search navigation consistency and more accurate mouse-to-row selection.
* **Documentation**
  * Updated tmux picker keybinding examples to use borderless popup (`-B`).
* **Tests**
  * Extended CLI setup test for the `-B` popup flag and added coverage for relative time formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->