### PR TITLE
feat(picker): ASCII loading animation while a picked session restores

### DIFF
--- a/cmd/lazy-tmux/picker.go
+++ b/cmd/lazy-tmux/picker.go
@@ -97,6 +97,15 @@ func runPicker(args []string, stdout, stderr io.Writer) int {
 			writeErr(stderr, fmt.Errorf("select target: %w", err))
 			return 1
 		}
+
+		// The interactive TUI shows a loading animation while the pick restores.
+		err = tmuxApp.RestoreTargetAnimated(target)
+		if err != nil {
+			writeErr(stderr, fmt.Errorf("restore target: %w", err))
+			return 1
+		}
+
+		return 0
 	}
 
 	err = tmuxApp.RestoreTarget(target, true)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -154,52 +154,13 @@ func (a *App) Restore(session string, switchClient bool) error {
 }
 
 func (a *App) RestoreTarget(target PickerTarget, switchClient bool) error {
-	session := strings.TrimSpace(target.SessionName)
-	if session == "" {
-		return fmt.Errorf("empty session name")
-	}
-
-	snap, err := a.store.LoadSession(session)
+	err := a.restoreSessionForTarget(target)
 	if err != nil {
-		return fmt.Errorf("load session: %w", err)
-	}
-
-	err = a.tmux.RestoreSession(snap)
-	if err != nil && err != tmux.ErrSessionExists {
-		return fmt.Errorf("restore session: %w", err)
-	}
-
-	switchTarget := session
-	if target.WindowIndex != nil {
-		switchTarget = fmt.Sprintf("%s:%d", session, *target.WindowIndex)
-	}
-
-	// Mark accessed before any hand-off: AttachSession replaces this process, so
-	// nothing after it would run.
-	err = a.store.MarkSessionAccessed(
-		session,
-		time.Now().UTC(),
-	)
-	if err != nil &&
-		!errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("mark session accessed: %w", err)
+		return err
 	}
 
 	if switchClient {
-		// Inside tmux, hop the current client to the session. Outside tmux,
-		// attach so the user lands inside the restored session instead of being
-		// left at the shell with a detached session (#182).
-		if a.tmux.InsideTmux() {
-			err = a.tmux.SwitchClient(switchTarget)
-			if err != nil {
-				return fmt.Errorf("switch client: %w", err)
-			}
-		} else {
-			err = a.tmux.AttachSession(switchTarget)
-			if err != nil {
-				return fmt.Errorf("attach session: %w", err)
-			}
-		}
+		return a.handoffToTarget(target)
 	}
 
 	return nil
@@ -230,6 +191,61 @@ func (a *App) ListRecords() ([]snapshot.Record, error) {
 	}
 
 	return records, nil
+}
+
+// restoreSessionForTarget loads and restores the session (creating it if needed)
+// and marks it accessed. It does not switch or attach — that is handoffToTarget,
+// kept separate so the loading animation can run between the two.
+func (a *App) restoreSessionForTarget(target PickerTarget) error {
+	session := strings.TrimSpace(target.SessionName)
+	if session == "" {
+		return fmt.Errorf("empty session name")
+	}
+
+	snap, err := a.store.LoadSession(session)
+	if err != nil {
+		return fmt.Errorf("load session: %w", err)
+	}
+
+	err = a.tmux.RestoreSession(snap)
+	if err != nil && err != tmux.ErrSessionExists {
+		return fmt.Errorf("restore session: %w", err)
+	}
+
+	err = a.store.MarkSessionAccessed(session, time.Now().UTC())
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("mark session accessed: %w", err)
+	}
+
+	return nil
+}
+
+// handoffToTarget moves the user into the restored session: inside tmux it hops
+// the current client, outside tmux it attaches (so the user lands inside instead
+// of being left at the shell — #182). Outside tmux this replaces the process.
+func (a *App) handoffToTarget(target PickerTarget) error {
+	session := strings.TrimSpace(target.SessionName)
+
+	switchTarget := session
+	if target.WindowIndex != nil {
+		switchTarget = fmt.Sprintf("%s:%d", session, *target.WindowIndex)
+	}
+
+	if a.tmux.InsideTmux() {
+		err := a.tmux.SwitchClient(switchTarget)
+		if err != nil {
+			return fmt.Errorf("switch client: %w", err)
+		}
+
+		return nil
+	}
+
+	err := a.tmux.AttachSession(switchTarget)
+	if err != nil {
+		return fmt.Errorf("attach session: %w", err)
+	}
+
+	return nil
 }
 
 func (a *App) runDaemonSaveAll() error {

--- a/internal/app/app_picker.go
+++ b/internal/app/app_picker.go
@@ -134,8 +134,10 @@ func (a *App) RestoreTargetAnimated(target PickerTarget) error {
 		return restoreErr
 	}
 
+	// The animation is cosmetic: a render failure must not skip the hand-off and
+	// leave the session restored but never switched/attached. Log and continue.
 	if animErr != nil {
-		return fmt.Errorf("restore animation: %w", animErr)
+		log.Printf("lazy-tmux: restore animation: %v", animErr)
 	}
 
 	return a.handoffToTarget(target)

--- a/internal/app/app_picker.go
+++ b/internal/app/app_picker.go
@@ -111,6 +111,36 @@ func toPickerStatus(status integration.Status) picker.WindowStatus {
 	}
 }
 
