### PR TITLE
chore: translate fix-homebrew-tap.sh comment to English

### DIFF
--- a/scripts/fix-homebrew-tap.sh
+++ b/scripts/fix-homebrew-tap.sh
@@ -23,7 +23,7 @@ mkdir -p Formula
 moved=false
 for f in *.rb; do
   if [ -f "$f" ]; then
-    # Удаляем старый файл в Formula, если он есть
+    # Remove the old file under Formula/ if it exists.
     if [ -f "Formula/$f" ]; then
       git rm -f "Formula/$f"
     fi


### PR DESCRIPTION
Translates the one remaining Russian comment in `scripts/fix-homebrew-tap.sh` to English. Repo content (code comments included) should be English.

The other two scripts with Russian comments (`format-comment.sh`, `parse-output.sh`) are translated in #169.