### PR TITLE
fix(restore): attach outside tmux only from the interactive picker, keep restore scriptable

### DIFF
--- a/cmd/lazy-tmux/picker.go
+++ b/cmd/lazy-tmux/picker.go
@@ -108,7 +108,9 @@ func runPicker(args []string, stdout, stderr io.Writer) int {
 		return 0
 	}
 
-	err = tmuxApp.RestoreTarget(target, true)
+	// The fzf engine is also an interactive picker: attach into the pick even
+	// from a plain shell (no animation — it has no TUI to draw into).
+	err = tmuxApp.RestoreTargetInteractive(target)
 	if err != nil {
 		writeErr(stderr, fmt.Errorf("restore target: %w", err))
 		return 1

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -160,7 +160,9 @@ func (a *App) RestoreTarget(target PickerTarget, switchClient bool) error {
 	}
 
 	if switchClient {
-		return a.handoffToTarget(target)
+		// CLI restore/bootstrap: switch inside tmux, but never attach outside it —
+		// keep it scriptable.
+		return a.handoffToTarget(target, false)
 	}
 
 	return nil
@@ -220,10 +222,13 @@ func (a *App) restoreSessionForTarget(target PickerTarget) error {
 	return nil
 }
 
-// handoffToTarget moves the user into the restored session: inside tmux it hops
-// the current client, outside tmux it attaches (so the user lands inside instead
-// of being left at the shell — #182). Outside tmux this replaces the process.
-func (a *App) handoffToTarget(target PickerTarget) error {
+// handoffToTarget moves the user into the restored session. Inside tmux it hops
+// the current client to the session. Outside tmux it attaches only when
+// allowAttach is set — that path is reserved for the interactive picker, where
+// the user picked a session and wants to land in it. Plain CLI commands
+// (restore/bootstrap) pass allowAttach=false so they stay scriptable and don't
+// hijack the terminal with a blocking attach.
+func (a *App) handoffToTarget(target PickerTarget, allowAttach bool) error {
 	session := strings.TrimSpace(target.SessionName)
 
 	switchTarget := session
@@ -237,6 +242,12 @@ func (a *App) handoffToTarget(target PickerTarget) error {
 			return fmt.Errorf("switch client: %w", err)
 		}
 
+		return nil
+	}
+
+	// Outside tmux: attach only for the interactive picker; otherwise leave the
+	// session restored-but-detached so scripts aren't blocked (#182/#183).
+	if !allowAttach {
 		return nil
 	}
 

--- a/internal/app/app_picker.go
+++ b/internal/app/app_picker.go
@@ -140,7 +140,21 @@ func (a *App) RestoreTargetAnimated(target PickerTarget) error {
 		log.Printf("lazy-tmux: restore animation: %v", animErr)
 	}
 
-	return a.handoffToTarget(target)
+	// allowAttach: the user picked this session interactively and wants to land
+	// in it, even from a plain shell outside tmux.
+	return a.handoffToTarget(target, true)
+}
+
+// RestoreTargetInteractive restores target and hands off, attaching outside tmux
+// (the user picked it interactively). Used by the fzf picker engine, which has
+// no TUI to draw the loading animation into.
+func (a *App) RestoreTargetInteractive(target PickerTarget) error {
+	err := a.restoreSessionForTarget(target)
+	if err != nil {
+		return err
+	}
+
+	return a.handoffToTarget(target, true)
 }
 
 func (a *App) SelectTargetWithTUI() (PickerTarget, error) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -44,15 +44,28 @@ func TestRestoreTargetHandsOff(t *testing.T) {
 
 	cases := []struct {
 		name         string
+		interactive  bool // RestoreTargetInteractive vs. the plain CLI RestoreTarget
 		inside       bool
 		windowIndex  *int
 		wantSwitched string
 		wantAttached string
 	}{
-		{name: "inside tmux switches", inside: true, wantSwitched: "s1"},
-		{name: "outside tmux attaches", inside: false, wantAttached: "s1"},
+		// Inside tmux both paths switch the client.
+		{name: "cli inside tmux switches", inside: true, wantSwitched: "s1"},
+		{name: "picker inside tmux switches", interactive: true, inside: true, wantSwitched: "s1"},
+
+		// Outside tmux only the interactive picker attaches; the plain CLI restore
+		// stays scriptable and does neither.
+		{name: "cli outside tmux does not attach", inside: false},
 		{
-			name:         "outside tmux attaches to window",
+			name:         "picker outside tmux attaches",
+			interactive:  true,
+			inside:       false,
+			wantAttached: "s1",
+		},
+		{
+			name:         "picker outside tmux attaches to window",
+			interactive:  true,
 			inside:       false,
 			windowIndex:  &idx,
 			wantAttached: "s1:2",
@@ -70,10 +83,15 @@ func TestRestoreTargetHandsOff(t *testing.T) {
 			fake := &recordingTmux{inside: tc.inside}
 			a.tmux = fake
 
-			err := a.RestoreTarget(
-				PickerTarget{SessionName: "s1", WindowIndex: tc.windowIndex},
-				true,
-			)
+			target := PickerTarget{SessionName: "s1", WindowIndex: tc.windowIndex}
+
+			var err error
+			if tc.interactive {
+				err = a.RestoreTargetInteractive(target)
+			} else {
+				err = a.RestoreTarget(target, true)
+			}
+
 			if err != nil {
 				t.Fatalf("restore target: %v", err)
 			}


### PR DESCRIPTION
## Problem

The outside-tmux `attach-session` added in #182/#183 was wired into **every** restore path via `handoffToTarget`. That meant `lazy-tmux restore <name>` run from a plain shell would attach (a blocking call that replaces the process), hijacking the terminal and breaking scriptability. Attaching should only happen when the user picks a session **interactively**.

## Fix

Reserve the outside-tmux attach for interactive picks:

- `handoffToTarget(target, allowAttach)`: inside tmux it always `switch-client`s; outside tmux it `attach-session`s **only when `allowAttach` is true**, otherwise it leaves the session restored-but-detached.
- `RestoreTarget` (used by the `restore` and `bootstrap` CLI commands) passes `allowAttach=false` → restores, switches the client when already inside tmux, but never attaches from a plain shell. Scriptable again, matching the pre-#183 behavior.
- The interactive pickers pass `allowAttach=true`:
  - TUI picker → `RestoreTargetAnimated` (restore + loading animation + hand-off), so pressing Enter on a sleeping session restores it *while the animation plays* and then drops you straight in.
  - fzf engine → new `RestoreTargetInteractive` (same hand-off, no animation — it has no TUI to draw into).
- `wakeup` is unchanged (it already restores without switching).

## Behavior matrix

| Entry point | Inside tmux | Outside tmux |
|---|---|---|
| `restore` / `bootstrap` (CLI) | switch-client | **nothing** (scriptable) |
| TUI picker (Enter) | switch-client | attach (after animation) |
| fzf picker | switch-client | attach |

## Tests

- `TestRestoreTargetHandsOff` reworked into a matrix: CLI restore switches inside tmux and does **not** attach outside; the interactive path attaches outside (incl. `session:window`).
- `make build build-fzf`, `make test` (200), `make golangci-lint` (0 issues) green.

Follow-up to #182/#183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a distinct interactive restore flow for picker-based selection, improving how restored sessions are handled after choosing a target.

* **Bug Fixes**
  * Restoring from the command line now switches within tmux without unexpectedly attaching a separate terminal session.
  * Interactive restores continue to attach as expected, both inside and outside tmux.

* **Tests**
  * Expanded coverage to verify different restore behavior for interactive and non-interactive paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->