+// RestoreTargetAnimated restores target while showing the ASCII loading field in
+// the terminal, then hands off (switch/attach). Used by the interactive TUI
+// picker so a slow restore shows motion instead of a black popup (#199). Without
+// a TTY the animation is a no-op and this behaves like RestoreTarget(_, true).
+func (a *App) RestoreTargetAnimated(target PickerTarget) error {
+	done := make(chan struct{})
+
+	var restoreErr error
+
+	go func() {
+		restoreErr = a.restoreSessionForTarget(target)
+		close(done)
+	}()
+
+	// Shows the field until done is closed; a no-op (returns immediately) without
+	// a TTY, so we always wait on done ourselves before handing off.
+	animErr := picker.RunRestoreAnimation(target.SessionName, done)
+	<-done
+
+	if restoreErr != nil {
+		return restoreErr
+	}
+
+	if animErr != nil {
+		return fmt.Errorf("restore animation: %w", animErr)
+	}
+
+	return a.handoffToTarget(target)
+}
+
 func (a *App) SelectTargetWithTUI() (PickerTarget, error) {
 	return a.SelectTargetWithTUISorted(DefaultPickerSortOptions())
 }

--- a/internal/picker/loading.go
+++ b/internal/picker/loading.go
@@ -146,8 +146,10 @@ func (m loadingModel) field(width, height int) string {
 		caption = "restoring " + m.name + "…"
 	}
 
+	// Center by display width; frameLine pads the rest of the row to innerW, so
+	// no stale field glyphs remain to the right of the caption.
 	captionRow := innerH / 2
-	capStart := max(0, (innerW-len([]rune(caption)))/2)
+	capStart := max(0, (innerW-displayWidth(caption))/2)
 
 	var buf strings.Builder
 

