### PR TITLE
fix(tmux): printable field separator in session capture (fixes version matrix false negatives)

### DIFF
--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -18,7 +18,7 @@ import (
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
 )
 
-const fieldSep = "\x1f"
+const fieldSep = "|"
 
 // defaultRestoreSettleTimeout bounds how long RestoreSession waits for restored
 // pane commands to actually start before returning. restoreSettlePollInterval
@@ -28,14 +28,22 @@ const (
 	restoreSettlePollInterval   = 100 * time.Millisecond
 )
 
-// splitFields splits a tmux -F output line on the field separator. tmux 3.5a
-// (and likely other versions) escapes control bytes in format output as octal
-// (so the 0x1f separator arrives as the literal four characters `\037`),
-// whereas tmux 3.6+ emits the raw byte. Normalize the escaped form back to the
-// separator so capture works across tmux versions.
-func splitFields(line string) []string {
-	line = strings.ReplaceAll(line, `\037`, fieldSep)
-	return strings.Split(line, fieldSep)
+// splitFieldsN splits a tmux -F output line into at most n fields on the field
+// separator.
+//
+// The separator must be a *printable ASCII* character: tmux sanitizes
+// non-printable bytes in format output, and the exact substitution varies by
+// version and build — the 0x1f we used before arrives raw on some builds,
+// octal-escaped as `\037` on tmux 3.5a, and replaced with `_` on others (e.g.
+// the Linux tmux 3.6 built in CI), which silently collapsed every field into one
+// and dropped all windows. A printable '|' is emitted verbatim everywhere.
+//
+// '|' never occurs in the structured fields (indices, pids, the 0/1 active flag,
+// the window layout, or the tty path). The only free-form fields — the window
+// name and the pane current path — are placed LAST in their format strings so
+// SplitN keeps them intact even if they themselves contain a '|'.
+func splitFieldsN(line string, n int) []string {
+	return strings.SplitN(line, fieldSep, n)
 }
 
 var (
@@ -284,7 +292,8 @@ func (client *Client) CaptureSession(name string) (snapshot.SessionSnapshot, err
 		"-t",
 		sessionTarget(name),
 		"-F",
-		"#{window_index}"+fieldSep+"#{window_name}"+fieldSep+"#{window_layout}"+fieldSep+"#{window_active}",
+		// window_name is free-form, so it goes LAST (SplitN keeps it whole).
+		"#{window_index}"+fieldSep+"#{window_layout}"+fieldSep+"#{window_active}"+fieldSep+"#{window_name}",
 	)
 	if err != nil {
 		return snapshot.SessionSnapshot{}, err
@@ -293,7 +302,7 @@ func (client *Client) CaptureSession(name string) (snapshot.SessionSnapshot, err
 	windows := make([]snapshot.Window, 0)
 
 	for _, line := range splitLines(wOut) {
-		parts := splitFields(line)
+		parts := splitFieldsN(line, 4)
 		if len(parts) != 4 {
 			continue
 		}
@@ -301,38 +310,39 @@ func (client *Client) CaptureSession(name string) (snapshot.SessionSnapshot, err
 		idx, _ := strconv.Atoi(parts[0])
 		window := snapshot.Window{
 			Index:    idx,
-			Name:     parts[1],
-			Layout:   parts[2],
-			IsActive: parts[3] == "1",
+			Layout:   parts[1],
+			IsActive: parts[2] == "1",
+			Name:     parts[3],
 		}
 
+		// pane_current_path is free-form, so it goes LAST.
 		pOut, err := client.Output("list-panes", "-t", sessionWindowTarget(name, idx), "-F",
 			"#{pane_index}"+fieldSep+
-				"#{pane_current_path}"+fieldSep+
-				"#{pane_current_command}"+fieldSep+
 				"#{pane_active}"+fieldSep+
 				"#{pane_pid}"+fieldSep+
-				"#{pane_tty}",
+				"#{pane_tty}"+fieldSep+
+				"#{pane_current_command}"+fieldSep+
+				"#{pane_current_path}",
 		)
 		if err != nil {
 			return snapshot.SessionSnapshot{}, err
 		}
 
 		for _, pLine := range splitLines(pOut) {
-			parts := splitFields(pLine)
+			parts := splitFieldsN(pLine, 6)
 			if len(parts) != 6 {
 				continue
 			}
 
 			pIdx, _ := strconv.Atoi(parts[0])
-			panePID, _ := strconv.Atoi(strings.TrimSpace(parts[4]))
-			restoreCmd, _ := client.foregroundCommand(parts[5], panePID)
+			panePID, _ := strconv.Atoi(strings.TrimSpace(parts[2]))
+			restoreCmd, _ := client.foregroundCommand(parts[3], panePID)
 
 			pane := snapshot.Pane{
 				Index:       pIdx,
-				CurrentPath: parts[1],
-				CurrentCmd:  parts[2],
-				IsActive:    parts[3] == "1",
+				IsActive:    parts[1] == "1",
+				CurrentCmd:  parts[4],
+				CurrentPath: parts[5],
 				RestoreCmd:  strings.TrimSpace(restoreCmd),
 			}
 			if pane.IsActive {

--- a/internal/tmux/client_test.go
+++ b/internal/tmux/client_test.go
@@ -82,6 +82,40 @@ func TestWaitForRestoredCommandsDisabled(t *testing.T) {
 	}
 }
 
+// The field separator must be printable ASCII: tmux sanitizes non-printable
+// bytes in -F output (the previous 0x1f became "_" on some builds, collapsing
+// every field into one and dropping all windows — see the version-matrix bug).
+func TestFieldSepIsPrintableASCII(t *testing.T) {
+	if len(fieldSep) == 0 {
+		t.Fatal("fieldSep must not be empty")
+	}
+
+	for _, r := range fieldSep {
+		if r < 0x20 || r > 0x7e {
+			t.Fatalf("fieldSep must be printable ASCII, got %q", fieldSep)
+		}
+	}
+}
+
+// The free-form fields (window name, pane current path) are placed last in the
+// -F format strings, so splitFieldsN must keep a trailing field intact even when
+// it contains the separator.
+func TestSplitFieldsNKeepsTrailingFieldIntact(t *testing.T) {
+	line := "3" + fieldSep + "bb,80x24" + fieldSep + "1" + fieldSep + "weird" + fieldSep + "name"
+	got := splitFieldsN(line, 4)
+
+	want := []string{"3", "bb,80x24", "1", "weird" + fieldSep + "name"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d fields, got %d: %q", len(want), len(got), got)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("field %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestCurrentWindowPane(t *testing.T) {
 	// Active window's index and active pane are authoritative, even when the
 	// base index is 1 (regression guard: current window must not collapse to 0).


### PR DESCRIPTION
## What

Fixes the tmux version matrix **false negatives** (#173): recent tmux (3.6+) and
old versions (≤3.3a) were reported unsupported even though they work, because
`lazy-tmux save` captured **0 windows** for them.

Fixes #173.

## Root cause (reproduced in the CI container)

`CaptureSession` packed several `tmux -F` fields onto one line using the control
byte **0x1f** as the separator. tmux **sanitizes non-printable bytes** in format
output, and the exact substitution depends on the tmux version *and build*:

| build | 0x1f comes back as |
|-------|--------------------|
| some builds (e.g. macOS 3.6b) | raw `0x1f` |
| tmux 3.5a | octal-escaped `\037` |
| **Linux tmux 3.6 built in CI** | **`_` (underscore)** |

`splitFields` only understood the raw byte and the `\037` form. When the
container's tmux 3.6 emitted `_`, the whole line became a single field, every
window/pane row was dropped (`len(parts) != 4/6 → continue`), and `save` wrote a
snapshot with 0 windows. The round-trip check then failed the version.

Verified by reproducing the CI container with podman:

```
### raw bytes of `list-windows -F "#{window_index}\x1f…"` on container tmux 3.6b
0   _   w   i   n   0   _   a   c   9   d   ,   2   0   0   x   5   0   …
```

A follow-up probe confirmed this build replaces **every** non-printable / non-ASCII
separator (0x1f, tab, U+241F, `│`) with `_`; only printable ASCII survives verbatim.

## Fix

- Switch the separator from `0x1f` to a printable `|`, which tmux emits verbatim
  across versions/builds.
- Move the only free-form fields — `window_name` and `pane_current_path` — to the
  **end** of each `-F` format string and parse with `SplitN`, so they stay intact
  even if they contain a `|`. The remaining fields (indices, pids, the 0/1 active
  flag, the window layout, the tty path, the command name) never contain `|`.
- Drop the now-obsolete `\037` normalization.

## Verification

- `make build`, `make test`, `make golangci-lint` — all green.
- New regression tests: `fieldSep` must be printable ASCII; `splitFieldsN` keeps a
  separator-containing trailing field intact.
- **End-to-end in the CI container (podman):** `2.9`, `3.4` and `3.6b` now all pass
  the save round-trip (3.6b was ✗ before; 3.4 still ✓ — no regression).

## Unblocks

- #174 (publishing the version matrix to the docs Installation page) — the matrix
  is now accurate.
