### PR TITLE
fix(picker): attach to the restored session when run outside tmux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,13 +8,13 @@ require (
 	charm.land/lipgloss/v2 v2.0.4
 	github.com/BurntSushi/toml v1.6.0
 	github.com/charmbracelet/x/ansi v0.11.7
+	github.com/charmbracelet/x/term v0.2.2
 )
 
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654 // indirect
-	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -31,6 +31,8 @@ type tmuxSessionCapturer interface {
 type tmuxSessionRestorer interface {
 	RestoreSession(snap snapshot.SessionSnapshot) error
 	SwitchClient(target string) error
+	AttachSession(target string) error
+	InsideTmux() bool
 }
 
 type tmuxSessionMutator interface {
@@ -167,18 +169,13 @@ func (a *App) RestoreTarget(target PickerTarget, switchClient bool) error {
 		return fmt.Errorf("restore session: %w", err)
 	}
 
-	if switchClient {
-		switchTarget := session
-		if target.WindowIndex != nil {
-			switchTarget = fmt.Sprintf("%s:%d", session, *target.WindowIndex)
-		}
-
-		err := a.tmux.SwitchClient(switchTarget)
-		if err != nil {
-			return fmt.Errorf("switch client: %w", err)
-		}
+	switchTarget := session
+	if target.WindowIndex != nil {
+		switchTarget = fmt.Sprintf("%s:%d", session, *target.WindowIndex)
 	}
 
+	// Mark accessed before any hand-off: AttachSession replaces this process, so
+	// nothing after it would run.
 	err = a.store.MarkSessionAccessed(
 		session,
 		time.Now().UTC(),
@@ -186,6 +183,23 @@ func (a *App) RestoreTarget(target PickerTarget, switchClient bool) error {
 	if err != nil &&
 		!errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("mark session accessed: %w", err)
+	}
+
+	if switchClient {
+		// Inside tmux, hop the current client to the session. Outside tmux,
+		// attach so the user lands inside the restored session instead of being
+		// left at the shell with a detached session (#182).
+		if a.tmux.InsideTmux() {
+			err = a.tmux.SwitchClient(switchTarget)
+			if err != nil {
+				return fmt.Errorf("switch client: %w", err)
+			}
+		} else {
+			err = a.tmux.AttachSession(switchTarget)
+			if err != nil {
+				return fmt.Errorf("attach session: %w", err)
+			}
+		}
 	}
 
 	return nil

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -7,8 +7,87 @@ import (
 	"time"
 
 	"github.com/alchemmist/lazy-tmux/internal/config"
+	"github.com/alchemmist/lazy-tmux/internal/snapshot"
 	"github.com/alchemmist/lazy-tmux/internal/testutil"
 )
+
+// recordingTmux is a tmuxClient that records how RestoreTarget hands off to the
+// session. Methods RestoreTarget doesn't touch are inherited from the embedded
+// (nil) interface and panic if called, surfacing any unexpected dependency.
+type recordingTmux struct {
+	tmuxClient
+
+	inside   bool
+	switched string
+	attached string
+}
+
+func (r *recordingTmux) RestoreSession(snapshot.SessionSnapshot) error { return nil }
+func (r *recordingTmux) InsideTmux() bool                              { return r.inside }
+
+func (r *recordingTmux) SwitchClient(
+	target string,
+) error {
+	r.switched = target
+	return nil
+}
+
+func (r *recordingTmux) AttachSession(
+	target string,
+) error {
+	r.attached = target
+	return nil
+}
+
+func TestRestoreTargetHandsOff(t *testing.T) {
+	idx := 2
+
+	cases := []struct {
+		name         string
+		inside       bool
+		windowIndex  *int
+		wantSwitched string
+		wantAttached string
+	}{
+		{name: "inside tmux switches", inside: true, wantSwitched: "s1"},
+		{name: "outside tmux attaches", inside: false, wantAttached: "s1"},
+		{
+			name:         "outside tmux attaches to window",
+			inside:       false,
+			windowIndex:  &idx,
+			wantAttached: "s1:2",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a, _ := newTestApp(t)
+
+			if err := a.store.SaveSession(snapshot.SessionSnapshot{SessionName: "s1"}); err != nil {
+				t.Fatalf("save snapshot: %v", err)
+			}
+
+			fake := &recordingTmux{inside: tc.inside}
+			a.tmux = fake
+
+			err := a.RestoreTarget(
+				PickerTarget{SessionName: "s1", WindowIndex: tc.windowIndex},
+				true,
+			)
+			if err != nil {
+				t.Fatalf("restore target: %v", err)
+			}
+
+			if fake.switched != tc.wantSwitched {
+				t.Fatalf("switched = %q, want %q", fake.switched, tc.wantSwitched)
+			}
+
+			if fake.attached != tc.wantAttached {
+				t.Fatalf("attached = %q, want %q", fake.attached, tc.wantAttached)
+			}
+		})
+	}
+}
 
 func newTestApp(t *testing.T) (*App, string) {
 	t.Helper()

--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
+	"github.com/charmbracelet/x/term"
 )
 
 const fieldSep = "|"
@@ -275,14 +276,12 @@ func (client *Client) InsideTmux() bool {
 var attachExec = syscall.Exec
 
 // hasControllingTTY reports whether stdout is a real terminal. attach-session
-// needs one; a package var so tests can force it.
+// needs one; a package var so tests can force it. It uses a real isatty probe
+// on the fd rather than os.ModeCharDevice, which also matches non-terminals
+// such as /dev/null and would let the attach fall through to "open terminal
+// failed".
 var hasControllingTTY = func() bool {
-	info, err := os.Stdout.Stat()
-	if err != nil {
-		return false
-	}
-
-	return info.Mode()&os.ModeCharDevice != 0
+	return term.IsTerminal(os.Stdout.Fd())
 }
 
 // AttachSession replaces the current process with `tmux attach-session -t

--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -274,12 +274,30 @@ func (client *Client) InsideTmux() bool {
 // failure to launch; on success the current process image is replaced by tmux.
 var attachExec = syscall.Exec
 
+// hasControllingTTY reports whether stdout is a real terminal. attach-session
+// needs one; a package var so tests can force it.
+var hasControllingTTY = func() bool {
+	info, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+
+	return info.Mode()&os.ModeCharDevice != 0
+}
+
 // AttachSession replaces the current process with `tmux attach-session -t
 // <target>`, so a picker/restore run from a plain shell drops the user inside
 // the restored session (and detaching returns them to that shell). target may
 // carry a window, e.g. "name:2", matching SwitchClient. It returns only when
 // the attach fails to launch.
 func (client *Client) AttachSession(target string) error {
+	// attach-session needs a controlling terminal; without one (piped output,
+	// headless CI, fzf --filter) tmux would fail with "open terminal failed".
+	// Leave the session restored-but-detached instead of erroring.
+	if !hasControllingTTY() {
+		return nil
+	}
+
 	bin, err := exec.LookPath(client.bin)
 	if err != nil {
 		return fmt.Errorf("locate tmux %q: %w", client.bin, err)

--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
@@ -260,6 +261,33 @@ func (client *Client) SwitchClient(session string) error {
 	_, err := client.Output("switch-client", "-t", sessionTarget(session))
 
 	return err
+}
+
+// InsideTmux reports whether we are running inside a tmux client (so the caller
+// can switch-client) versus a plain shell (so it must attach-session instead).
+func (client *Client) InsideTmux() bool {
+	return strings.TrimSpace(os.Getenv("TMUX")) != ""
+}
+
+// attachExec hands the terminal off to tmux. It is a package var so tests can
+// stub it without replacing the test process. syscall.Exec returns only on
+// failure to launch; on success the current process image is replaced by tmux.
+var attachExec = syscall.Exec
+
+// AttachSession replaces the current process with `tmux attach-session -t
+// <target>`, so a picker/restore run from a plain shell drops the user inside
+// the restored session (and detaching returns them to that shell). target may
+// carry a window, e.g. "name:2", matching SwitchClient. It returns only when
+// the attach fails to launch.
+func (client *Client) AttachSession(target string) error {
+	bin, err := exec.LookPath(client.bin)
+	if err != nil {
+		return fmt.Errorf("locate tmux %q: %w", client.bin, err)
+	}
+
+	args := []string{bin, "attach-session", "-t", sessionTarget(target)}
+
+	return attachExec(bin, args, os.Environ())
 }
 
 func (client *Client) KillWindow(session string, windowIndex int) error {

--- a/internal/tmux/client_test.go
+++ b/internal/tmux/client_test.go
@@ -372,3 +372,56 @@ func TestNewSessionArgs(t *testing.T) {
 		t.Fatalf("expected -c /work in args: %#v", args)
 	}
 }
+
+func TestInsideTmux(t *testing.T) {
+	client := NewClient("tmux")
+
+	t.Setenv("TMUX", "")
+
+	if client.InsideTmux() {
+		t.Fatal("InsideTmux must be false when $TMUX is empty")
+	}
+
+	t.Setenv("TMUX", "/tmp/tmux-1000/default,1234,0")
+
+	if !client.InsideTmux() {
+		t.Fatal("InsideTmux must be true when $TMUX is set")
+	}
+}
+
+func TestAttachSessionExecsTmux(t *testing.T) {
+	var (
+		gotArgv0 string
+		gotArgs  []string
+	)
+
+	orig := attachExec
+	attachExec = func(argv0 string, argv, _ []string) error {
+		gotArgv0 = argv0
+		gotArgs = argv
+
+		return nil
+	}
+
+	t.Cleanup(func() { attachExec = orig })
+
+	// "sh" resolves on every supported platform, so LookPath succeeds.
+	if err := NewClient("sh").AttachSession("proj:2"); err != nil {
+		t.Fatalf("attach session: %v", err)
+	}
+
+	if gotArgv0 == "" {
+		t.Fatal("expected a resolved tmux binary path")
+	}
+
+	want := []string{gotArgv0, "attach-session", "-t", "=proj:2"}
+	if len(gotArgs) != len(want) {
+		t.Fatalf("argv = %v, want %v", gotArgs, want)
+	}
+
+	for i := range want {
+		if gotArgs[i] != want[i] {
+			t.Fatalf("argv = %v, want %v", gotArgs, want)
+		}
+	}
+}

--- a/internal/tmux/client_test.go
+++ b/internal/tmux/client_test.go
@@ -395,7 +395,7 @@ func TestAttachSessionExecsTmux(t *testing.T) {
 		gotArgs  []string
 	)
 
-	orig := attachExec
+	origExec := attachExec
 	attachExec = func(argv0 string, argv, _ []string) error {
 		gotArgv0 = argv0
 		gotArgs = argv
@@ -403,7 +403,13 @@ func TestAttachSessionExecsTmux(t *testing.T) {
 		return nil
 	}
 
-	t.Cleanup(func() { attachExec = orig })
+	origTTY := hasControllingTTY
+	hasControllingTTY = func() bool { return true }
+
+	t.Cleanup(func() {
+		attachExec = origExec
+		hasControllingTTY = origTTY
+	})
 
 	// "sh" resolves on every supported platform, so LookPath succeeds.
 	if err := NewClient("sh").AttachSession("proj:2"); err != nil {
@@ -423,5 +429,33 @@ func TestAttachSessionExecsTmux(t *testing.T) {
 		if gotArgs[i] != want[i] {
 			t.Fatalf("argv = %v, want %v", gotArgs, want)
 		}
+	}
+}
+
+func TestAttachSessionWithoutTTYIsNoOp(t *testing.T) {
+	called := false
+
+	origExec := attachExec
+	attachExec = func(string, []string, []string) error {
+		called = true
+		return nil
+	}
+
+	origTTY := hasControllingTTY
+	hasControllingTTY = func() bool { return false }
+
+	t.Cleanup(func() {
+		attachExec = origExec
+		hasControllingTTY = origTTY
+	})
+
+	// Without a controlling terminal, attach must be skipped (tmux would fail
+	// with "open terminal failed"), leaving the session restored-but-detached.
+	if err := NewClient("sh").AttachSession("proj"); err != nil {
+		t.Fatalf("attach session: %v", err)
+	}
+
+	if called {
+		t.Fatal("attach must not exec tmux without a controlling TTY")
 	}
 }


### PR DESCRIPTION
## What

When the TUI picker or `lazy-tmux restore` is run **outside of tmux**, selecting a session now drops the user *inside* the restored session instead of leaving them at their shell.

Previously `Client.SwitchClient` was a no-op when `$TMUX` was empty, so the session was created on the server but never attached — the user had to `tmux attach -t <session>` by hand.

## How

- `Client.InsideTmux()` — reports whether we're in a tmux client.
- `Client.AttachSession(target)` — replaces the current process with `tmux attach-session -t <target>` via `syscall.Exec`, handing the terminal off (and honoring a `name:window` target). Behind a stubbable `attachExec` package var so it's unit-testable.
- `App.RestoreTarget` now branches: **inside tmux** → `switch-client` (unchanged); **outside tmux** → `attach-session`. Session-accessed is marked *before* the hand-off, since attach replaces the process.

## Tests

- `internal/tmux`: `TestInsideTmux` (env toggling), `TestAttachSessionExecsTmux` (argv + target encoding via stubbed `attachExec`).
- `internal/app`: `TestRestoreTargetHandsOff` — table test covering inside→switch, outside→attach, and outside→attach-to-window.
- `make build build-fzf`, `make test` (193 tests), `make golangci-lint` (0 issues) all green.

Fixes #182. Reported by @callmiy in #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restoring a tmux session now correctly hands off depending on whether the app is already running inside tmux.
  * When launching from outside tmux, the app now attaches directly into the restored session.
  * Restore targets are formatted more consistently, including explicit window indexes.
  * Attachment is skipped when no controlling TTY is available (headless/piped environments).
* **Tests**
  * Added coverage to verify switch vs attach behavior and target string formatting during restore.
  * Added tmux client tests for inside-tmux detection and attach no-op behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->