--- a/internal/picker/loading.go
+++ b/internal/picker/loading.go
@@ -1,0 +1,250 @@
+//go:build !lazy_fzf
+
+package picker
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+// The loading view ports the landing page's generative ASCII field
+// (docs/src/components/AsciiField.tsx) into the terminal: several drifting sine
+// waves interfere into a breathing field of glyphs, sparse-to-dense along the
+// ramp, with the brand amber lighting up the peaks. It fills the whole popup
+// while a picked session restores, so a slow restore shows motion instead of a
+// black screen (#199).
+const (
+	animFPS   = 30
+	animRamp  = " .·:-=+*#%@"
+	animGrace = 120 * time.Millisecond // don't flash the field on a fast restore
+)
+
+// frameMsg advances the animation; graceMsg reveals it after the grace period;
+// restoreDoneMsg quits once the background restore has finished.
+type (
+	frameMsg       struct{}
+	graceMsg       struct{}
+	restoreDoneMsg struct{}
+)
+
+type loadingModel struct {
+	name    string
+	done    <-chan struct{}
+	width   int
+	height  int
+	frame   int
+	started bool // grace elapsed → render the field (else stay invisible)
+
+	dim   lipgloss.Style
+	mid   lipgloss.Style
+	hot   lipgloss.Style
+	label lipgloss.Style
+}
+
+func newLoadingModel(sessionName string, done <-chan struct{}) loadingModel {
+	return loadingModel{
+		name:  strings.TrimSpace(sessionName),
+		done:  done,
+		dim:   lipgloss.NewStyle().Foreground(lipgloss.Color(colFaint)),
+		mid:   lipgloss.NewStyle().Foreground(lipgloss.Color(colText)),
+		hot:   lipgloss.NewStyle().Foreground(lipgloss.Color(colAccent)),
+		label: lipgloss.NewStyle().Foreground(lipgloss.Color(colAccent)).Bold(true),
+	}
+}
+
+func (m loadingModel) Init() tea.Cmd {
+	return tea.Batch(
+		waitForRestore(m.done),
+		tea.Tick(animGrace, func(time.Time) tea.Msg { return graceMsg{} }),
+	)
+}
+
+// waitForRestore blocks in tea's goroutine until the restore signals completion.
+func waitForRestore(done <-chan struct{}) tea.Cmd {
+	return func() tea.Msg {
+		<-done
+		return restoreDoneMsg{}
+	}
+}
+
+func frameTick() tea.Cmd {
+	return tea.Tick(time.Second/animFPS, func(time.Time) tea.Msg { return frameMsg{} })
+}
+
+func (m loadingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+
+		return m, nil
+	case graceMsg:
+		m.started = true
+
+		return m, frameTick()
+	case frameMsg:
+		m.frame++
+
+		return m, frameTick()
+	case restoreDoneMsg:
+		return m, tea.Quit
+	case tea.KeyPressMsg:
+		// Let the user bail out; the restore still finishes in the background.
+		if s := msg.String(); s == "ctrl+c" || s == "esc" || s == "q" {
+			return m, tea.Quit
+		}
+	}
+
+	return m, nil
+}
+
+func (m loadingModel) View() tea.View {
+	// Before the grace period elapses we render nothing (and stay off the alt
+	// screen) so a restore that finishes quickly never flashes the animation.
+	if !m.started {
+		return tea.NewView("")
+	}
+
+	width, height := m.width, m.height
+	if width <= 0 {
+		width = 80
+	}
+
+	if height <= 0 {
+		height = 24
+	}
+
+	view := tea.NewView(m.field(width, height))
+	view.AltScreen = true
+
+	return view
+}
+
+// field renders one animation frame: a width×height grid of ramp glyphs from the
+// interfering-sine field, with a centered "restoring <name>…" caption.
+func (m loadingModel) field(width, height int) string {
+	phase := float64(m.frame) / animFPS
+	cols := float64(width)
+	rows := float64(height)
+
+	caption := "restoring…"
+	if m.name != "" {
+		caption = "restoring " + m.name + "…"
+	}
+
+	captionRow := height / 2
+	capStart := max(0, (width-len([]rune(caption)))/2)
+
+	var buf strings.Builder
+
+	for row := range height {
+		// The caption owns its row: a clean band keeps it readable over the field.
+		if row == captionRow {
+			buf.WriteString(strings.Repeat(" ", capStart) + m.label.Render(caption))
+		} else {
+			m.writeFieldRow(&buf, row, width, cols, rows, phase)
+		}
+
+		if row < height-1 {
+			buf.WriteByte('\n')
+		}
+	}
+
+	return buf.String()
+}
+
+// writeFieldRow renders one field row, grouping runs of same-styled glyphs so
+// each frame emits few ANSI escapes.
+func (m loadingModel) writeFieldRow(
+	buf *strings.Builder,
+	row, width int,
+	cols, rows, phase float64,
+) {
+	var (
+		run   strings.Builder
+		tier  = -1
+		flush = func(next int) {
+			if run.Len() > 0 {
+				buf.WriteString(m.styleFor(tier).Render(run.String()))
+				run.Reset()
+			}
+
+			tier = next
+		}
+	)
+
+	for col := range width {
+		glyph, level := fieldGlyph(float64(col), float64(row), cols, rows, phase)
+		if level != tier {
+			flush(level)
+		}
+
+		run.WriteRune(glyph)
+	}
+
+	flush(-1)
+}
+
+func (m loadingModel) styleFor(tier int) lipgloss.Style {
+	switch tier {
+	case 2:
+		return m.hot
+	case 1:
+		return m.mid
+	default:
+		return m.dim
+	}
+}
+
+// fieldGlyph computes the ramp glyph and color tier (0 dim, 1 mid, 2 hot) for the
+// cell at (col,row), mirroring the landing page's sine-interference math. Short
+// names (x/y/v) match that formula.
+//
+//nolint:varnamelen // math formula reads best with x/y/v
+func fieldGlyph(col, row, cols, rows, phase float64) (rune, int) {
+	x := col * 0.18
+	y := row * 0.28
+
+	v := math.Sin(x+phase*0.6) +
+		math.Sin(y*0.8-phase*0.5) +
+		math.Sin((x+y)*0.5+phase*0.4) +
+		math.Sin(math.Hypot(x-cols*0.09, y-rows*0.14)-phase*0.8)
+	v /= 4
+	v = math.Max(0, math.Min(1, (v+1)/2))
+
+	ramp := []rune(animRamp)
+	glyph := ramp[int(v*float64(len(ramp)-1))]
+
+	switch {
+	case glyph == ' ':
+		return ' ', 0
+	case v > 0.86:
+		return glyph, 2
+	case v > 0.5:
+		return glyph, 1
+	default:
+		return glyph, 0
+	}
+}
+
+// RunRestoreAnimation shows the loading field until done is closed. Without a
+// controlling terminal (tests, piped output) it is a no-op and the caller waits
+// on done itself.
+func RunRestoreAnimation(sessionName string, done <-chan struct{}) error {
+	if !isTerminal(os.Stdout) {
+		return nil
+	}
+
+	_, err := tea.NewProgram(newLoadingModel(sessionName, done)).Run()
+	if err != nil {
+		return fmt.Errorf("run restore animation: %w", err)
+	}
+
+	return nil
+}

