### PR TITLE
feat(docs): use the base amber accent in the ASCII background

### DIFF
--- a/docs/src/components/AsciiField.tsx
+++ b/docs/src/components/AsciiField.tsx
@@ -5,7 +5,8 @@ const RAMP = " .·:-=+*#%@";
 const CELL_W = 9;
 const CELL_H = 15;
 const TARGET_FPS = 30;
-const WARM = "rgba(255, 210, 90,";
+// WARM is the site's base accent (#d7875f) — the same amber used by the picker.
+const WARM = "rgba(215, 135, 95,";
 const COOL = "rgba(232, 232, 232,";
 
 // A generative ASCII background: several drifting sine waves interfere into an


### PR DESCRIPTION
Recolor the ASCII background animation's warm peaks from yellow to the site's base accent `#d7875f` (`rgba(215,135,95)`) — the same amber the picker now uses, so the docs background and the TUI picker share one accent color.

Only the `WARM` constant in `docs/src/components/AsciiField.tsx` changes; the cool/idle glyph color is unchanged.

Verified with `make docs-build` (SSG build succeeds).