### PR TITLE
feat(picker): agent-style color-coded action modes (#163)

### DIFF
--- a/docs/src/pages/TuiPicker.tsx
+++ b/docs/src/pages/TuiPicker.tsx
@@ -5,40 +5,72 @@ import { DemoVideo } from "../components/DemoVideo";
 
 const KEYS: { key: ReactNode; action: ReactNode }[] = [
   { key: <InlineCode>Type</InlineCode>, action: "Fuzzy search sessions and windows." },
+  {
+    key: <InlineCode>/</InlineCode>,
+    action: (
+      <>
+        Open the command palette: <InlineCode>/delete</InlineCode>, <InlineCode>/rename</InlineCode>,{" "}
+        <InlineCode>/new</InlineCode>, <InlineCode>/wake</InlineCode>, <InlineCode>/sleep</InlineCode>.{" "}
+        <InlineCode>Tab</InlineCode> completes, <InlineCode>Enter</InlineCode> runs the highlighted
+        command and enters its color-coded mode.
+      </>
+    ),
+  },
   { key: <InlineCode>{"<C-j>"}</InlineCode>, action: "Move down to the next selectable row." },
   { key: <InlineCode>{"<C-k>"}</InlineCode>, action: "Move up to the previous selectable row." },
-  { key: <InlineCode>Enter</InlineCode>, action: "Restore the selected session or window." },
+  {
+    key: <InlineCode>Enter</InlineCode>,
+    action: "Restore the selected target — or, inside a mode, perform that mode's action.",
+  },
+  {
+    key: <InlineCode>Esc</InlineCode>,
+    action: "Cancel the active mode and return to browse; in browse mode, close the picker.",
+  },
   {
     key: (
       <>
-        <InlineCode>Esc</InlineCode>, <InlineCode>{"<C-c>"}</InlineCode>,{" "}
-        <InlineCode>{"<C-q>"}</InlineCode>
+        <InlineCode>{"<C-c>"}</InlineCode>, <InlineCode>{"<C-q>"}</InlineCode>
       </>
     ),
     action: "Cancel and close the picker.",
   },
-  { key: <InlineCode>{"<C-d>"}</InlineCode>, action: "Delete window under cursor." },
+  {
+    key: <InlineCode>Space</InlineCode>,
+    action: (
+      <>
+        In delete mode, mark or unmark the row under the cursor. Marking a session marks all of its
+        windows, so a fully-marked session is deleted as a whole.
+      </>
+    ),
+  },
+  {
+    key: <InlineCode>{"<C-d>"}</InlineCode>,
+    action: "Enter delete mode with the window under the cursor already marked.",
+  },
   {
     key: <InlineCode>{"<Alt-d>"}</InlineCode>,
-    action: 'Delete the session that owns the window under the cursor. Confirm by typing "y".',
+    action: "Enter delete mode with the whole session under the cursor marked.",
   },
-  { key: <InlineCode>{"<C-r>"}</InlineCode>, action: "Rename window under cursor." },
+  {
+    key: <InlineCode>{"<C-r>"}</InlineCode>,
+    action: "Enter rename mode on the window under the cursor.",
+  },
   {
     key: <InlineCode>{"<Alt-r>"}</InlineCode>,
-    action: "Rename the session that owns the window under the cursor.",
+    action: "Enter rename mode on the session that owns the window under the cursor.",
   },
   {
     key: <InlineCode>{"<C-n>"}</InlineCode>,
-    action: "Create new window in session under cursor. Enter window name.",
+    action: "Enter new mode to add a window to the session under the cursor.",
   },
-  { key: <InlineCode>{"<Alt-n>"}</InlineCode>, action: "Create new session. Enter session name." },
+  { key: <InlineCode>{"<Alt-n>"}</InlineCode>, action: "Enter new mode to create a fresh session." },
   {
     key: <InlineCode>{"<Alt-w>"}</InlineCode>,
-    action: "Wakeup: Restore a saved session that is not currently running.",
+    action: "Enter wake mode (sleeping sessions only): restore a saved session that is not running.",
   },
   {
     key: <InlineCode>{"<Alt-s>"}</InlineCode>,
-    action: "Sleep: Save session state and close a running session.",
+    action: "Enter sleep mode (live sessions only): save a running session's state and close it.",
   },
 ];
 
@@ -54,6 +86,14 @@ export function TuiPicker() {
         <h1>TUI picker</h1>
 
         <DemoVideo src="/assets/demo-tui.mp4" />
+
+        <p>
+          Actions are organized into <strong>color-coded modes</strong>. Type <InlineCode>/</InlineCode>{" "}
+          to open the command palette, or use the shortcut for a mode directly. While a mode is
+          active the whole frame recolors (red for delete, blue for rename, green for new, cyan for
+          wake/sleep), the list is filtered to the targets that mode can act on, and{" "}
+          <InlineCode>Esc</InlineCode> returns to the resting browse mode.
+        </p>
 
         <table className="cli-table">
           <thead>

--- a/internal/picker/actions.go
+++ b/internal/picker/actions.go
@@ -4,38 +4,217 @@ package picker
 
 import (
 	"fmt"
+	"sort"
+	"strconv"
 	"strings"
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 )
 
-func (m *pickerModel) deleteCurrentWindow() error {
-	row, ok := m.currentRow()
-	if !ok || row.target.WindowIndex == nil {
-		return fmt.Errorf("select a window row to delete")
+// markState describes how much of a row is marked for deletion: a window is
+// either marked or not; a session is empty, partial or fully marked.
+type markState int
+
+const (
+	markNone markState = iota
+	markPartial
+	markFull
+)
+
+// targetKey identifies a window in the mark set; the NUL byte cannot appear in a
+// session name, so it is an unambiguous separator.
+func targetKey(session string, windowIndex int) string {
+	return session + "\x00" + strconv.Itoa(windowIndex)
+}
+
+func parseTargetKey(key string) (session string, windowIndex int, ok bool) {
+	session, rest, found := strings.Cut(key, "\x00")
+	if !found {
+		return "", 0, false
+	}
+
+	idx, err := strconv.Atoi(rest)
+	if err != nil {
+		return "", 0, false
+	}
+
+	return session, idx, true
+}
+
+func (m *pickerModel) sessionWindowIndices(session string) []int {
+	for index := range m.sessions {
+		if m.sessions[index].Record.SessionName != session {
+			continue
+		}
+
+		idxs := make([]int, 0, len(m.sessions[index].Windows))
+		for _, win := range m.sessions[index].Windows {
+			idxs = append(idxs, win.Index)
+		}
+
+		return idxs
+	}
+
+	return nil
+}
+
+// markWindow marks a single window for deletion.
+func (m *pickerModel) markWindow(target Target) {
+	if target.WindowIndex == nil {
+		return
+	}
+
+	m.marked[targetKey(target.SessionName, *target.WindowIndex)] = struct{}{}
+}
+
+// markSession toggles every window of a session: if all are already marked it
+// clears them, otherwise it marks them all (so a fully-marked session deletes).
+func (m *pickerModel) markSession(session string) {
+	idxs := m.sessionWindowIndices(session)
+	if len(idxs) == 0 {
+		return
+	}
+
+	unmarkAll := true
+
+	for _, idx := range idxs {
+		if _, ok := m.marked[targetKey(session, idx)]; !ok {
+			unmarkAll = false
+			break
+		}
+	}
+
+	for _, idx := range idxs {
+		key := targetKey(session, idx)
+		if unmarkAll {
+			delete(m.marked, key)
+		} else {
+			m.marked[key] = struct{}{}
+		}
+	}
+}
+
+// toggleMark flips the mark for the row under the cursor (window: itself;
+// session header: all of its windows).
+func (m *pickerModel) toggleMark(row pickerRow) {
+	if row.synthetic {
+		return
+	}
+
+	if row.target.WindowIndex == nil {
+		m.markSession(row.target.SessionName)
+		return
+	}
+
+	key := targetKey(row.target.SessionName, *row.target.WindowIndex)
+	if _, ok := m.marked[key]; ok {
+		delete(m.marked, key)
+	} else {
+		m.marked[key] = struct{}{}
+	}
+}
+
+func (m pickerModel) markState(row pickerRow) markState {
+	if row.target.WindowIndex != nil {
+		if _, ok := m.marked[targetKey(row.target.SessionName, *row.target.WindowIndex)]; ok {
+			return markFull
+		}
+
+		return markNone
+	}
+
+	idxs := m.sessionWindowIndices(row.target.SessionName)
+	if len(idxs) == 0 {
+		return markNone
+	}
+
+	marked := 0
+
+	for _, idx := range idxs {
+		if _, ok := m.marked[targetKey(row.target.SessionName, idx)]; ok {
+			marked++
+		}
+	}
+
+	switch {
+	case marked == 0:
+		return markNone
+	case marked == len(idxs):
+		return markFull
+	default:
+		return markPartial
+	}
+}
+
+// commitDelete removes every marked window, collapsing a fully-marked session
+// into a single DeleteSession. Windows are removed high-index-first so earlier
+// indices stay valid, and sessions are processed in a stable order.
+func (m *pickerModel) commitDelete() {
+	if len(m.marked) == 0 {
+		m.exitMode()
+		return
+	}
+
+	bySession := map[string][]int{}
+
+	for key := range m.marked {
+		session, idx, ok := parseTargetKey(key)
+		if !ok {
+			continue
+		}
+
+		bySession[session] = append(bySession[session], idx)
+	}
+
+	sessions := make([]string, 0, len(bySession))
+	for session := range bySession {
+		sessions = append(sessions, session)
+	}
+
+	sort.Strings(sessions)
+
+	var firstErr error
+
+	for _, session := range sessions {
+		err := m.deleteMarkedSession(session, bySession[session])
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	if firstErr != nil {
+		m.setStatus(firstErr.Error())
+	} else {
+		m.clearStatus()
+	}
+
+	m.exitMode()
+	m.reload()
+	m.renderViewport()
+}
+
+func (m *pickerModel) deleteMarkedSession(session string, idxs []int) error {
+	if total := len(m.sessionWindowIndices(session)); total > 0 && len(idxs) >= total {
+		return m.deleteSession(session)
 	}
 
 	if m.actions.DeleteWindow == nil {
 		return fmt.Errorf("delete window not available")
 	}
 
-	return m.actions.DeleteWindow(row.target.SessionName, *row.target.WindowIndex)
-}
+	sort.Sort(sort.Reverse(sort.IntSlice(idxs)))
 
-func (m *pickerModel) confirmDeleteSession() {
-	row, ok := m.currentRow()
-	if !ok {
-		m.setStatus("select a session to delete")
-		return
+	var firstErr error
+
+	for _, idx := range idxs {
+		err := m.actions.DeleteWindow(session, idx)
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
 	}
 
-	m.pending = row.target
-	m.mode = modeConfirmDeleteSession
-	m.promptInput = textinput.New()
-	m.promptInput.Prompt = fmt.Sprintf("Delete session %s? type y: ", row.target.SessionName)
-	m.promptInput.Focus()
-	m.resize()
+	return firstErr
 }
 
 func (m *pickerModel) renameCurrentWindow() {
@@ -99,26 +278,13 @@ func (m *pickerModel) newWindow() {
 func (m pickerModel) handlePromptKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc", "ctrl+c":
-		m.mode = modeBrowse
 		m.promptInput.Blur()
-		m.resize()
+		m.mode = modeBrowse
+		m.exitMode() // cancel the prompt and its action mode, back to browse
 
 		return m, nil
 	case "enter":
 		switch m.mode {
-		case modeConfirmDeleteSession:
-			val := strings.TrimSpace(m.promptInput.Value())
-			if strings.EqualFold(val, "y") {
-				err := m.deleteSession(m.pending.SessionName)
-				if err != nil {
-					m.setStatus(err.Error())
-				} else {
-					m.clearStatus()
-				}
-
-				m.reload()
-				m.renderViewport()
-			}
 		case modeRenameWindow:
 			name := strings.TrimSpace(m.promptInput.Value())
 			if name != "" && m.pending.WindowIndex != nil {
@@ -176,9 +342,9 @@ func (m pickerModel) handlePromptKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.renderViewport()
 		}
 
-		m.mode = modeBrowse
 		m.promptInput.Blur()
-		m.resize()
+		m.mode = modeBrowse
+		m.exitMode() // action completed, return to browse (orange)
 
 		return m, nil
 	}
@@ -306,41 +472,13 @@ func (m *pickerModel) statusHeight() int {
 	return 1
 }
 
-func nearestSelectableRow(rows []pickerRow, from int) int {
-	if len(rows) == 0 {
-		return 0
-	}
-
-	if from < 0 {
-		from = 0
-	}
-
-	if from >= len(rows) {
-		from = len(rows) - 1
-	}
-
-	for i := from; i >= 0; i-- {
-		if rows[i].selectable {
-			return i
-		}
-	}
-
-	for i := from + 1; i < len(rows); i++ {
-		if rows[i].selectable {
-			return i
-		}
-	}
-
-	return 0
-}
-
 func (m *pickerModel) moveNextSelectable() {
 	if len(m.visible) == 0 {
 		return
 	}
 
 	for i := m.cursor + 1; i < len(m.visible); i++ {
-		if m.visible[i].selectable {
+		if m.rowSelectable(m.visible[i]) {
 			m.cursor = i
 			return
 		}
@@ -353,7 +491,7 @@ func (m *pickerModel) movePrevSelectable() {
 	}
 
 	for i := m.cursor - 1; i >= 0; i-- {
-		if m.visible[i].selectable {
+		if m.rowSelectable(m.visible[i]) {
 			m.cursor = i
 			return
 		}

--- a/internal/picker/commands.go
+++ b/internal/picker/commands.go
@@ -1,0 +1,105 @@
+//go:build !lazy_fzf
+
+package picker
+
+import "strings"
+
+// actionMode is the picker's colored modal flow: a resting browse mode plus one
+// dedicated mode per in-place action. It is orthogonal to the text-prompt
+// pickerMode (rename/new still pop a themed prompt once a target is picked).
+type actionMode int
+
+const (
+	actionBrowse actionMode = iota
+	actionDelete
+	actionRename
+	actionNew
+	actionWake
+	actionSleep
+)
+
+// hint is one footer key/label pair, e.g. {"↵", "remove"}.
+type hint struct{ key, label string }
+
+// pickerCommand binds a typed slash-command to its mode, accent color, palette
+// description and mode-specific footer hints.
+type pickerCommand struct {
+	name   string
+	mode   actionMode
+	accent string
+	label  string // short uppercase mode label shown in title/footer
+	desc   string // palette description
+	hints  []hint // mode-specific footer hints (esc is appended by helpHints)
+}
+
+// pickerCommands is the ordered command palette. Wake/sleep share the cyan
+// accent; delete is the only multi-select mode (space marks targets).
+var pickerCommands = []pickerCommand{
+	{
+		name:   "delete",
+		mode:   actionDelete,
+		accent: colDelete,
+		label:  "DELETE",
+		desc:   "mark windows/sessions, remove them",
+		hints:  []hint{{"space", "mark"}, {"↵", "remove"}},
+	},
+	{
+		name:   "rename",
+		mode:   actionRename,
+		accent: colRename,
+		label:  "RENAME",
+		desc:   "rename a session or window",
+		hints:  []hint{{"↵", "rename"}},
+	},
+	{
+		name:   "new",
+		mode:   actionNew,
+		accent: colNew,
+		label:  "NEW",
+		desc:   "create a session or a window",
+		hints:  []hint{{"↵", "create"}},
+	},
+	{
+		name:   "wake",
+		mode:   actionWake,
+		accent: colSleepWake,
+		label:  "WAKE",
+		desc:   "wake a sleeping session",
+		hints:  []hint{{"↵", "wake"}},
+	},
+	{
+		name:   "sleep",
+		mode:   actionSleep,
+		accent: colSleepWake,
+		label:  "SLEEP",
+		desc:   "sleep a live session",
+		hints:  []hint{{"↵", "sleep"}},
+	},
+}
+
+// matchCommands returns the commands whose name starts with prefix (the text
+// after the leading "/"). An empty prefix returns the whole palette.
+func matchCommands(prefix string) []pickerCommand {
+	prefix = strings.ToLower(strings.TrimSpace(prefix))
+
+	out := make([]pickerCommand, 0, len(pickerCommands))
+	for _, cmd := range pickerCommands {
+		if strings.HasPrefix(cmd.name, prefix) {
+			out = append(out, cmd)
+		}
+	}
+
+	return out
+}
+
+// commandForMode returns the command backing an active action mode (and false
+// for browse, which has no command).
+func commandForMode(mode actionMode) (pickerCommand, bool) {
+	for _, cmd := range pickerCommands {
+		if cmd.mode == mode {
+			return cmd, true
+		}
+	}
+
+	return pickerCommand{}, false
+}

--- a/internal/picker/commands_test.go
+++ b/internal/picker/commands_test.go
@@ -1,0 +1,51 @@
+//go:build !lazy_fzf
+
+package picker
+
+import "testing"
+
+func TestMatchCommands(t *testing.T) {
+	if got := matchCommands(""); len(got) != len(pickerCommands) {
+		t.Fatalf("empty prefix should match every command, got %d", len(got))
+	}
+
+	got := matchCommands("de")
+	if len(got) != 1 || got[0].name != "delete" {
+		t.Fatalf("prefix 'de' should match only delete, got %+v", got)
+	}
+
+	if got := matchCommands("zzz"); len(got) != 0 {
+		t.Fatalf("unknown prefix should match nothing, got %+v", got)
+	}
+
+	// Leading slash is stripped by the caller, but a stray space must not break
+	// matching.
+	if got := matchCommands(" wake "); len(got) != 1 || got[0].mode != actionWake {
+		t.Fatalf("padded 'wake' should match wake, got %+v", got)
+	}
+}
+
+func TestCommandForMode(t *testing.T) {
+	cmd, ok := commandForMode(actionRename)
+	if !ok || cmd.name != "rename" || cmd.accent != colRename {
+		t.Fatalf("rename mode should resolve to the rename command, got %+v ok=%v", cmd, ok)
+	}
+
+	if _, ok := commandForMode(actionBrowse); ok {
+		t.Fatal("browse has no backing command")
+	}
+}
+
+func TestAccentForMode(t *testing.T) {
+	if accentForMode(actionBrowse) != colAccent {
+		t.Fatal("browse should use the amber accent")
+	}
+
+	if accentForMode(actionDelete) != colDelete {
+		t.Fatal("delete should use the red accent")
+	}
+
+	if accentForMode(actionWake) != accentForMode(actionSleep) {
+		t.Fatal("wake and sleep share the cyan accent")
+	}
+}

--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -500,8 +500,12 @@ func (m *pickerModel) focusSynthetic() {
 }
 
 // exitMode returns to the resting browse (orange) mode, dropping the action,
-// palette and marks and restoring the full list.
+// palette and marks and restoring the full list. It keeps the cursor on the row
+// that was acted on (so Esc lands you back where you were) when that row still
+// exists.
 func (m *pickerModel) exitMode() {
+	prev, hadRow := m.currentRow()
+
 	m.action = actionBrowse
 	m.palette = false
 	m.paletteIdx = 0
@@ -511,6 +515,16 @@ func (m *pickerModel) exitMode() {
 	m.cursor = 0
 	m.resize()
 	m.applyFilter()
+
+	if hadRow && !prev.synthetic {
+		if prev.target.WindowIndex != nil {
+			m.focusWindow(prev.target)
+		} else {
+			m.focusSession(prev.target.SessionName)
+			m.cursor = m.nearestSelectable(m.cursor)
+		}
+	}
+
 	m.ensureCursorVisible()
 	m.renderViewport()
 }

--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -19,7 +19,8 @@ type pickerRow struct {
 	state      string
 	cmd        string
 	windowName string
-	selectable bool
+	selectable bool // inherent browse-mode selectability (window rows)
+	synthetic  bool // the "＋ new session" row injected in new mode
 }
 
 type pickerModel struct {
@@ -37,15 +38,20 @@ type pickerModel struct {
 	actions     Actions
 	statusMsg   string
 	mode        pickerMode
+	action      actionMode
+	marked      map[string]struct{} // delete multi-select, keyed by targetKey
+	palette     bool                // slash-command entry is open
+	paletteIdx  int                 // highlighted command in the palette
 	promptInput textinput.Model
 	pending     Target
 }
 
+// pickerMode is the text-prompt overlay (rename/new). It is orthogonal to the
+// colored actionMode: a mode stays active while its prompt collects input.
 type pickerMode int
 
 const (
 	modeBrowse pickerMode = iota
-	modeConfirmDeleteSession
 	modeRenameWindow
 	modeRenameSession
 	modeNewSession
@@ -55,7 +61,7 @@ const (
 const scrollMargin = 2
 
 func newPickerModel(sessions []Session, windowSort []WindowSortKey, actions Actions) pickerModel {
-	theme := newPickerTheme()
+	theme := newPickerTheme(colAccent)
 
 	input := textinput.New()
 	input.Placeholder = ""
@@ -78,6 +84,8 @@ func newPickerModel(sessions []Session, windowSort []WindowSortKey, actions Acti
 		cursor:     0,
 		actions:    actions,
 		mode:       modeBrowse,
+		action:     actionBrowse,
+		marked:     make(map[string]struct{}),
 	}
 	model.applyFilter()
 
@@ -98,7 +106,7 @@ func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		return m, nil
 	case tea.MouseWheelMsg:
-		if m.mode != modeBrowse {
+		if m.mode != modeBrowse || m.palette {
 			return m, nil
 		}
 
@@ -114,7 +122,7 @@ func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		return m, nil
 	case tea.MouseClickMsg:
-		if m.mode != modeBrowse || msg.Button != tea.MouseLeft {
+		if m.mode != modeBrowse || m.palette || msg.Button != tea.MouseLeft {
 			return m, nil
 		}
 
@@ -123,22 +131,21 @@ func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		if idx == m.cursor {
-			m.selected = m.visible[idx].target
-			return m, tea.Quit
-		}
-
-		m.cursor = idx
-		m.ensureCursorVisible()
-		m.renderViewport()
-
-		return m, nil
+		return m.handleRowClick(idx)
 	case tea.KeyPressMsg:
 		if m.mode != modeBrowse {
 			return m.handlePromptKey(msg)
 		}
 
-		if next, cmd, handled := m.handleBrowseKey(msg); handled {
+		if m.palette {
+			if next, cmd, handled := m.handlePaletteKey(msg); handled {
+				return next, cmd
+			}
+		} else if m.action != actionBrowse {
+			if next, cmd, handled := m.handleActionKey(msg); handled {
+				return next, cmd
+			}
+		} else if next, cmd, handled := m.handleBrowseKey(msg); handled {
 			return next, cmd
 		}
 	}
@@ -149,6 +156,7 @@ func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	m.queryInput, cmd = m.queryInput.Update(msg)
 	if prevQuery != m.queryInput.Value() {
+		m.syncPalette()
 		m.applyFilter()
 		m.ensureCursorVisible()
 		m.renderViewport()
@@ -165,13 +173,13 @@ func (m pickerModel) View() tea.View {
 
 	var buf strings.Builder
 
-	// Top border: title + session/window counts.
+	// Top border: title (with the active mode) + session/window counts.
 	sessions, windows := m.counts()
 	right := m.theme.count.Render(fmt.Sprintf("%d sessions · %d windows", sessions, windows))
-	buf.WriteString(m.theme.frameTop("lazy-tmux", right, width))
+	buf.WriteString(m.theme.frameTop(m.titleText(), right, width))
 	buf.WriteString("\n")
 
-	// Search input (or the active action prompt).
+	// Search input (or the active text prompt for rename/new).
 	input := m.queryInput.View()
 	if m.mode != modeBrowse {
 		input = m.promptInput.View()
@@ -180,26 +188,10 @@ func (m pickerModel) View() tea.View {
 	buf.WriteString(m.theme.frameLine(input, width))
 	buf.WriteString("\n")
 
-	// Column header, aligned with the row name column (2 leading cells).
-	layout := buildPickerTableLayout(m.tableContentWidth())
-	buf.WriteString(m.theme.frameLine("  "+layout.styledHeader(m.theme), width))
-	buf.WriteString("\n")
-
-	if m.statusMsg != "" {
-		buf.WriteString(m.theme.frameLine(m.theme.statusErr.Render(m.statusMsg), width))
-		buf.WriteString("\n")
-	}
-
-	if len(m.visible) == 0 {
-		buf.WriteString(
-			m.theme.frameLine(m.theme.faint.Render("No sessions or windows match query"), width),
-		)
-		buf.WriteString("\n")
+	if m.palette {
+		m.writePalette(&buf, width)
 	} else {
-		for line := range strings.SplitSeq(m.viewport.View(), "\n") {
-			buf.WriteString(m.theme.frameLine(line, width))
-			buf.WriteString("\n")
-		}
+		m.writeTable(&buf, width)
 	}
 
 	// Bottom border: key hints.
@@ -212,6 +204,119 @@ func (m pickerModel) View() tea.View {
 	return view
 }
 
+// titleText is "lazy-tmux" while browsing, or "lazy-tmux · DELETE" in a mode.
+func (m pickerModel) titleText() string {
+	if cmd, ok := commandForMode(m.action); ok {
+		return "lazy-tmux · " + cmd.label
+	}
+
+	return "lazy-tmux"
+}
+
+// writeTable renders the column header, optional status line and the row
+// viewport (or an empty-state message) into buf.
+func (m pickerModel) writeTable(buf *strings.Builder, width int) {
+	layout := buildPickerTableLayout(m.tableContentWidth())
+	lead := "  " + strings.Repeat(" ", m.markerWidth())
+	buf.WriteString(m.theme.frameLine(lead+layout.styledHeader(m.theme), width))
+	buf.WriteString("\n")
+
+	if m.statusMsg != "" {
+		buf.WriteString(m.theme.frameLine(m.theme.statusErr.Render(m.statusMsg), width))
+		buf.WriteString("\n")
+	}
+
+	if len(m.visible) == 0 {
+		buf.WriteString(
+			m.theme.frameLine(m.theme.faint.Render("No sessions or windows match query"), width),
+		)
+		buf.WriteString("\n")
+
+		return
+	}
+
+	for line := range strings.SplitSeq(m.viewport.View(), "\n") {
+		buf.WriteString(m.theme.frameLine(line, width))
+		buf.WriteString("\n")
+	}
+}
+
+// writePalette renders the slash-command dropdown into buf, highlighting the
+// selected command with the browse-accent stripe.
+func (m pickerModel) writePalette(buf *strings.Builder, width int) {
+	matches := matchCommands(m.commandPrefix())
+	if len(matches) == 0 {
+		buf.WriteString(m.theme.frameLine(m.theme.faint.Render("no matching command"), width))
+		buf.WriteString("\n")
+
+		return
+	}
+
+	for i, cmd := range matches {
+		name := m.theme.title.Render("/" + cmd.name)
+		line := name + "  " + m.theme.meta.Render(cmd.desc)
+
+		if i == m.paletteIdx {
+			line = m.theme.stripe.Render("▌") + " " + line
+		} else {
+			line = "  " + line
+		}
+
+		buf.WriteString(m.theme.frameLine(line, width))
+		buf.WriteString("\n")
+	}
+}
+
+// handleRowClick performs the click action for a row, per the active mode:
+// browse selects (and quits when re-clicking the cursor row), delete toggles
+// the mark, and the single-target modes act on the clicked row.
+func (m pickerModel) handleRowClick(idx int) (tea.Model, tea.Cmd) {
+	if m.action == actionBrowse {
+		if idx == m.cursor {
+			m.selected = m.visible[idx].target
+			return m, tea.Quit
+		}
+
+		m.cursor = idx
+		m.ensureCursorVisible()
+		m.renderViewport()
+
+		return m, nil
+	}
+
+	m.cursor = idx
+
+	if m.action == actionDelete {
+		m.toggleMark(m.visible[idx])
+		m.ensureCursorVisible()
+		m.renderViewport()
+
+		return m, nil
+	}
+
+	return m.commitAction()
+}
+
+// syncPalette opens or closes the slash-command palette based on the current
+// query: a leading "/" (while browsing) enters command entry; anything else
+// leaves it. paletteIdx is clamped to the available matches.
+func (m *pickerModel) syncPalette() {
+	m.palette = m.action == actionBrowse && strings.HasPrefix(m.queryInput.Value(), "/")
+	if !m.palette {
+		m.paletteIdx = 0
+		return
+	}
+
+	if matches := matchCommands(m.commandPrefix()); m.paletteIdx >= len(matches) {
+		m.paletteIdx = max(0, len(matches)-1)
+	}
+}
+
+// commandPrefix is the typed command name (the query text after the "/").
+func (m pickerModel) commandPrefix() string {
+	return strings.TrimPrefix(m.queryInput.Value(), "/")
+}
+
 func (m pickerModel) counts() (sessions, windows int) {
 	for i := range m.sessions {
 		windows += len(m.sessions[i].Windows)
@@ -221,18 +326,33 @@ func (m pickerModel) counts() (sessions, windows int) {
 }
 
 func (m pickerModel) helpHints() string {
-	pairs := []struct{ key, label string }{
-		{"↵", "select"},
-		{"^j/^k", "move"},
-		{"^d", "del"},
-		{"^r", "rename"},
-		{"^n", "new"},
-		{"esc", "quit"},
+	var pairs []hint
+
+	switch {
+	case m.palette:
+		pairs = []hint{{"↵", "run"}, {"tab", "complete"}, {"^j/^k", "move"}, {"esc", "cancel"}}
+	case m.action != actionBrowse:
+		cmd, _ := commandForMode(m.action)
+		pairs = append([]hint{{cmd.label, ""}}, cmd.hints...)
+		pairs = append(pairs, hint{"^j/^k", "move"}, hint{"esc", "cancel"})
+	default:
+		pairs = []hint{
+			{"↵", "select"}, {"^j/^k", "move"}, {"/", "commands"}, {"esc", "quit"},
+		}
 	}
 
 	parts := make([]string, 0, len(pairs))
-	for _, p := range pairs {
-		parts = append(parts, m.theme.helpKey.Render(p.key)+" "+m.theme.helpText.Render(p.label))
+
+	for _, pair := range pairs {
+		if pair.label == "" {
+			parts = append(parts, m.theme.helpKey.Render(pair.key))
+			continue
+		}
+
+		parts = append(
+			parts,
+			m.theme.helpKey.Render(pair.key)+" "+m.theme.helpText.Render(pair.label),
+		)
 	}
 
 	return strings.Join(parts, m.theme.helpText.Render("  ·  "))
@@ -246,29 +366,10 @@ func (m pickerModel) handleBrowseKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, b
 	case "ctrl+c", "ctrl+q", "esc":
 		m.cancelled = true
 		return m, tea.Quit, true
-	case "ctrl+d":
-		m.applyActionResult(m.deleteCurrentWindow())
-		return m, nil, true
-	case "alt+d":
-		m.confirmDeleteSession()
-		return m, nil, true
-	case "ctrl+r":
-		m.renameCurrentWindow()
-		return m, nil, true
-	case "alt+r":
-		m.renameCurrentSession()
-		return m, nil, true
-	case "alt+n":
-		m.newSession()
-		return m, nil, true
-	case "ctrl+n":
-		m.newWindow()
-		return m, nil, true
-	case "alt+w":
-		m.applyActionResult(m.wakeupSession())
-		return m, nil, true
-	case "alt+s":
-		m.applyActionResult(m.sleepSession())
+	case "ctrl+d", "alt+d", "ctrl+r", "alt+r", "ctrl+n", "alt+n", "alt+w", "alt+s":
+		m.enterModeShortcut(msg.String())
+		m.renderViewport()
+
 		return m, nil, true
 	case "ctrl+k":
 		m.movePrevSelectable()
@@ -305,6 +406,253 @@ func (m *pickerModel) applyActionResult(err error) {
 	m.renderViewport()
 }
 
+// enterMode switches into a colored action mode: it rebuilds the theme around
+// the mode accent, clears any query/marks, and re-filters the list to the
+// mode's valid targets.
+func (m *pickerModel) enterMode(mode actionMode) {
+	m.action = mode
+	m.palette = false
+	m.paletteIdx = 0
+	m.marked = make(map[string]struct{})
+	m.queryInput.SetValue("")
+	m.theme = newPickerTheme(accentForMode(mode))
+	m.resize()
+	m.applyFilter() // clamps the carried-over cursor to a mode-selectable row
+	m.ensureCursorVisible()
+}
+
+// enterModeShortcut maps a legacy chord to its mode, positioning the cursor on
+// the relevant row (and pre-marking it in delete mode) so muscle memory keeps
+// working: ^d/^r target the current window, alt+d/alt+r the current session,
+// ^n adds a window to it, alt+n starts a fresh session, alt+w/alt+s the session.
+func (m *pickerModel) enterModeShortcut(key string) {
+	cur, _ := m.currentRow()
+
+	switch key {
+	case "ctrl+d":
+		m.enterMode(actionDelete)
+		m.focusWindow(cur.target)
+		m.markWindow(cur.target)
+	case "alt+d":
+		m.enterMode(actionDelete)
+		m.focusSession(cur.target.SessionName)
+		m.markSession(cur.target.SessionName)
+	case "ctrl+r":
+		m.enterMode(actionRename)
+		m.focusWindow(cur.target)
+	case "alt+r":
+		m.enterMode(actionRename)
+		m.focusSession(cur.target.SessionName)
+	case "ctrl+n":
+		m.enterMode(actionNew)
+		m.focusSession(cur.target.SessionName)
+	case "alt+n":
+		m.enterMode(actionNew)
+		m.focusSynthetic()
+	case "alt+w":
+		m.enterMode(actionWake)
+		m.focusSession(cur.target.SessionName)
+	case "alt+s":
+		m.enterMode(actionSleep)
+		m.focusSession(cur.target.SessionName)
+	}
+}
+
+// focusWindow moves the cursor onto a specific window row, if visible.
+func (m *pickerModel) focusWindow(target Target) {
+	if target.WindowIndex == nil {
+		return
+	}
+
+	for i, row := range m.visible {
+		if row.target.SessionName == target.SessionName && row.target.WindowIndex != nil &&
+			*row.target.WindowIndex == *target.WindowIndex {
+			m.cursor = i
+			m.ensureCursorVisible()
+
+			return
+		}
+	}
+}
+
+// focusSession moves the cursor onto a session header row, if visible.
+func (m *pickerModel) focusSession(name string) {
+	for i, row := range m.visible {
+		if !row.synthetic && row.target.WindowIndex == nil && row.target.SessionName == name {
+			m.cursor = i
+			m.ensureCursorVisible()
+
+			return
+		}
+	}
+}
+
+// focusSynthetic moves the cursor onto the synthetic "＋ new session" row.
+func (m *pickerModel) focusSynthetic() {
+	for i, row := range m.visible {
+		if row.synthetic {
+			m.cursor = i
+			m.ensureCursorVisible()
+
+			return
+		}
+	}
+}
+
+// exitMode returns to the resting browse (orange) mode, dropping the action,
+// palette and marks and restoring the full list.
+func (m *pickerModel) exitMode() {
+	m.action = actionBrowse
+	m.palette = false
+	m.paletteIdx = 0
+	m.marked = make(map[string]struct{})
+	m.queryInput.SetValue("")
+	m.theme = newPickerTheme(colAccent)
+	m.cursor = 0
+	m.resize()
+	m.applyFilter()
+	m.ensureCursorVisible()
+	m.renderViewport()
+}
+
+// handlePaletteKey drives the slash-command dropdown. Printable keys fall
+// through (handled=false) so the typed command name keeps editing the query.
+func (m pickerModel) handlePaletteKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, bool) {
+	matches := matchCommands(m.commandPrefix())
+
+	switch msg.String() {
+	case "esc", "ctrl+c":
+		m.exitMode()
+		return m, nil, true
+	case "ctrl+k":
+		if m.paletteIdx > 0 {
+			m.paletteIdx--
+		}
+
+		return m, nil, true
+	case "ctrl+j":
+		if m.paletteIdx < len(matches)-1 {
+			m.paletteIdx++
+		}
+
+		return m, nil, true
+	case "tab":
+		if len(matches) > 0 {
+			m.queryInput.SetValue("/" + matches[m.paletteIdx].name)
+			m.queryInput.CursorEnd()
+			m.syncPalette()
+		}
+
+		return m, nil, true
+	case "enter":
+		if len(matches) > 0 {
+			m.enterMode(matches[m.paletteIdx].mode)
+			m.renderViewport()
+		}
+
+		return m, nil, true
+	}
+
+	return m, nil, false
+}
+
+// handleActionKey drives an active action mode. Unhandled printable keys fall
+// through so typing still filters the mode's list.
+func (m pickerModel) handleActionKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, bool) {
+	switch msg.String() {
+	case "ctrl+c", "ctrl+q":
+		m.cancelled = true
+		return m, tea.Quit, true
+	case "esc":
+		m.exitMode()
+		return m, nil, true
+	case "ctrl+k":
+		m.movePrevSelectable()
+		m.ensureCursorVisible()
+		m.renderViewport()
+
+		return m, nil, true
+	case "ctrl+j":
+		m.moveNextSelectable()
+		m.ensureCursorVisible()
+		m.renderViewport()
+
+		return m, nil, true
+	case "space":
+		if m.action != actionDelete {
+			return m, nil, false
+		}
+
+		if row, ok := m.currentRow(); ok {
+			m.toggleMark(row)
+			m.renderViewport()
+		}
+
+		return m, nil, true
+	case "enter":
+		next, cmd := m.commitAction()
+		return next, cmd, true
+	}
+
+	return m, nil, false
+}
+
+// commitAction performs the active mode's action on the current row: delete
+// removes all marked targets; rename/new open a themed prompt; wake/sleep act
+// immediately and drop back to browse.
+func (m pickerModel) commitAction() (tea.Model, tea.Cmd) {
+	switch m.action {
+	case actionDelete:
+		m.commitDelete()
+	case actionRename:
+		m.beginRename()
+	case actionNew:
+		m.beginNew()
+	case actionWake:
+		err := m.wakeupSession()
+		m.exitMode()
+		m.applyActionResult(err)
+	case actionSleep:
+		err := m.sleepSession()
+		m.exitMode()
+		m.applyActionResult(err)
+	}
+
+	return m, nil
+}
+
+// beginRename opens the rename prompt for the picked row (window or session),
+// keeping the rename accent until the prompt resolves.
+func (m *pickerModel) beginRename() {
+	row, ok := m.currentRow()
+	if !ok {
+		m.exitMode()
+		return
+	}
+
+	if row.target.WindowIndex != nil {
+		m.renameCurrentWindow()
+	} else {
+		m.renameCurrentSession()
+	}
+}
+
+// beginNew opens the new-session prompt for the synthetic row, or the
+// new-window prompt for a picked session.
+func (m *pickerModel) beginNew() {
+	row, ok := m.currentRow()
+	if !ok {
+		m.exitMode()
+		return
+	}
+
+	if row.synthetic {
+		m.newSession()
+	} else {
+		m.newWindow()
+	}
+}
+
 func (m *pickerModel) resize() {
 	if m.width <= 0 || m.height <= 0 {
 		return
@@ -318,9 +666,14 @@ func (m *pickerModel) resize() {
 }
 
 func (m *pickerModel) applyFilter() {
-	query := strings.TrimSpace(strings.ToLower(m.queryInput.Value()))
+	query := ""
+	if !m.palette {
+		query = strings.TrimSpace(strings.ToLower(m.queryInput.Value()))
+	}
 
-	m.visible = filteredTreeRows(m.sessions, query, m.windowSort)
+	rows := filteredTreeRows(m.modeSessions(), query, m.windowSort)
+	m.visible = m.decorateRows(rows)
+
 	if len(m.visible) == 0 {
 		m.cursor = 0
 		m.viewport.SetContent("")
@@ -328,9 +681,32 @@ func (m *pickerModel) applyFilter() {
 		return
 	}
 
-	if m.cursor < 0 || m.cursor >= len(m.visible) || !m.visible[m.cursor].selectable {
-		m.cursor = nearestSelectableRow(m.visible, m.cursor)
+	if m.cursor < 0 || m.cursor >= len(m.visible) || !m.rowSelectable(m.visible[m.cursor]) {
+		m.cursor = m.nearestSelectable(m.cursor)
 	}
+}
+
+// nearestSelectable finds the closest mode-selectable row at or around `from`.
+func (m pickerModel) nearestSelectable(from int) int {
+	if len(m.visible) == 0 {
+		return 0
+	}
+
+	from = min(max(from, 0), len(m.visible)-1)
+
+	for i := from; i >= 0; i-- {
+		if m.rowSelectable(m.visible[i]) {
+			return i
+		}
+	}
+
+	for i := from + 1; i < len(m.visible); i++ {
+		if m.rowSelectable(m.visible[i]) {
+			return i
+		}
+	}
+
+	return 0
 }
 
 func (m *pickerModel) renderViewport() {
@@ -344,8 +720,10 @@ func (m *pickerModel) renderViewport() {
 	lines := make([]string, 0, len(m.visible))
 
 	for rowIndex, row := range m.visible {
-		if rowIndex == m.cursor && row.selectable {
-			body := layout.row(row)
+		marker := m.markerFor(row)
+
+		if rowIndex == m.cursor && m.rowSelectable(row) {
+			body := marker + layout.row(row)
 
 			if pad := barWidth - displayWidth(body); pad > 0 {
 				body += strings.Repeat(" ", pad)
@@ -356,10 +734,44 @@ func (m *pickerModel) renderViewport() {
 			continue
 		}
 
-		lines = append(lines, "  "+layout.styledRow(row, m.theme))
+		lines = append(lines, "  "+marker+layout.styledRow(row, m.theme))
 	}
 
 	m.viewport.SetContent(strings.Join(lines, "\n"))
+}
+
+// markerFor returns the leading multi-select indicator for a row: empty outside
+// delete mode, otherwise a filled/partial/empty circle (plus a trailing space)
+// reflecting how much of the row is marked. The width is constant (markerWidth)
+// so columns stay aligned across rows.
+func (m pickerModel) markerFor(row pickerRow) string {
+	if m.action != actionDelete || row.synthetic {
+		if m.markerWidth() > 0 {
+			return strings.Repeat(" ", m.markerWidth())
+		}
+
+		return ""
+	}
+
+	glyph := "○"
+
+	switch m.markState(row) {
+	case markFull:
+		glyph = "●"
+	case markPartial:
+		glyph = "◐"
+	}
+
+	return m.theme.mark.Render(glyph) + " "
+}
+
+// markerWidth is the fixed width reserved for the delete-mode mark column.
+func (m pickerModel) markerWidth() int {
+	if m.action == actionDelete {
+		return 2 // glyph + space
+	}
+
+	return 0
 }
 
 // contentWidth is the usable width inside the frame's side borders and gutter
@@ -374,9 +786,10 @@ func (m *pickerModel) contentWidth() int {
 }
 
 // tableContentWidth is the width available to the column table, after the 2
-// leading cells reserved for the selection stripe / row indent.
+// leading cells reserved for the selection stripe / row indent and the
+// (delete-mode) mark column.
 func (m *pickerModel) tableContentWidth() int {
-	return max(1, m.contentWidth()-2)
+	return max(1, m.contentWidth()-2-m.markerWidth())
 }
 
 // rowAtY maps a mouse Y coordinate to a selectable row index. The list starts
@@ -389,7 +802,7 @@ func (m *pickerModel) rowAtY(mouseY int) (int, bool) {
 	}
 
 	idx := m.viewport.YOffset() + (mouseY - rowStart)
-	if idx < 0 || idx >= len(m.visible) || !m.visible[idx].selectable {
+	if idx < 0 || idx >= len(m.visible) || !m.rowSelectable(m.visible[idx]) {
 		return 0, false
 	}
 

--- a/internal/picker/model_test.go
+++ b/internal/picker/model_test.go
@@ -173,11 +173,18 @@ func TestModelDeleteWindow(t *testing.T) {
 	rec := &recordingActions{}
 	m := newTestModel(t, rec, makeSession("alpha", false, "one", "two"))
 
-	// cursor on alpha:1
-	feed(t, m, keyCtrl('d'))
+	// ^d enters delete mode and pre-marks the current window (one of two, so a
+	// window — not the whole session — is removed); ↵ commits.
+	m = feed(t, m, keyCtrl('d'))
+	if m.action != actionDelete {
+		t.Fatalf("ctrl+d should enter delete mode, got %d", m.action)
+	}
+
+	feed(t, m, keyCode(tea.KeyEnter))
+
 	if rec.deletedWindowS != "alpha" || rec.deletedWindow[0] != 1 {
 		t.Fatalf(
-			"ctrl+d should delete current window, got %q idx=%d",
+			"ctrl+d ↵ should delete current window, got %q idx=%d",
 			rec.deletedWindowS,
 			rec.deletedWindow[0],
 		)
@@ -186,9 +193,11 @@ func TestModelDeleteWindow(t *testing.T) {
 
 func TestModelDeleteWindowErrorSetsStatus(t *testing.T) {
 	rec := &recordingActions{failDelete: true}
-	m := newTestModel(t, rec, makeSession("alpha", false, "one"))
+	m := newTestModel(t, rec, makeSession("alpha", false, "one", "two"))
 
 	m = feed(t, m, keyCtrl('d'))
+	m = feed(t, m, keyCode(tea.KeyEnter))
+
 	if m.statusMsg == "" {
 		t.Fatal("a failing delete should set a status message")
 	}
@@ -198,20 +207,52 @@ func TestModelDeleteSessionFlow(t *testing.T) {
 	rec := &recordingActions{}
 	m := newTestModel(t, rec, makeSession("alpha", false, "one"))
 
-	m = feed(t, m, keyAlt('d')) // confirm-delete-session mode
-	if m.mode != modeConfirmDeleteSession {
-		t.Fatalf("alt+d should enter confirm mode, got %d", m.mode)
+	m = feed(t, m, keyAlt('d')) // delete mode, whole session pre-marked
+	if m.action != actionDelete {
+		t.Fatalf("alt+d should enter delete mode, got %d", m.action)
 	}
 
-	m = feed(t, m, keyRune('y')) // type confirmation into prompt
 	m = feed(t, m, keyCode(tea.KeyEnter))
 
 	if rec.deletedSession != "alpha" {
 		t.Fatalf("expected session alpha deleted, got %q", rec.deletedSession)
 	}
 
-	if m.mode != modeBrowse {
-		t.Fatalf("should return to browse mode, got %d", m.mode)
+	if m.action != actionBrowse || m.mode != modeBrowse {
+		t.Fatalf("should return to browse, got action=%d mode=%d", m.action, m.mode)
+	}
+}
+
+func TestModelDeleteMultiSelect(t *testing.T) {
+	rec := &recordingActions{}
+	m := newTestModel(t, rec, makeSession("alpha", false, "one", "two", "three"))
+
+	// /delete via the palette starts with nothing marked.
+	m = feed(t, m, keyRune('/'))
+	for _, r := range "delete" {
+		m = feed(t, m, keyRune(r))
+	}
+
+	m = feed(t, m, keyCode(tea.KeyEnter)) // enter delete mode
+	if m.action != actionDelete {
+		t.Fatalf("/delete should enter delete mode, got %d", m.action)
+	}
+
+	// Mark the first two window rows (rows: [hdr, w1, w2, w3]).
+	m.cursor = 1
+	m = feed(t, m, keyRune(' '))
+	m.cursor = 2
+	m = feed(t, m, keyRune(' '))
+
+	feed(t, m, keyCode(tea.KeyEnter))
+
+	// Two of three windows marked -> per-window deletes, not a session delete.
+	if rec.deletedSession != "" {
+		t.Fatalf("partial selection must not delete the session, got %q", rec.deletedSession)
+	}
+
+	if rec.deletedWindowS != "alpha" {
+		t.Fatalf("expected window deletes in alpha, got %q", rec.deletedWindowS)
 	}
 }
 
@@ -219,9 +260,14 @@ func TestModelRenameWindowFlow(t *testing.T) {
 	rec := &recordingActions{}
 	m := newTestModel(t, rec, makeSession("alpha", false, "one"))
 
-	m = feed(t, m, keyCtrl('r')) // rename window, prompt preset to "one"
+	m = feed(t, m, keyCtrl('r')) // rename mode, cursor on the window
+	if m.action != actionRename {
+		t.Fatalf("ctrl+r should enter rename mode, got %d", m.action)
+	}
+
+	m = feed(t, m, keyCode(tea.KeyEnter)) // open the prompt (preset to "one")
 	if m.mode != modeRenameWindow {
-		t.Fatalf("ctrl+r should enter rename-window mode, got %d", m.mode)
+		t.Fatalf("↵ should open the rename-window prompt, got %d", m.mode)
 	}
 
 	m = feed(t, m, keyRune('X'))
@@ -236,7 +282,8 @@ func TestModelRenameSessionFlow(t *testing.T) {
 	rec := &recordingActions{}
 	m := newTestModel(t, rec, makeSession("alpha", false, "one"))
 
-	m = feed(t, m, keyAlt('r'))
+	m = feed(t, m, keyAlt('r')) // rename mode, cursor on the session header
+	m = feed(t, m, keyCode(tea.KeyEnter))
 	m = feed(t, m, keyRune('Z'))
 	feed(t, m, keyCode(tea.KeyEnter))
 
@@ -249,9 +296,14 @@ func TestModelNewSessionFlow(t *testing.T) {
 	rec := &recordingActions{}
 	m := newTestModel(t, rec, makeSession("alpha", false, "one"))
 
-	m = feed(t, m, keyAlt('n'))
+	m = feed(t, m, keyAlt('n')) // new mode, cursor on synthetic "+ new session"
+	if m.action != actionNew {
+		t.Fatalf("alt+n should enter new mode, got %d", m.action)
+	}
+
+	m = feed(t, m, keyCode(tea.KeyEnter)) // open new-session prompt
 	if m.mode != modeNewSession {
-		t.Fatalf("alt+n should enter new-session mode, got %d", m.mode)
+		t.Fatalf("↵ on the synthetic row should open new-session, got %d", m.mode)
 	}
 
 	m = feed(t, m, keyRune('q'))
@@ -267,9 +319,14 @@ func TestModelNewWindowFlow(t *testing.T) {
 	rec := &recordingActions{}
 	m := newTestModel(t, rec, makeSession("alpha", false, "one"))
 
-	m = feed(t, m, keyCtrl('n'))
+	m = feed(t, m, keyCtrl('n')) // new mode, cursor on the alpha session header
+	if m.action != actionNew {
+		t.Fatalf("ctrl+n should enter new mode, got %d", m.action)
+	}
+
+	m = feed(t, m, keyCode(tea.KeyEnter)) // open new-window prompt
 	if m.mode != modeNewWindow {
-		t.Fatalf("ctrl+n should enter new-window mode, got %d", m.mode)
+		t.Fatalf("↵ on a session row should open new-window, got %d", m.mode)
 	}
 
 	feed(t, m, keyCode(tea.KeyEnter)) // empty name allowed (auto-named)
@@ -279,18 +336,97 @@ func TestModelNewWindowFlow(t *testing.T) {
 	}
 }
 
-func TestModelWakeupAndSleep(t *testing.T) {
+func TestModelWakeFiltersToSleeping(t *testing.T) {
+	rec := &recordingActions{}
+	m := newTestModel(t, rec,
+		makeSession("sleepy", false, "one"), // not live -> wakeable
+		makeSession("live", true, "two"),    // live -> not wakeable
+	)
+
+	m = feed(t, m, keyAlt('w')) // wake mode
+
+	for _, row := range m.visible {
+		if row.target.SessionName == "live" {
+			t.Fatal("wake mode must hide live sessions")
+		}
+	}
+
+	m = feed(t, m, keyCode(tea.KeyEnter))
+	if rec.wokeUp != "sleepy" {
+		t.Fatalf("↵ in wake mode should wake the sleeping session, got %q", rec.wokeUp)
+	}
+
+	if m.action != actionBrowse {
+		t.Fatalf("acting should return to browse, got %d", m.action)
+	}
+}
+
+func TestModelSleepFiltersToLive(t *testing.T) {
+	rec := &recordingActions{}
+	m := newTestModel(t, rec,
+		makeSession("sleepy", false, "one"),
+		makeSession("live", true, "two"),
+	)
+
+	m = feed(t, m, keyAlt('s')) // sleep mode
+
+	for _, row := range m.visible {
+		if row.target.SessionName == "sleepy" {
+			t.Fatal("sleep mode must hide sleeping sessions")
+		}
+	}
+
+	feed(t, m, keyCode(tea.KeyEnter))
+	if rec.slept != "live" {
+		t.Fatalf("↵ in sleep mode should sleep the live session, got %q", rec.slept)
+	}
+}
+
+func TestModelEscExitsActionMode(t *testing.T) {
 	rec := &recordingActions{}
 	m := newTestModel(t, rec, makeSession("alpha", false, "one"))
 
-	m = feed(t, m, keyAlt('w'))
-	if rec.wokeUp != "alpha" {
-		t.Fatalf("alt+w should wake alpha, got %q", rec.wokeUp)
+	m = feed(t, m, keyAlt('d')) // delete mode
+	if m.action != actionDelete {
+		t.Fatalf("alt+d should enter delete mode, got %d", m.action)
 	}
 
-	feed(t, m, keyAlt('s'))
-	if rec.slept != "alpha" {
-		t.Fatalf("alt+s should sleep alpha, got %q", rec.slept)
+	m = feed(t, m, keyCode(tea.KeyEscape))
+
+	if m.action != actionBrowse {
+		t.Fatalf("esc should drop back to browse, got %d", m.action)
+	}
+
+	if m.cancelled {
+		t.Fatal("esc in a mode must cancel the mode, not the picker")
+	}
+
+	if rec.deletedSession != "" || rec.deletedWindowS != "" {
+		t.Fatal("esc must not perform the action")
+	}
+}
+
+func TestModelPaletteOpensOnSlash(t *testing.T) {
+	rec := &recordingActions{}
+	m := newTestModel(t, rec, makeSession("alpha", false, "one"))
+
+	m = feed(t, m, keyRune('/'))
+	if !m.palette {
+		t.Fatal("typing / should open the command palette")
+	}
+
+	// Refine to "/del" and confirm: only delete matches, so ↵ enters delete.
+	for _, r := range "del" {
+		m = feed(t, m, keyRune(r))
+	}
+
+	m = feed(t, m, keyCode(tea.KeyEnter))
+	if m.action != actionDelete {
+		t.Fatalf("/del ↵ should enter delete mode, got %d", m.action)
+	}
+
+	if m.palette {
+		t.Fatal("palette should close once a command runs")
 	}
 }
 

--- a/internal/picker/model_test.go
+++ b/internal/picker/model_test.go
@@ -258,18 +258,21 @@ func TestModelDeleteMultiSelect(t *testing.T) {
 		t.Fatalf("partial selection must not delete the session, got %q", rec.deletedSession)
 	}
 
-	deleted := map[int]bool{}
-	for _, call := range rec.deletedWindowCalls {
-		if call.session != "alpha" {
-			t.Fatalf("expected window deletes in alpha, got %q", call.session)
-		}
-
-		deleted[call.index] = true
+	// Both marked windows must be deleted high-index-first so earlier indices
+	// stay valid (commitDelete deletes in descending order).
+	want := []deletedWindowCall{
+		{session: "alpha", index: 2},
+		{session: "alpha", index: 1},
 	}
 
-	// Both marked windows (1 and 2) must be deleted, and only those.
-	if len(rec.deletedWindowCalls) != 2 || !deleted[1] || !deleted[2] {
-		t.Fatalf("expected windows 1 and 2 deleted, got %+v", rec.deletedWindowCalls)
+	if len(rec.deletedWindowCalls) != len(want) {
+		t.Fatalf("expected %d delete calls, got %+v", len(want), rec.deletedWindowCalls)
+	}
+
+	for i, call := range rec.deletedWindowCalls {
+		if call != want[i] {
+			t.Fatalf("expected delete calls %+v, got %+v", want, rec.deletedWindowCalls)
+		}
 	}
 }
 

--- a/internal/picker/model_test.go
+++ b/internal/picker/model_test.go
@@ -59,17 +59,23 @@ func makeSession(name string, restored bool, windowNames ...string) Session {
 // struct is the picker's real dependency boundary; production wires these to
 // the app (which talks to real tmux). Driving them here exercises the model's
 // dispatch logic without a terminal.
+type deletedWindowCall struct {
+	session string
+	index   int
+}
+
 type recordingActions struct {
-	deletedWindow  [2]int
-	deletedWindowS string
-	deletedSession string
-	renamedWindow  string
-	renamedSession string
-	newSession     string
-	newWindow      [2]string
-	wokeUp         string
-	slept          string
-	failDelete     bool
+	deletedWindow      [2]int
+	deletedWindowS     string
+	deletedWindowCalls []deletedWindowCall
+	deletedSession     string
+	renamedWindow      string
+	renamedSession     string
+	newSession         string
+	newWindow          [2]string
+	wokeUp             string
+	slept              string
+	failDelete         bool
 }
 
 func (r *recordingActions) toActions(sessions []Session) Actions {
@@ -81,6 +87,7 @@ func (r *recordingActions) toActions(sessions []Session) Actions {
 
 			r.deletedWindowS = s
 			r.deletedWindow = [2]int{idx, idx}
+			r.deletedWindowCalls = append(r.deletedWindowCalls, deletedWindowCall{s, idx})
 
 			return nil
 		},
@@ -251,8 +258,18 @@ func TestModelDeleteMultiSelect(t *testing.T) {
 		t.Fatalf("partial selection must not delete the session, got %q", rec.deletedSession)
 	}
 
-	if rec.deletedWindowS != "alpha" {
-		t.Fatalf("expected window deletes in alpha, got %q", rec.deletedWindowS)
+	deleted := map[int]bool{}
+	for _, call := range rec.deletedWindowCalls {
+		if call.session != "alpha" {
+			t.Fatalf("expected window deletes in alpha, got %q", call.session)
+		}
+
+		deleted[call.index] = true
+	}
+
+	// Both marked windows (1 and 2) must be deleted, and only those.
+	if len(rec.deletedWindowCalls) != 2 || !deleted[1] || !deleted[2] {
+		t.Fatalf("expected windows 1 and 2 deleted, got %+v", rec.deletedWindowCalls)
 	}
 }
 
@@ -333,6 +350,38 @@ func TestModelNewWindowFlow(t *testing.T) {
 
 	if rec.newWindow[0] != "alpha" {
 		t.Fatalf("expected new window in alpha, got %q", rec.newWindow[0])
+	}
+}
+
+func TestModelNewFilteringBindsToSession(t *testing.T) {
+	rec := &recordingActions{}
+	m := newTestModel(t, rec, makeSession("alpha", false, "one"), makeSession("beta", false, "two"))
+
+	m = feed(t, m, keyAlt('n')) // new mode, cursor on synthetic row
+
+	// Filter to "beta": the synthetic "+ new session" row must drop out so the
+	// only target is the matched session, and Enter creates a window in it.
+	m = feed(t, m, keyRune('b'))
+
+	for _, row := range m.visible {
+		if row.synthetic {
+			t.Fatal("synthetic new-session row must be hidden while filtering")
+		}
+	}
+
+	m = feed(t, m, keyCode(tea.KeyEnter)) // open new-window prompt
+	if m.mode != modeNewWindow {
+		t.Fatalf("filtered ↵ should bind to new-window, got %d", m.mode)
+	}
+
+	feed(t, m, keyCode(tea.KeyEnter))
+
+	if rec.newWindow[0] != "beta" {
+		t.Fatalf("expected new window in beta, got %q", rec.newWindow[0])
+	}
+
+	if rec.newSession != "" {
+		t.Fatalf("filtering must not trigger new-session, got %q", rec.newSession)
 	}
 }
 

--- a/internal/picker/rows.go
+++ b/internal/picker/rows.go
@@ -64,6 +64,77 @@ func filteredTreeRows(sessions []Session, query string, windowSort []WindowSortK
 	return rows
 }
 
+// modeSessions narrows the session list to those valid for the active mode:
+// wake shows only sleeping (not live) sessions, sleep only live ones; the other
+// modes see every session.
+func (m pickerModel) modeSessions() []Session {
+	switch m.action {
+	case actionWake:
+		return filterSessions(m.sessions, func(s Session) bool { return !s.Restored })
+	case actionSleep:
+		return filterSessions(m.sessions, func(s Session) bool { return s.Restored })
+	default:
+		return m.sessions
+	}
+}
+
+func filterSessions(sessions []Session, keep func(Session) bool) []Session {
+	out := make([]Session, 0, len(sessions))
+
+	for _, s := range sessions {
+		if keep(s) {
+			out = append(out, s)
+		}
+	}
+
+	return out
+}
+
+// decorateRows adapts the base session/window tree to the active mode: new,
+// wake and sleep act on whole sessions, so window rows are dropped; new also
+// prepends a synthetic "＋ new session" row. Delete, rename and browse keep the
+// full tree.
+func (m pickerModel) decorateRows(rows []pickerRow) []pickerRow {
+	switch m.action {
+	case actionNew:
+		out := make([]pickerRow, 0, len(rows)+1)
+		out = append(out, pickerRow{item: "＋ new session", synthetic: true})
+
+		return append(out, sessionRowsOnly(rows)...)
+	case actionWake, actionSleep:
+		return sessionRowsOnly(rows)
+	default:
+		return rows
+	}
+}
+
+func sessionRowsOnly(rows []pickerRow) []pickerRow {
+	out := make([]pickerRow, 0, len(rows))
+
+	for _, r := range rows {
+		if r.target.WindowIndex == nil {
+			out = append(out, r)
+		}
+	}
+
+	return out
+}
+
+// rowSelectable reports whether a row can be acted on in the active mode. Browse
+// keeps the inherent window-only selectability; delete and rename also let you
+// target session headers; new/wake/sleep target sessions (and the synthetic
+// new-session row).
+func (m pickerModel) rowSelectable(row pickerRow) bool {
+	switch m.action {
+	case actionDelete, actionRename:
+		return true // sessions and windows are both valid targets
+	case actionNew, actionWake, actionSleep:
+		return row.synthetic || row.target.WindowIndex == nil
+	default:
+		return row.selectable
+	}
+}
+
 // relativeTime renders a capture time as a compact, scannable age such as
 // "just now", "3m ago", "2h ago", "5d ago" or "4mo ago".
 func relativeTime(then, now time.Time) string {

--- a/internal/picker/rows.go
+++ b/internal/picker/rows.go
@@ -97,10 +97,18 @@ func filterSessions(sessions []Session, keep func(Session) bool) []Session {
 func (m pickerModel) decorateRows(rows []pickerRow) []pickerRow {
 	switch m.action {
 	case actionNew:
-		out := make([]pickerRow, 0, len(rows)+1)
+		sessionRows := sessionRowsOnly(rows)
+
+		// While the user is filtering, drop the synthetic row so Enter binds to
+		// the matched session (new window) rather than "new session".
+		if strings.TrimSpace(m.queryInput.Value()) != "" {
+			return sessionRows
+		}
+
+		out := make([]pickerRow, 0, len(sessionRows)+1)
 		out = append(out, pickerRow{item: "＋ new session", synthetic: true})
 
-		return append(out, sessionRowsOnly(rows)...)
+		return append(out, sessionRows...)
 	case actionWake, actionSleep:
 		return sessionRowsOnly(rows)
 	default:

--- a/internal/picker/theme.go
+++ b/internal/picker/theme.go
@@ -10,9 +10,10 @@ import (
 
 // The picker palette is aligned with the "moss-dark" terminal theme: a muted,
 // desaturated set of pastels on near-black. Amber is the browse-mode accent
-// (title, cursor, selected stripe, key hints); red is reserved for errors. This
-// keeps the picker feeling native in the terminal and in tune with the
-// monochrome lazy-tmux brand. (Per-mode accents are tracked in #163.)
+// (title, cursor, selected stripe, key hints); each action mode (#163) swaps in
+// its own accent so the whole frame visibly recolors. Red is reserved for
+// errors (and reused as the delete-mode accent). This keeps the picker feeling
+// native in the terminal and in tune with the monochrome lazy-tmux brand.
 const (
 	colAccent  = "#d7875f" // amber/orange (moss-dark "yellow") — browse-mode accent
 	colText    = "#d0d0d0" // primary text (session / window names)
@@ -23,6 +24,12 @@ const (
 	colSelText = "#f0f0f0" // selected-row text
 	colError   = "#d75f5f" // error status
 	colCount   = "#9e9e9e" // header counts
+
+	// Per-mode accents (#163), drawn from the moss-dark palette.
+	colDelete    = "#d75f5f" // red — delete mode
+	colRename    = "#5f87af" // blue — rename mode
+	colNew       = "#87af87" // green — new mode
+	colSleepWake = "#8787af" // cyan — wake / sleep modes
 )
 
 type pickerTheme struct {
@@ -37,28 +44,49 @@ type pickerTheme struct {
 	faint      lipgloss.Style
 	stripe     lipgloss.Style
 	selBar     lipgloss.Style
+	mark       lipgloss.Style
 	statusErr  lipgloss.Style
 	helpKey    lipgloss.Style
 	helpText   lipgloss.Style
 }
 
-func newPickerTheme() pickerTheme {
+// accentForMode maps an action mode to its frame accent: amber while browsing,
+// the command's color once a mode is active.
+func accentForMode(mode actionMode) string {
+	if cmd, ok := commandForMode(mode); ok {
+		return cmd.accent
+	}
+
+	return colAccent
+}
+
+// newPickerTheme builds the palette around accent. Browse passes the amber
+// colAccent; each action mode passes its own color so the border, title,
+// prompt, selection stripe, mark and key hints all recolor together. The frame
+// border stays neutral grey while browsing and takes the accent in a mode.
+func newPickerTheme(accent string) pickerTheme {
+	border := colBorder
+	if accent != colAccent {
+		border = accent
+	}
+
 	return pickerTheme{
-		border:     lipgloss.NewStyle().Foreground(lipgloss.Color(colBorder)),
-		title:      lipgloss.NewStyle().Foreground(lipgloss.Color(colAccent)).Bold(true),
+		border:     lipgloss.NewStyle().Foreground(lipgloss.Color(border)),
+		title:      lipgloss.NewStyle().Foreground(lipgloss.Color(accent)).Bold(true),
 		count:      lipgloss.NewStyle().Foreground(lipgloss.Color(colCount)),
-		prompt:     lipgloss.NewStyle().Foreground(lipgloss.Color(colAccent)),
+		prompt:     lipgloss.NewStyle().Foreground(lipgloss.Color(accent)),
 		headerCell: lipgloss.NewStyle().Foreground(lipgloss.Color(colFaint)),
 		name:       lipgloss.NewStyle().Foreground(lipgloss.Color(colText)),
 		session:    lipgloss.NewStyle().Foreground(lipgloss.Color(colText)).Bold(true),
 		meta:       lipgloss.NewStyle().Foreground(lipgloss.Color(colMeta)),
 		faint:      lipgloss.NewStyle().Foreground(lipgloss.Color(colFaint)),
-		stripe:     lipgloss.NewStyle().Foreground(lipgloss.Color(colAccent)),
+		stripe:     lipgloss.NewStyle().Foreground(lipgloss.Color(accent)),
 		selBar: lipgloss.NewStyle().
 			Background(lipgloss.Color(colSelBg)).
 			Foreground(lipgloss.Color(colSelText)),
+		mark:      lipgloss.NewStyle().Foreground(lipgloss.Color(accent)),
 		statusErr: lipgloss.NewStyle().Foreground(lipgloss.Color(colError)),
-		helpKey:   lipgloss.NewStyle().Foreground(lipgloss.Color(colAccent)),
+		helpKey:   lipgloss.NewStyle().Foreground(lipgloss.Color(accent)),
 		helpText:  lipgloss.NewStyle().Foreground(lipgloss.Color(colFaint)),
 	}
 }

--- a/internal/picker/view_test.go
+++ b/internal/picker/view_test.go
@@ -1,0 +1,38 @@
+//go:build !lazy_fzf
+
+package picker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestViewFrameWidthInvariant(t *testing.T) {
+	rec := &recordingActions{}
+	m := newTestModel(t, rec,
+		makeSession("alpha", false, "edit", "shell", "logs"),
+		makeSession("beta", true, "api"),
+	)
+
+	check := func(label string, mdl pickerModel) {
+		lines := strings.Split(strings.TrimRight(mdl.View().Content, "\n"), "\n")
+		want := ansi.StringWidth(lines[0])
+		for i, ln := range lines {
+			if got := ansi.StringWidth(ln); got != want {
+				t.Fatalf("%s line %d width %d != %d:\n%q", label, i, got, want, ln)
+			}
+		}
+		t.Logf("%s ok, %d lines @ %d cols", label, len(lines), want)
+	}
+
+	check("browse", m)
+	check("delete", feed(t, m, keyAlt('d')))
+	check("rename", feed(t, m, keyCtrl('r')))
+	check("new", feed(t, m, keyAlt('n')))
+	check("wake", feed(t, m, keyAlt('w')))
+
+	pal := feed(t, m, keyRune('/'))
+	check("palette", pal)
+}


### PR DESCRIPTION
## Summary

Closes #163. Turns the picker's hidden modifier chords into an **agent-style modal flow**. Typing `/` opens a command palette (`/delete`, `/rename`, `/new`, `/wake`, `/sleep`); confirming a command enters a dedicated, color-coded **mode**: the whole frame recolors, the list is filtered to that mode's valid targets, and acting returns to the resting orange browse mode.

Builds on the themed, framed picker from #162 — the palette is now parametrized by accent (`newPickerTheme(accent)`) and rebuilt per mode.

## Modes

| Command   | Accent      | List filtered to            | On select / confirm                       |
|-----------|-------------|-----------------------------|-------------------------------------------|
| `/delete` | red         | sessions + windows          | `Space` marks; `Enter` removes all marked |
| `/rename` | blue        | sessions + windows          | opens the themed rename prompt            |
| `/new`    | green       | sessions + "＋ new session"  | session → new window; ＋ → new session     |
| `/wake`   | cyan        | sleeping sessions only      | wakes immediately                         |
| `/sleep`  | cyan        | live sessions only          | sleeps immediately                        |

**Delete is multi-select**: `Space` marks the window under the cursor; marking a session marks all of its windows (`●` full / `◐` partial / `○` none), so a fully-marked session is removed via `DeleteSession` while partial selections delete per window.

The legacy chords still work and now *jump into the matching mode*, positioning the cursor (and pre-marking, for delete) so muscle memory is preserved: `^d`/`alt+d` (window/session delete), `^r`/`alt+r` (rename), `^n`/`alt+n` (new window/session), `alt+w`/`alt+s` (wake/sleep). `Esc` cancels a mode back to browse without acting.

## Rendering

```
╭─ lazy-tmux · DELETE ──────────────────────── 2 sessions · 5 windows ─╮
│ ❯                                                                    │
│     Session / Window         Cmd          Captured   Wins  State     │
│ ▌ ● work                                   5mo ago    3     ✓        │
│   ●   ├─ [1] edit            zsh                                      │
│   ○ api                                    5mo ago    2              │
╰─ DELETE  ·  space mark  ·  ↵ remove  ·  ^j/^k move  ·  esc cancel ───╯
```

A fixed-width mark column keeps the frame width constant across modes (guarded by a new `TestViewFrameWidthInvariant`).

## Tests / verification

- New unit tests: command matching, palette open → run, enter/exit modes, delete multi-select (partial vs full session), wake/sleep filtering, esc cancels a mode, frame-width invariant across all modes.
- `make build build-fzf` (fzf engine unaffected — modes are `!lazy_fzf`), `make test` (146 passing), `make golangci-lint` (0 issues), `make docs-build` all green.
- Docs `tui-picker` page updated to describe the palette and modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command palette (open with `/`) with mode-specific actions, refined keybinding text, and clearer on-screen guidance.
  * Introduced color-coded action modes (delete/rename/new/wake/sleep) with prompt-based interactions.
  * Enabled marking-based delete with multi-select, including both session-wide and per-window deletion behaviors.

* **Bug Fixes**
  * Improved wake/sleep filtering so actions target the correct sessions.
  * Standardized `Esc` to reliably return to browse mode without triggering pending deletes.

* **Tests / Documentation**
  * Expanded picker tests for palette/commands, delete flows, and view rendering consistency.
  * Updated the TUI picker keybind/action table and mode explanations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->