--- a/internal/picker/loading.go
+++ b/internal/picker/loading.go
@@ -41,6 +41,7 @@ type loadingModel struct {
 	frame   int
 	started bool // grace elapsed → render the field (else stay invisible)
 
+	theme pickerTheme
 	dim   lipgloss.Style
 	mid   lipgloss.Style
 	hot   lipgloss.Style
@@ -51,6 +52,7 @@ func newLoadingModel(sessionName string, done <-chan struct{}) loadingModel {
 	return loadingModel{
 		name:  strings.TrimSpace(sessionName),
 		done:  done,
+		theme: newPickerTheme(colAccent),
 		dim:   lipgloss.NewStyle().Foreground(lipgloss.Color(colFaint)),
 		mid:   lipgloss.NewStyle().Foreground(lipgloss.Color(colText)),
 		hot:   lipgloss.NewStyle().Foreground(lipgloss.Color(colAccent)),
@@ -126,47 +128,57 @@ func (m loadingModel) View() tea.View {
 	return view
 }
 
-// field renders one animation frame: a width×height grid of ramp glyphs from the
-// interfering-sine field, with a centered "restoring <name>…" caption.
+// field renders one animation frame inside the picker's rounded frame (same
+// border, corners and title as the browser), with the ASCII field filling the
+// inner area and a centered "restoring <name>…" caption.
 func (m loadingModel) field(width, height int) string {
+	// The frame owns the outer edge: 2 border rows (top/bottom) and, per inner
+	// row, 2 side borders + 2 gutter spaces (see theme.frameLine).
+	innerW := max(1, width-4)
+	innerH := max(1, height-2)
+
 	phase := float64(m.frame) / animFPS
-	cols := float64(width)
-	rows := float64(height)
+	cols := float64(innerW)
+	rows := float64(innerH)
 
 	caption := "restoring…"
 	if m.name != "" {
 		caption = "restoring " + m.name + "…"
 	}
 
-	captionRow := height / 2
-	capStart := max(0, (width-len([]rune(caption)))/2)
+	captionRow := innerH / 2
+	capStart := max(0, (innerW-len([]rune(caption)))/2)
 
 	var buf strings.Builder
 
-	for row := range height {
+	buf.WriteString(m.theme.frameTop("lazy-tmux", "", width))
+	buf.WriteString("\n")
+
+	for row := range innerH {
+		var line string
+
 		// The caption owns its row: a clean band keeps it readable over the field.
 		if row == captionRow {
-			buf.WriteString(strings.Repeat(" ", capStart) + m.label.Render(caption))
+			line = strings.Repeat(" ", capStart) + m.label.Render(caption)
 		} else {
-			m.writeFieldRow(&buf, row, width, cols, rows, phase)
+			line = m.fieldRow(row, innerW, cols, rows, phase)
 		}
 
-		if row < height-1 {
-			buf.WriteByte('\n')
-		}
+		buf.WriteString(m.theme.frameLine(line, width))
+		buf.WriteString("\n")
 	}
+
+	hints := m.theme.helpKey.Render("esc") + m.theme.helpText.Render(" cancel")
+	buf.WriteString(m.theme.frameBottom(hints, width))
 
 	return buf.String()
 }
 
-// writeFieldRow renders one field row, grouping runs of same-styled glyphs so
+// fieldRow renders one inner field row, grouping runs of same-styled glyphs so
 // each frame emits few ANSI escapes.
-func (m loadingModel) writeFieldRow(
-	buf *strings.Builder,
-	row, width int,
-	cols, rows, phase float64,
-) {
+func (m loadingModel) fieldRow(row, width int, cols, rows, phase float64) string {
 	var (
+		buf   strings.Builder
 		run   strings.Builder
 		tier  = -1
 		flush = func(next int) {
@@ -189,6 +201,8 @@ func (m loadingModel) writeFieldRow(
 	}
 
 	flush(-1)
+
+	return buf.String()
 }
 
 func (m loadingModel) styleFor(tier int) lipgloss.Style {

--- a/internal/picker/loading_fzf.go
+++ b/internal/picker/loading_fzf.go
@@ -1,0 +1,9 @@
+//go:build lazy_fzf
+
+package picker
+
+// RunRestoreAnimation is a no-op in the fzf-only build (no TUI to draw into);
+// the caller waits on done itself.
+func RunRestoreAnimation(_ string, _ <-chan struct{}) error {
+	return nil
+}

--- a/internal/picker/loading_test.go
+++ b/internal/picker/loading_test.go
@@ -1,0 +1,80 @@
+//go:build !lazy_fzf
+
+package picker
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestLoadingViewHiddenBeforeGrace(t *testing.T) {
+	m := newLoadingModel("blog", make(chan struct{}))
+	m.width, m.height = 80, 24
+
+	// Before the grace period (started=false) nothing renders, and we stay off
+	// the alt screen so a fast restore never flashes.
+	view := m.View()
+	if strings.TrimSpace(view.Content) != "" {
+		t.Fatalf("expected empty pre-grace view, got %q", view.Content)
+	}
+
+	if view.AltScreen {
+		t.Fatal("pre-grace view must not enter the alt screen")
+	}
+}
+
+func TestLoadingViewRendersFieldAndCaption(t *testing.T) {
+	m := newLoadingModel("blog", make(chan struct{}))
+	m.width, m.height = 80, 24
+	m.started = true
+	m.frame = 10
+
+	view := m.View()
+	if !view.AltScreen {
+		t.Fatal("animated view should use the alt screen")
+	}
+
+	lines := strings.Split(view.Content, "\n")
+	if len(lines) != 24 {
+		t.Fatalf("expected 24 rows, got %d", len(lines))
+	}
+
+	if !strings.Contains(view.Content, "restoring blog…") {
+		t.Fatal("expected the centered restoring caption")
+	}
+
+	// The field should contain at least one non-space ramp glyph somewhere.
+	if !strings.ContainsAny(view.Content, ".·:-=+*#%@") {
+		t.Fatal("expected the ascii field to render ramp glyphs")
+	}
+}
+
+func TestLoadingQuitsWhenRestoreDone(t *testing.T) {
+	m := newLoadingModel("x", make(chan struct{}))
+
+	_, cmd := m.Update(restoreDoneMsg{})
+	if cmd == nil {
+		t.Fatal("restoreDoneMsg must return a command")
+	}
+
+	if msg := cmd(); msg == nil {
+		t.Fatal("expected a quit message")
+	} else if _, ok := msg.(tea.QuitMsg); !ok {
+		t.Fatalf("expected tea.QuitMsg, got %T", msg)
+	}
+}
+
+func TestLoadingGraceRevealsField(t *testing.T) {
+	m := newLoadingModel("x", make(chan struct{}))
+
+	updated, cmd := m.Update(graceMsg{})
+	if !updated.(loadingModel).started {
+		t.Fatal("graceMsg must reveal the field (started=true)")
+	}
+
+	if cmd == nil {
+		t.Fatal("graceMsg must start the frame ticker")
+	}
+}

--- a/internal/picker/loading_test.go
+++ b/internal/picker/loading_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 )
 
 func TestLoadingViewHiddenBeforeGrace(t *testing.T) {
@@ -48,6 +49,21 @@ func TestLoadingViewRendersFieldAndCaption(t *testing.T) {
 	// The field should contain at least one non-space ramp glyph somewhere.
 	if !strings.ContainsAny(view.Content, ".·:-=+*#%@") {
 		t.Fatal("expected the ascii field to render ramp glyphs")
+	}
+
+	// The animation lives inside the picker's rounded frame.
+	for _, corner := range []string{"╭", "╮", "╰", "╯", "│"} {
+		if !strings.Contains(view.Content, corner) {
+			t.Fatalf("expected the rounded frame char %q around the animation", corner)
+		}
+	}
+
+	// Every framed line must be the same display width, or the border misaligns.
+	want := ansi.StringWidth(lines[0])
+	for i, ln := range lines {
+		if got := ansi.StringWidth(ln); got != want {
+			t.Fatalf("line %d width %d != %d: %q", i, got, want, ln)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

Picking a session in the TUI picker could leave the tmux popup **black for several seconds** while restore waited for pane commands to start — it looked frozen. This renders the landing page's generative ASCII field across the whole popup during restore instead, so the wait shows motion and reads as "restoring…".

Closes #199.

## How

- **`internal/picker/loading.go`** — a Bubble Tea model that ports the landing `AsciiField.tsx` field to the terminal: interfering sine waves over the ramp ` .·:-=+*#%@`, brand amber (`colAccent`) on the peaks, with a centered `restoring <name>…` caption. A ~120ms **grace** keeps a fast restore from flashing the animation (and it stays off the alt screen until the grace elapses). Runs at 30fps; groups same-styled runs so each frame emits few ANSI escapes. `ctrl+c`/`esc`/`q` bail out (restore still finishes in the background).
- **`internal/app`** — split `RestoreTarget` into `restoreSessionForTarget` (load + restore + mark accessed) and `handoffToTarget` (switch inside tmux / attach outside, per #183). New `RestoreTargetAnimated` restores in a goroutine while the animation runs, then hands off. No-op animation without a TTY, so scripted/headless restores are unaffected.
- **`cmd/lazy-tmux/picker.go`** — the interactive TUI path uses `RestoreTargetAnimated`; the fzf paths and `restore`/`bootstrap` keep the plain `RestoreTarget`.
- **`internal/picker/loading_fzf.go`** — no-op `RunRestoreAnimation` for the fzf-only build.

## Tests

- `loading_test.go`: hidden/off-alt-screen before grace; renders 24 rows + caption + ramp glyphs after grace; `restoreDoneMsg` quits; `graceMsg` reveals + starts the ticker.
- `make build build-fzf`, `make test` (198 tests), `make golangci-lint` (0 issues) all green.

## Notes

- Terminal-cell port of the canvas animation (the pointer ripple is dropped — no mouse in the popup). Frame phase is driven by a frame counter, so it's deterministic and testable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an animated “restoring…” terminal screen (with a short grace period) while restoring a picked session, then automatically completes the handoff.
* **Bug Fixes**
  * Improved the default restore flow so the selected session is restored first, making switching/attachment more reliable.
  * Animation timing is decoupled from the restore result (restoration failures still surface).
* **Tests**
  * Added unit tests covering animation rendering, grace timing, and proper quit/update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->