### PR TITLE
feat(integration): extensible program-integration framework + Claude resume (#147)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/alchemmist/lazy-tmux/internal/config"
+	"github.com/alchemmist/lazy-tmux/internal/integration"
+	"github.com/alchemmist/lazy-tmux/internal/integration/claude"
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
 	"github.com/alchemmist/lazy-tmux/internal/store"
 	"github.com/alchemmist/lazy-tmux/internal/tmux"
@@ -48,10 +50,11 @@ type tmuxClient interface {
 }
 
 type App struct {
-	cfg       config.Config
-	store     *store.Store
-	tmux      tmuxClient
-	saveAllFn func() error
+	cfg          config.Config
+	store        *store.Store
+	tmux         tmuxClient
+	integrations *integration.Registry
+	saveAllFn    func() error
 }
 
 func New(cfg config.Config) *App {
@@ -61,11 +64,31 @@ func New(cfg config.Config) *App {
 	client.SetRestoreTimeout(cfg.RestoreTimeout)
 	client.SetRestoreAllowlist(cfg.RestoreAllowlist)
 
+	registry := buildRegistry(cfg.Integrations)
+	client.SetRestoreResolver(registry)
+
 	return &App{
-		cfg:   cfg,
-		store: store.New(cfg.DataDir),
-		tmux:  client,
+		cfg:          cfg,
+		store:        store.New(cfg.DataDir),
+		tmux:         client,
+		integrations: registry,
 	}
+}
+
+// buildRegistry assembles the enabled program integrations from config. With the
+// master switch off it returns an empty (inert) registry.
+func buildRegistry(cfg config.IntegrationsConfig) *integration.Registry {
+	if !cfg.Enabled {
+		return integration.NewRegistry()
+	}
+
+	var items []integration.Integration
+
+	if cfg.Claude.Enabled {
+		items = append(items, claude.New(config.ExpandHome(cfg.Claude.Home)))
+	}
+
+	return integration.NewRegistry(items...)
 }
 
 // SaveAll snapshots every running tmux session and returns how many were saved
@@ -95,6 +118,10 @@ func (a *App) SaveSession(session string) error {
 	if a.cfg.Scrollback.Enabled {
 		a.captureShellScrollback(&snap)
 	}
+
+	// Enrich panes with program-integration metadata (e.g. the Claude session
+	// id) so restore can replay a smarter command. Inert when disabled.
+	a.integrations.Enrich(&snap)
 
 	err = a.store.SaveSession(snap)
 	if err != nil {

--- a/internal/app/integration_test.go
+++ b/internal/app/integration_test.go
@@ -1,0 +1,48 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/alchemmist/lazy-tmux/internal/config"
+	"github.com/alchemmist/lazy-tmux/internal/snapshot"
+)
+
+func claudePane() snapshot.Pane {
+	return snapshot.Pane{
+		CurrentCmd: "claude",
+		Meta:       map[string]string{"claude.session_id": "sess-9"},
+	}
+}
+
+func TestBuildRegistryEnabledResolvesClaude(t *testing.T) {
+	reg := buildRegistry(config.IntegrationsConfig{
+		Enabled: true,
+		Claude:  config.ClaudeIntegrationConfig{Enabled: true, Home: "~/.claude"},
+	})
+
+	if got := reg.Resolve(claudePane()); got != "claude --resume sess-9" {
+		t.Fatalf("enabled claude should resolve resume command, got %q", got)
+	}
+}
+
+func TestBuildRegistryMasterSwitchOff(t *testing.T) {
+	reg := buildRegistry(config.IntegrationsConfig{
+		Enabled: false,
+		Claude:  config.ClaudeIntegrationConfig{Enabled: true, Home: "~/.claude"},
+	})
+
+	if got := reg.Resolve(claudePane()); got != "" {
+		t.Fatalf("master switch off should disable all integrations, got %q", got)
+	}
+}
+
+func TestBuildRegistryClaudeDisabled(t *testing.T) {
+	reg := buildRegistry(config.IntegrationsConfig{
+		Enabled: true,
+		Claude:  config.ClaudeIntegrationConfig{Enabled: false},
+	})
+
+	if got := reg.Resolve(claudePane()); got != "" {
+		t.Fatalf("disabled claude should not resolve, got %q", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	SaveInterval   time.Duration
 	RestoreTimeout time.Duration
 	Scrollback     ScrollbackConfig
+	Integrations   IntegrationsConfig
 
 	// RestoreAllowlist limits which commands are replayed on restore, matched by
 	// executable name. A nil slice means no allowlist is configured and every
@@ -33,6 +34,22 @@ type ScrollbackConfig struct {
 	Lines   int
 }
 
+// IntegrationsConfig controls the program-integration framework: a master switch
+// plus per-integration settings.
+type IntegrationsConfig struct {
+	Enabled bool
+	Claude  ClaudeIntegrationConfig
+}
+
+// ClaudeIntegrationConfig configures the Claude Code integration (restore a
+// `claude` pane as `claude --resume <session-id>`).
+type ClaudeIntegrationConfig struct {
+	Enabled bool
+	// Home is the Claude Code data directory; transcripts live under
+	// <Home>/projects/<cwd>/<session-id>.jsonl.
+	Home string
+}
+
 func Default() Config {
 	return Config{
 		TmuxBin:        "tmux",
@@ -42,6 +59,13 @@ func Default() Config {
 		Scrollback: ScrollbackConfig{
 			Enabled: false,
 			Lines:   5000,
+		},
+		Integrations: IntegrationsConfig{
+			Enabled: true,
+			Claude: ClaudeIntegrationConfig{
+				Enabled: true,
+				Home:    "~/.claude",
+			},
 		},
 	}
 }
@@ -113,17 +137,28 @@ func LoadFrom(path string) (Config, error) {
 // leaves the corresponding default untouched, rather than overwriting it with a
 // zero value.
 type fileConfig struct {
-	TmuxBin          *string             `toml:"tmux_bin"`
-	DataDir          *string             `toml:"data_dir"`
-	SaveInterval     *duration           `toml:"save_interval"`
-	RestoreTimeout   *duration           `toml:"restore_timeout"`
-	RestoreAllowlist *[]string           `toml:"restore_allowlist"`
-	Scrollback       *fileScrollbackConf `toml:"scrollback"`
+	TmuxBin          *string               `toml:"tmux_bin"`
+	DataDir          *string               `toml:"data_dir"`
+	SaveInterval     *duration             `toml:"save_interval"`
+	RestoreTimeout   *duration             `toml:"restore_timeout"`
+	RestoreAllowlist *[]string             `toml:"restore_allowlist"`
+	Scrollback       *fileScrollbackConf   `toml:"scrollback"`
+	Integrations     *fileIntegrationsConf `toml:"integrations"`
 }
 
 type fileScrollbackConf struct {
 	Enabled *bool `toml:"enabled"`
 	Lines   *int  `toml:"lines"`
+}
+
+type fileIntegrationsConf struct {
+	Enabled *bool                  `toml:"enabled"`
+	Claude  *fileClaudeIntegration `toml:"claude"`
+}
+
+type fileClaudeIntegration struct {
+	Enabled *bool   `toml:"enabled"`
+	Home    *string `toml:"home"`
 }
 
 // withFile returns a copy of cfg with every value set in file applied on top.
@@ -167,7 +202,29 @@ func (cfg Config) withFile(file fileConfig) Config {
 		}
 	}
 
+	if file.Integrations != nil {
+		cfg.Integrations = cfg.Integrations.withFile(*file.Integrations)
+	}
+
 	return cfg
+}
+
+func (ic IntegrationsConfig) withFile(file fileIntegrationsConf) IntegrationsConfig {
+	if file.Enabled != nil {
+		ic.Enabled = *file.Enabled
+	}
+
+	if file.Claude != nil {
+		if file.Claude.Enabled != nil {
+			ic.Claude.Enabled = *file.Claude.Enabled
+		}
+
+		if file.Claude.Home != nil {
+			ic.Claude.Home = ExpandHome(*file.Claude.Home)
+		}
+	}
+
+	return ic
 }
 
 // duration lets the TOML decoder accept Go duration strings like "5m" or "10s".

--- a/internal/config/default.toml
+++ b/internal/config/default.toml
@@ -34,3 +34,21 @@ restore_timeout = "5s"
 enabled = false
 # Maximum scrollback lines captured per pane.
 lines = 5000
+
+# Program integrations adapt interactive programs to lazy-tmux's save/restore.
+# When a pane runs a supported program, lazy-tmux records program-specific state
+# on save and replays a smarter command on restore. Integrations compose with
+# restore_allowlist: if an allowlist is set, the program must be in it (e.g.
+# "claude") for its command to be replayed.
+[integrations]
+# Master switch for all program integrations.
+enabled = true
+
+# Claude Code: restore a `claude` pane as `claude --resume <session-id>` so the
+# conversation continues instead of starting fresh.
+[integrations.claude]
+enabled = true
+# Claude Code data directory. Transcripts are read from
+# <home>/projects/<cwd>/<session-id>.jsonl to resolve the pane's session. A
+# leading ~ is expanded.
+home = "~/.claude"

--- a/internal/config/gen.go
+++ b/internal/config/gen.go
@@ -82,5 +82,11 @@ func (c Config) Render() string {
 	fmt.Fprintf(&buf, "enabled = %t\n", c.Scrollback.Enabled)
 	fmt.Fprintf(&buf, "lines   = %d\n", c.Scrollback.Lines)
 
+	buf.WriteString("\n[integrations]\n")
+	fmt.Fprintf(&buf, "enabled = %t\n", c.Integrations.Enabled)
+	buf.WriteString("\n[integrations.claude]\n")
+	fmt.Fprintf(&buf, "enabled = %t\n", c.Integrations.Claude.Enabled)
+	fmt.Fprintf(&buf, "home    = %s\n", strconv.Quote(c.Integrations.Claude.Home))
+
 	return buf.String()
 }

--- a/internal/config/integrations_test.go
+++ b/internal/config/integrations_test.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIntegrationsDefaults(t *testing.T) {
+	cfg := Default()
+
+	if !cfg.Integrations.Enabled || !cfg.Integrations.Claude.Enabled {
+		t.Fatal("integrations should default to enabled")
+	}
+
+	if cfg.Integrations.Claude.Home != "~/.claude" {
+		t.Fatalf("unexpected default claude home: %q", cfg.Integrations.Claude.Home)
+	}
+}
+
+func TestIntegrationsOverrideAndExpand(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home dir: %v", err)
+	}
+
+	path := writeConfig(t, `
+[integrations]
+enabled = true
+
+[integrations.claude]
+enabled = false
+home = "~/custom-claude"
+`)
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if cfg.Integrations.Claude.Enabled {
+		t.Fatal("claude.enabled should be overridden to false")
+	}
+
+	want := filepath.Join(home, "custom-claude")
+	if cfg.Integrations.Claude.Home != want {
+		t.Fatalf("home should expand ~, got %q want %q", cfg.Integrations.Claude.Home, want)
+	}
+}
+
+func TestIntegrationsPartialKeepsDefaults(t *testing.T) {
+	// Only the master switch is set; claude sub-keys keep their defaults.
+	path := writeConfig(t, "[integrations]\nenabled = false\n")
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if cfg.Integrations.Enabled {
+		t.Fatal("master switch should be false")
+	}
+
+	if !cfg.Integrations.Claude.Enabled || cfg.Integrations.Claude.Home != "~/.claude" {
+		t.Fatal("omitted claude keys should keep defaults")
+	}
+}
+
+func TestRenderIncludesIntegrations(t *testing.T) {
+	out := Default().Render()
+
+	for _, want := range []string{"[integrations]", "[integrations.claude]", "home    = \"~/.claude\""} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("rendered config missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/integration/claude/claude.go
+++ b/internal/integration/claude/claude.go
@@ -1,0 +1,134 @@
+// Package claude integrates Claude Code with lazy-tmux: it captures the resumable
+// session id of a running `claude` pane at save time and restores it as
+// `claude --resume <id>` so the conversation continues where it left off.
+package claude
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/alchemmist/lazy-tmux/internal/snapshot"
+)
+
+const (
+	// metaSessionID is the (un-namespaced) metadata key for the resolved session.
+	metaSessionID = "session_id"
+	transcriptExt = ".jsonl"
+)
+
+// Integration resolves and replays Claude Code sessions. home is the Claude data
+// directory (default ~/.claude); transcripts live under <home>/projects/<cwd>/.
+type Integration struct {
+	home string
+}
+
+// New builds the integration rooted at the given Claude data directory.
+func New(home string) *Integration {
+	return &Integration{home: home}
+}
+
+func (i *Integration) Name() string { return "claude" }
+
+// Matches reports whether the pane is running Claude Code. Claude is a Node app,
+// so pane_current_command can surface as "node"; matching the executable name or
+// a "claude" token in the captured command keeps detection robust, and a missed
+// match simply falls back to the default restore.
+func (i *Integration) Matches(pane snapshot.Pane) bool {
+	for _, cmd := range []string{pane.RestoreCmd, pane.CurrentCmd} {
+		cmd = strings.ToLower(strings.TrimSpace(cmd))
+		if cmd == "" {
+			continue
+		}
+
+		if executableName(cmd) == "claude" || strings.Contains(cmd, "claude") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Capture resolves the pane's most recent Claude session id from its working
+// directory. A missing project dir or transcript yields nil (no metadata), so
+// restore falls back to a plain `claude`.
+func (i *Integration) Capture(pane snapshot.Pane) (map[string]string, error) {
+	sessionID, ok := i.latestSessionID(pane.CurrentPath)
+	if !ok {
+		// Empty (not nil) so the no-metadata case never trips the nilnil lint;
+		// the registry treats a zero-length map as "nothing captured".
+		return map[string]string{}, nil
+	}
+
+	return map[string]string{metaSessionID: sessionID}, nil
+}
+
+// RestoreCommand replays the captured session, or "" to fall back to default.
+func (i *Integration) RestoreCommand(_ snapshot.Pane, meta map[string]string) string {
+	id := strings.TrimSpace(meta[metaSessionID])
+	if id == "" {
+		return ""
+	}
+
+	return "claude --resume " + id
+}
+
+// latestSessionID maps a working directory to <home>/projects/<encoded-cwd> and
+// returns the newest transcript's session id (its filename without .jsonl).
+func (i *Integration) latestSessionID(cwd string) (string, bool) {
+	cwd = strings.TrimSpace(cwd)
+	if cwd == "" || strings.TrimSpace(i.home) == "" {
+		return "", false
+	}
+
+	dir := filepath.Join(i.home, "projects", encodeProjectDir(cwd))
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", false
+	}
+
+	var (
+		newestID   string
+		newestTime int64
+		found      bool
+	)
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), transcriptExt) {
+			continue
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+
+		if mod := info.ModTime().UnixNano(); !found || mod > newestTime {
+			newestTime = mod
+			newestID = strings.TrimSuffix(entry.Name(), transcriptExt)
+			found = true
+		}
+	}
+
+	return newestID, found
+}
+
+// encodeProjectDir mirrors Claude Code's per-project directory naming: the
+// absolute cwd with path separators and dots replaced by "-", e.g.
+// "/Users/me/code/lazy-tmux" -> "-Users-me-code-lazy-tmux".
+func encodeProjectDir(cwd string) string {
+	replacer := strings.NewReplacer("/", "-", ".", "-")
+	return replacer.Replace(cwd)
+}
+
+func executableName(cmd string) string {
+	fields := strings.Fields(strings.TrimSpace(cmd))
+	if len(fields) == 0 {
+		return ""
+	}
+
+	base := filepath.Base(fields[0])
+
+	return strings.TrimPrefix(base, "-")
+}

--- a/internal/integration/claude/claude_test.go
+++ b/internal/integration/claude/claude_test.go
@@ -1,0 +1,129 @@
+package claude
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/alchemmist/lazy-tmux/internal/snapshot"
+)
+
+// writeTranscript creates <home>/projects/<encoded cwd>/<id>.jsonl with the
+// given modification time so tests can control which one is "newest".
+func writeTranscript(t *testing.T, home, cwd, id string, mod time.Time) {
+	t.Helper()
+
+	dir := filepath.Join(home, "projects", encodeProjectDir(cwd))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	path := filepath.Join(dir, id+transcriptExt)
+	if err := os.WriteFile(path, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	if err := os.Chtimes(path, mod, mod); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+}
+
+func TestCaptureReturnsNewestSession(t *testing.T) {
+	home := t.TempDir()
+	cwd := "/Users/me/code/proj"
+
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	writeTranscript(t, home, cwd, "old-session", base)
+	writeTranscript(t, home, cwd, "new-session", base.Add(time.Hour))
+
+	integ := New(home)
+
+	meta, err := integ.Capture(snapshot.Pane{CurrentPath: cwd, CurrentCmd: "claude"})
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+
+	if meta["session_id"] != "new-session" {
+		t.Fatalf("expected newest session, got %q", meta["session_id"])
+	}
+}
+
+func TestCaptureMissingProjectDir(t *testing.T) {
+	integ := New(t.TempDir())
+
+	meta, err := integ.Capture(snapshot.Pane{CurrentPath: "/no/such/dir", CurrentCmd: "claude"})
+	if err != nil {
+		t.Fatalf("capture should not error on missing dir: %v", err)
+	}
+
+	if len(meta) != 0 {
+		t.Fatalf("missing dir should yield no meta, got %v", meta)
+	}
+}
+
+func TestCaptureIgnoresNonTranscripts(t *testing.T) {
+	home := t.TempDir()
+	cwd := "/Users/me/proj"
+
+	dir := filepath.Join(home, "projects", encodeProjectDir(cwd))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	meta, _ := New(home).Capture(snapshot.Pane{CurrentPath: cwd})
+	if len(meta) != 0 {
+		t.Fatalf("non-.jsonl files must be ignored, got %v", meta)
+	}
+}
+
+func TestMatches(t *testing.T) {
+	integ := New(t.TempDir())
+
+	cases := []struct {
+		pane snapshot.Pane
+		want bool
+	}{
+		{snapshot.Pane{CurrentCmd: "claude"}, true},
+		{snapshot.Pane{RestoreCmd: "node /usr/local/lib/claude/cli.js"}, true},
+		{snapshot.Pane{CurrentCmd: "node", RestoreCmd: "claude --resume x"}, true},
+		{snapshot.Pane{CurrentCmd: "vim"}, false},
+		{snapshot.Pane{CurrentCmd: "zsh"}, false},
+		{snapshot.Pane{}, false},
+	}
+
+	for _, tc := range cases {
+		if got := integ.Matches(tc.pane); got != tc.want {
+			t.Fatalf("Matches(%+v) = %v, want %v", tc.pane, got, tc.want)
+		}
+	}
+}
+
+func TestRestoreCommand(t *testing.T) {
+	integ := New(t.TempDir())
+
+	if got := integ.RestoreCommand(
+		snapshot.Pane{},
+		map[string]string{"session_id": "abc"},
+	); got != "claude --resume abc" {
+		t.Fatalf("unexpected restore command: %q", got)
+	}
+
+	if got := integ.RestoreCommand(snapshot.Pane{}, map[string]string{}); got != "" {
+		t.Fatalf("missing session id should fall back to empty, got %q", got)
+	}
+}
+
+func TestEncodeProjectDir(t *testing.T) {
+	if got := encodeProjectDir("/Users/me/code/lazy-tmux"); got != "-Users-me-code-lazy-tmux" {
+		t.Fatalf("unexpected encoding: %q", got)
+	}
+
+	if got := encodeProjectDir("/a/b.c/d"); got != "-a-b-c-d" {
+		t.Fatalf("dots should map to '-', got %q", got)
+	}
+}

--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -1,0 +1,48 @@
+// Package integration provides an extensible framework for adapting interactive
+// programs running in a pane to lazy-tmux's save/restore. Each program (Claude
+// Code, editors, REPLs, …) implements the Integration interface and is plugged
+// into a Registry; the core save/restore path stays free of program-specific
+// special cases.
+package integration
+
+import "github.com/alchemmist/lazy-tmux/internal/snapshot"
+
+// Integration adapts one program to lazy-tmux. Implementations must be cheap and
+// side-effect-free outside Capture (which runs at save time and may read the
+// program's own state on disk).
+type Integration interface {
+	// Name identifies the integration and namespaces its snapshot metadata
+	// (stored on the pane as "<name>.<key>").
+	Name() string
+	// Matches reports whether this integration applies to a captured pane,
+	// judged from its command / path.
+	Matches(pane snapshot.Pane) bool
+	// Capture gathers integration-specific state at save time (e.g. the Claude
+	// session id), returned with its own un-namespaced keys. Returning a nil/empty
+	// map (or an error) means "nothing to record" and must never break the save.
+	Capture(pane snapshot.Pane) (map[string]string, error)
+	// RestoreCommand builds the command to replay from the captured metadata
+	// (de-namespaced to this integration's keys). Returning "" falls back to the
+	// default restore behavior.
+	RestoreCommand(pane snapshot.Pane, meta map[string]string) string
+}
+
+// StatusReporter is an optional capability: integrations that can report the
+// live state of a running pane implement it. It is the extension point for the
+// follow-up TUI picker status dots; defined here so the framework is ready, but
+// not yet consumed by the picker.
+type StatusReporter interface {
+	Status(pane snapshot.Pane) (Status, bool)
+}
+
+// Status is the live state of a running, integrated pane.
+type Status int
+
+const (
+	StatusUnknown          Status = iota
+	StatusWorking                 // actively doing work (e.g. Claude is generating)
+	StatusAwaitingDecision        // blocked on a question / permission the user must answer
+	StatusAwaitingInput           // prompt ready, waiting for the user to type
+	StatusIdle                    // running but nothing pending
+	StatusError                   // crashed / errored
+)

--- a/internal/integration/registry.go
+++ b/internal/integration/registry.go
@@ -1,0 +1,95 @@
+package integration
+
+import (
+	"strings"
+
+	"github.com/alchemmist/lazy-tmux/internal/snapshot"
+)
+
+// Registry holds the enabled integrations and applies them at save and restore
+// time. The zero value (and a nil *Registry) is safe and inert.
+type Registry struct {
+	items []Integration
+}
+
+// NewRegistry builds a registry from the given integrations, consulted in order
+// (the first match wins per pane).
+func NewRegistry(items ...Integration) *Registry {
+	return &Registry{items: items}
+}
+
+// Enrich runs the first matching integration's Capture on every pane and stores
+// the result on the pane, namespaced as "<name>.<key>". Capture failures are
+// swallowed so saving can never break on integration state.
+func (r *Registry) Enrich(snap *snapshot.SessionSnapshot) {
+	if r == nil || snap == nil || len(r.items) == 0 {
+		return
+	}
+
+	for wi := range snap.Windows {
+		for pi := range snap.Windows[wi].Panes {
+			r.enrichPane(&snap.Windows[wi].Panes[pi])
+		}
+	}
+}
+
+// Resolve returns the restore command from the first matching integration, or ""
+// to fall back to the default restore. It satisfies tmux's
+// RestoreCommandResolver and is pure (reads only the pane's stored metadata).
+func (r *Registry) Resolve(pane snapshot.Pane) string {
+	if r == nil {
+		return ""
+	}
+
+	integ := r.match(pane)
+	if integ == nil {
+		return ""
+	}
+
+	return integ.RestoreCommand(pane, subMeta(pane.Meta, integ.Name()))
+}
+
+func (r *Registry) enrichPane(pane *snapshot.Pane) {
+	integ := r.match(*pane)
+	if integ == nil {
+		return
+	}
+
+	meta, err := integ.Capture(*pane)
+	if err != nil || len(meta) == 0 {
+		return
+	}
+
+	if pane.Meta == nil {
+		pane.Meta = make(map[string]string, len(meta))
+	}
+
+	for key, value := range meta {
+		pane.Meta[integ.Name()+"."+key] = value
+	}
+}
+
+func (r *Registry) match(pane snapshot.Pane) Integration {
+	for _, integ := range r.items {
+		if integ.Matches(pane) {
+			return integ
+		}
+	}
+
+	return nil
+}
+
+// subMeta extracts the keys belonging to one integration, stripping the
+// "<name>." namespace prefix.
+func subMeta(meta map[string]string, name string) map[string]string {
+	prefix := name + "."
+	out := make(map[string]string)
+
+	for key, value := range meta {
+		if after, ok := strings.CutPrefix(key, prefix); ok {
+			out[after] = value
+		}
+	}
+
+	return out
+}

--- a/internal/integration/registry_test.go
+++ b/internal/integration/registry_test.go
@@ -1,0 +1,103 @@
+package integration
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/alchemmist/lazy-tmux/internal/snapshot"
+)
+
+// fakeIntegration matches panes by CurrentCmd and echoes its metadata back so
+// tests can verify namespacing and de-namespacing.
+type fakeIntegration struct {
+	name       string
+	matchCmd   string
+	meta       map[string]string
+	captureErr error
+}
+
+func (f fakeIntegration) Name() string                 { return f.name }
+func (f fakeIntegration) Matches(p snapshot.Pane) bool { return p.CurrentCmd == f.matchCmd }
+func (f fakeIntegration) Capture(snapshot.Pane) (map[string]string, error) {
+	return f.meta, f.captureErr
+}
+
+func (f fakeIntegration) RestoreCommand(_ snapshot.Pane, meta map[string]string) string {
+	if meta["session_id"] == "" {
+		return ""
+	}
+
+	return "resume " + meta["session_id"]
+}
+
+func paneSnap(panes ...snapshot.Pane) *snapshot.SessionSnapshot {
+	return &snapshot.SessionSnapshot{Windows: []snapshot.Window{{Panes: panes}}}
+}
+
+func TestRegistryEnrichNamespacesMeta(t *testing.T) {
+	reg := NewRegistry(fakeIntegration{
+		name:     "fake",
+		matchCmd: "myprog",
+		meta:     map[string]string{"session_id": "abc"},
+	})
+
+	snap := paneSnap(
+		snapshot.Pane{Index: 0, CurrentCmd: "myprog"},
+		snapshot.Pane{Index: 1, CurrentCmd: "zsh"},
+	)
+	reg.Enrich(snap)
+
+	if got := snap.Windows[0].Panes[0].Meta["fake.session_id"]; got != "abc" {
+		t.Fatalf("matched pane should carry namespaced meta, got %q", got)
+	}
+
+	if snap.Windows[0].Panes[1].Meta != nil {
+		t.Fatalf("non-matching pane must stay un-enriched, got %v", snap.Windows[0].Panes[1].Meta)
+	}
+}
+
+func TestRegistryEnrichSwallowsCaptureFailures(t *testing.T) {
+	reg := NewRegistry(fakeIntegration{
+		name:       "fake",
+		matchCmd:   "myprog",
+		captureErr: errors.New("boom"),
+	})
+
+	snap := paneSnap(snapshot.Pane{CurrentCmd: "myprog"})
+	reg.Enrich(snap) // must not panic
+
+	if snap.Windows[0].Panes[0].Meta != nil {
+		t.Fatal("a failing Capture must record nothing")
+	}
+}
+
+func TestRegistryResolveDeNamespaces(t *testing.T) {
+	reg := NewRegistry(fakeIntegration{name: "fake", matchCmd: "myprog"})
+
+	pane := snapshot.Pane{
+		CurrentCmd: "myprog",
+		Meta:       map[string]string{"fake.session_id": "xyz", "other.k": "v"},
+	}
+
+	if got := reg.Resolve(pane); got != "resume xyz" {
+		t.Fatalf("Resolve should pass de-namespaced meta, got %q", got)
+	}
+}
+
+func TestRegistryResolveNoMatch(t *testing.T) {
+	reg := NewRegistry(fakeIntegration{name: "fake", matchCmd: "myprog"})
+
+	if got := reg.Resolve(snapshot.Pane{CurrentCmd: "vim"}); got != "" {
+		t.Fatalf("no match should resolve to empty, got %q", got)
+	}
+}
+
+func TestRegistryNilSafe(t *testing.T) {
+	var reg *Registry
+
+	reg.Enrich(paneSnap(snapshot.Pane{CurrentCmd: "x"})) // must not panic
+
+	if got := reg.Resolve(snapshot.Pane{CurrentCmd: "x"}); got != "" {
+		t.Fatalf("nil registry resolve should be empty, got %q", got)
+	}
+}

--- a/internal/snapshot/types.go
+++ b/internal/snapshot/types.go
@@ -29,6 +29,12 @@ type Pane struct {
 	RestoreCmd  string         `json:"restore_cmd,omitempty"`
 	Scrollback  *ScrollbackRef `json:"scrollback,omitempty"`
 	IsActive    bool           `json:"is_active"`
+
+	// Meta carries program-integration metadata captured at save time, keyed by
+	// "<integration>.<key>" (e.g. "claude.session_id"). It is opaque to the core
+	// save/restore path; integrations read it back to build a resume command.
+	// Omitted when empty, so older snapshots and JSON stay unaffected.
+	Meta map[string]string `json:"meta,omitempty"`
 }
 
 type ScrollbackRef struct {

--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -91,6 +91,16 @@ type Client struct {
 	// nothing).
 	allowlist    map[string]struct{}
 	allowlistSet bool
+
+	// resolver lets a program-integration registry override the restore command
+	// for a pane (e.g. `claude --resume <id>`). nil keeps the default behavior.
+	resolver RestoreCommandResolver
+}
+
+// RestoreCommandResolver lets an external registry rewrite the command replayed
+// for a pane on restore. Returning "" defers to the default restore command.
+type RestoreCommandResolver interface {
+	Resolve(pane snapshot.Pane) string
 }
 
 func NewClient(bin string) *Client {
@@ -145,6 +155,12 @@ func (client *Client) SetRestoreAllowlist(list []string) {
 			client.allowlist[name] = struct{}{}
 		}
 	}
+}
+
+// SetRestoreResolver installs a program-integration resolver that may override
+// the command replayed for a pane on restore. Passing nil restores the default.
+func (client *Client) SetRestoreResolver(resolver RestoreCommandResolver) {
+	client.resolver = resolver
 }
 
 func sessionTarget(name string) string {
@@ -662,6 +678,20 @@ func firstPanePath(w snapshot.Window) string {
 	return filepath.Clean(path)
 }
 
+// effectiveRestoreCommand is the command actually replayed for a pane: a
+// program integration's override when one applies, otherwise the default
+// normalized command. Both the replay and the settle-wait predictor go through
+// this so they always agree on what a pane will run.
+func (client *Client) effectiveRestoreCommand(pane snapshot.Pane) string {
+	if client.resolver != nil {
+		if override := strings.TrimSpace(client.resolver.Resolve(pane)); override != "" {
+			return override
+		}
+	}
+
+	return normalizedCommand(pane.RestoreCmd, pane.CurrentCmd)
+}
+
 func normalizedCommand(restore, current string) string {
 	restore = sanitizeCommand(restore)
 	if restore != "" && !isShellCommand(restore) {
@@ -727,7 +757,7 @@ func (client *Client) restoreWindowCommands(
 	sort.Slice(panes, func(i, j int) bool { return panes[i].Index < panes[j].Index })
 
 	for _, pane := range panes {
-		cmd := normalizedCommand(pane.RestoreCmd, pane.CurrentCmd)
+		cmd := client.effectiveRestoreCommand(pane)
 		if strings.TrimSpace(cmd) == "" {
 			continue
 		}
@@ -771,7 +801,7 @@ func (client *Client) expectedPaneCommands(windows []snapshot.Window) map[string
 
 	for _, window := range windows {
 		for _, pane := range window.Panes {
-			exe := executableName(normalizedCommand(pane.RestoreCmd, pane.CurrentCmd))
+			exe := executableName(client.effectiveRestoreCommand(pane))
 			if exe == "" || !client.commandAllowed(exe) {
 				continue
 			}

--- a/internal/tmux/resolver_test.go
+++ b/internal/tmux/resolver_test.go
@@ -1,0 +1,114 @@
+package tmux
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alchemmist/lazy-tmux/internal/snapshot"
+)
+
+// recordingRunner captures every tmux invocation and returns success.
+type recordingRunner struct {
+	calls [][]string
+}
+
+func (r *recordingRunner) runCommand(args ...string) commandResult {
+	r.calls = append(r.calls, append([]string(nil), args...))
+	return commandResult{}
+}
+
+// fakeResolver overrides the restore command for a chosen current command.
+type fakeResolver struct {
+	matchCmd string
+	override string
+}
+
+func (f fakeResolver) Resolve(pane snapshot.Pane) string {
+	if pane.CurrentCmd == f.matchCmd {
+		return f.override
+	}
+
+	return ""
+}
+
+func sentKeys(calls [][]string) []string {
+	var out []string
+
+	for _, call := range calls {
+		if len(call) > 1 && call[1] == "send-keys" {
+			// send-keys -t <target> <cmd> C-m
+			out = append(out, call[len(call)-2])
+		}
+	}
+
+	return out
+}
+
+func TestRestoreResolverOverridesCommand(t *testing.T) {
+	runner := &recordingRunner{}
+	client := NewClientWithRunner("tmux", runner)
+	client.SetRestoreResolver(fakeResolver{matchCmd: "claude", override: "claude --resume sess-1"})
+
+	window := snapshot.Window{
+		Index: 1,
+		Panes: []snapshot.Pane{
+			{Index: 0, CurrentCmd: "claude", RestoreCmd: "claude"},
+			{Index: 1, CurrentCmd: "vim", RestoreCmd: "vim main.go"},
+		},
+	}
+
+	if err := client.restoreWindowCommands("work", window, 1); err != nil {
+		t.Fatalf("restoreWindowCommands: %v", err)
+	}
+
+	sent := sentKeys(runner.calls)
+	if len(sent) != 2 {
+		t.Fatalf("expected 2 send-keys, got %v", sent)
+	}
+
+	if sent[0] != "claude --resume sess-1" {
+		t.Fatalf("claude pane should use the resolver override, got %q", sent[0])
+	}
+
+	if sent[1] != "vim main.go" {
+		t.Fatalf("non-matching pane keeps the default command, got %q", sent[1])
+	}
+}
+
+func TestEffectiveRestoreCommandFallsBack(t *testing.T) {
+	client := NewClientWithRunner("tmux", &recordingRunner{})
+
+	// No resolver: default normalized command.
+	pane := snapshot.Pane{CurrentCmd: "vim", RestoreCmd: "vim main.go"}
+	if got := client.effectiveRestoreCommand(pane); got != "vim main.go" {
+		t.Fatalf("default path changed, got %q", got)
+	}
+
+	// Resolver returning "" must defer to the default.
+	client.SetRestoreResolver(fakeResolver{matchCmd: "claude", override: "x"})
+	if got := client.effectiveRestoreCommand(pane); got != "vim main.go" {
+		t.Fatalf("empty override should fall back, got %q", got)
+	}
+}
+
+func TestRestoreResolverRespectsAllowlist(t *testing.T) {
+	runner := &recordingRunner{}
+	client := NewClientWithRunner("tmux", runner)
+	client.SetRestoreResolver(fakeResolver{matchCmd: "claude", override: "claude --resume s"})
+	client.SetRestoreAllowlist([]string{"vim"}) // claude not allowed
+
+	window := snapshot.Window{
+		Index: 1,
+		Panes: []snapshot.Pane{{Index: 0, CurrentCmd: "claude", RestoreCmd: "claude"}},
+	}
+
+	if err := client.restoreWindowCommands("work", window, 1); err != nil {
+		t.Fatalf("restoreWindowCommands: %v", err)
+	}
+
+	for _, cmd := range sentKeys(runner.calls) {
+		if strings.Contains(cmd, "claude") {
+			t.Fatalf("allowlist must block the resolved claude command, sent %q", cmd)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

First step of #147: replace the single hard-coded restore rule with an **extensible program-integration framework**, and prove it end-to-end with the **Claude Code resume** integration. A `claude` pane is now restored as `claude --resume <session-id>` instead of a fresh `claude`, so the conversation continues. Adding a future integration (editors, REPLs, ssh, …) means implementing one interface and registering it — no changes to the core save/restore path.

This is the refactor-first slice. The live picker **status dots** (the `StatusReporter` capability) are scaffolded as an interface but their picker rendering/detection are a deliberate follow-up.

## Framework

- **`internal/integration`** (depends only on `snapshot`):
  - `Integration` interface — `Name` / `Matches` / `Capture` (save-time metadata) / `RestoreCommand` (replay command, `""` = default).
  - `Registry` — `Enrich(snap)` runs the first matching integration's `Capture` per pane and stores results namespaced on `pane.Meta` (`claude.session_id`); `Resolve(pane)` returns the restore command (pure, reads stored meta). Capture failures are swallowed so saving never breaks.
  - `StatusReporter` capability + `Status` enum scaffolded for the follow-up.
- **`snapshot.Pane`** gains `Meta map[string]string` (`omitempty`) — forward/backward compatible; old snapshots load unchanged.
- **`tmux` client** gains a `RestoreCommandResolver` seam. Both the command replay (`restoreWindowCommands`) and the settle-wait predictor (`expectedPaneCommands`) route through one `effectiveRestoreCommand`, so the default behavior is byte-for-byte unchanged and the **`restore_allowlist` still applies** to the resolved command (`claude --resume …` needs `claude` allow-listed if an allowlist is set).
- **`App`** builds the registry from config, `SetRestoreResolver` on the client, and `Enrich`es each snapshot on save. The tmux client stays a dumb executor (no `integration` import — avoids a cycle).

## Claude integration

- Maps a pane's cwd → `<home>/projects/<encoded-cwd>/`, picks the newest `*.jsonl` as the session id; a missing transcript dir falls back to plain `claude` (never breaks restore).
- Encoding verified against the real `~/.claude/projects` layout (`/Users/me/code/lazy-tmux` → `-Users-me-code-lazy-tmux`).
- Robust matching (executable name **or** a `claude` token) covers the case where the pane surfaces as `node`.

## Config

New `[integrations]` section (master switch + `[integrations.claude]` `enabled` / `home`), mirroring the `[scrollback]` pointer-merge pattern. Documented in `default.toml`, printed by `config show`:

```toml
[integrations]
enabled = true

[integrations.claude]
enabled = true
home    = "~/.claude"
```

## Tests / verification

- New unit tests: registry enrich/resolve/namespacing + nil-safety; claude discovery (newest transcript, missing dir, non-`.jsonl` ignored, encoding) / matching / restore command; tmux resolver override + fallback + allowlist interaction; config defaults/override/partial/render; app registry wiring (enabled / master-off / claude-off).
- `make build build-fzf`, `make test` (169 passing), `make golangci-lint` (0 issues) all green; `config show` shows the new section.

## Follow-ups (next PRs)

- Live picker status dots — implement `StatusReporter` for Claude (transcript tailing) + render a colored per-window dot.
- Additional integrations on top of the framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
