### PR TITLE
feat(restore): add restore_denylist to block specific commands on restore

### DIFF
--- a/docs/src/pages/Configuration.tsx
+++ b/docs/src/pages/Configuration.tsx
@@ -7,7 +7,7 @@ export function Configuration() {
     <>
       <Seo
         title="Configuration — lazy-tmux"
-        description="lazy-tmux TOML config file: lookup order, precedence, restore command allowlist and restore settle timeout."
+        description="lazy-tmux TOML config file: lookup order, precedence, restore command allow/denylist and restore settle timeout."
         slug="configuration"
       />
       <section className="doc-section">
@@ -50,6 +50,12 @@ restore_timeout = "5s"                         # max wait for restored pane comm
 # only those programs; use an empty list [] to restore no commands at all.
 restore_allowlist = ["nvim", "vim", "htop", "less", "tail", "ssh"]
 
+# Denylist of commands lazy-tmux must never replay, matched by program name.
+# Use this instead of an allowlist when you trust most commands and only want to
+# exclude a few. The denylist wins over the allowlist. Omit or leave empty to
+# block nothing (default).
+restore_denylist = ["npm", "node"]
+
 [scrollback]
 enabled = false   # capture shell pane scrollback
 lines   = 5000    # max scrollback lines per pane`}</CodeBlock>
@@ -78,6 +84,18 @@ lines   = 5000    # max scrollback lines per pane`}</CodeBlock>
         <p className="muted">
           Matching is by program name, so <InlineCode>nvim</InlineCode> also
           matches <InlineCode>/usr/bin/nvim main.go</InlineCode>.
+        </p>
+
+        <h3 className="cli-subtitle">Restore command denylist</h3>
+        <p className="muted">
+          The inverse of the allowlist: rather than enumerating everything you
+          trust, list only the few programs to block with{" "}
+          <InlineCode>restore_denylist</InlineCode>. Handy when you trust almost
+          everything and just want to stop a long-running server or a program
+          that re-prompts from being replayed. It composes with the allowlist and{" "}
+          <strong>wins over it</strong> — a command is replayed only when it is
+          not denied and (no allowlist is set or it is allowed). Matching is by
+          program name, and an omitted or empty list blocks nothing.
         </p>
 
         <h3 className="cli-subtitle">Restore settle timeout</h3>

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -65,6 +65,7 @@ func New(cfg config.Config) *App {
 	client := tmux.NewClient(config.ExpandHome(cfg.TmuxBin))
 	client.SetRestoreTimeout(cfg.RestoreTimeout)
 	client.SetRestoreAllowlist(cfg.RestoreAllowlist)
+	client.SetRestoreDenylist(cfg.RestoreDenylist)
 
 	registry := buildRegistry(cfg.Integrations, ClaudeStatusDir(cfg.DataDir))
 	client.SetRestoreResolver(registry)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,14 @@ type Config struct {
 	// one — activates the allowlist: only the listed commands are restored, and
 	// an empty list restores none.
 	RestoreAllowlist []string
+
+	// RestoreDenylist blocks specific commands from being replayed on restore,
+	// matched by executable name. It is the inverse of RestoreAllowlist: instead
+	// of enumerating everything you trust, you list only the few programs to
+	// exclude. The denylist wins over the allowlist — a command is replayed only
+	// when it is not denied and (no allowlist is set or it is allowed). A nil or
+	// empty slice blocks nothing (the default).
+	RestoreDenylist []string
 }
 
 type ScrollbackConfig struct {
@@ -142,6 +150,7 @@ type fileConfig struct {
 	SaveInterval     *duration             `toml:"save_interval"`
 	RestoreTimeout   *duration             `toml:"restore_timeout"`
 	RestoreAllowlist *[]string             `toml:"restore_allowlist"`
+	RestoreDenylist  *[]string             `toml:"restore_denylist"`
 	Scrollback       *fileScrollbackConf   `toml:"scrollback"`
 	Integrations     *fileIntegrationsConf `toml:"integrations"`
 }
@@ -190,6 +199,12 @@ func (cfg Config) withFile(file fileConfig) Config {
 		}
 
 		cfg.RestoreAllowlist = allowlist
+	}
+
+	if file.RestoreDenylist != nil {
+		// Unlike the allowlist, the denylist has no "configured-but-empty"
+		// meaning: an empty list simply blocks nothing, so a plain copy is fine.
+		cfg.RestoreDenylist = *file.RestoreDenylist
 	}
 
 	if file.Scrollback != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -216,6 +216,30 @@ func TestLoadFromRestoreAllowlist(t *testing.T) {
 	}
 }
 
+func TestLoadFromRestoreDenylist(t *testing.T) {
+	// Absent key -> nil (nothing blocked).
+	cfg, err := LoadFrom(writeConfig(t, "tmux_bin = \"tmux\"\n"))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if cfg.RestoreDenylist != nil {
+		t.Fatalf("absent denylist should be nil, got %#v", cfg.RestoreDenylist)
+	}
+
+	// Populated list.
+	cfg, err = LoadFrom(writeConfig(t, "restore_denylist = [\"npm\", \"node\"]\n"))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if len(cfg.RestoreDenylist) != 2 ||
+		cfg.RestoreDenylist[0] != "npm" ||
+		cfg.RestoreDenylist[1] != "node" {
+		t.Fatalf("denylist: got %#v", cfg.RestoreDenylist)
+	}
+}
+
 func TestLoadFromUnknownKeyErrors(t *testing.T) {
 	// A typo'd key must fail loudly rather than be silently ignored.
 	path := writeConfig(t, "tmux_binn = \"tmux\"\n")

--- a/internal/config/default.toml
+++ b/internal/config/default.toml
@@ -29,6 +29,13 @@ restore_timeout = "5s"
 # programs; use an empty list [] to restore no commands at all.
 # restore_allowlist = ["nvim", "vim", "htop", "less", "tail", "ssh"]
 
+# Denylist of commands lazy-tmux must never replay on restore, matched by program
+# name. Use this instead of an allowlist when you trust most commands and only
+# want to exclude a few (e.g. long-running servers). The denylist wins over the
+# allowlist: a denied command is skipped even if the allowlist would permit it.
+# Omit or leave empty to block nothing (the default).
+# restore_denylist = ["htop", "npm", "node"]
+
 [scrollback]
 # Capture and replay shell pane scrollback on save/restore.
 enabled = false

--- a/internal/config/gen.go
+++ b/internal/config/gen.go
@@ -78,6 +78,17 @@ func (c Config) Render() string {
 		fmt.Fprintf(&buf, "restore_allowlist = [%s]\n", strings.Join(quoted, ", "))
 	}
 
+	if len(c.RestoreDenylist) == 0 {
+		buf.WriteString("# restore_denylist not set (no command is blocked)\n")
+	} else {
+		quoted := make([]string, len(c.RestoreDenylist))
+		for i, cmd := range c.RestoreDenylist {
+			quoted[i] = strconv.Quote(cmd)
+		}
+
+		fmt.Fprintf(&buf, "restore_denylist = [%s]\n", strings.Join(quoted, ", "))
+	}
+
 	buf.WriteString("\n[scrollback]\n")
 	fmt.Fprintf(&buf, "enabled = %t\n", c.Scrollback.Enabled)
 	fmt.Fprintf(&buf, "lines   = %d\n", c.Scrollback.Lines)

--- a/internal/config/gen_test.go
+++ b/internal/config/gen_test.go
@@ -59,6 +59,7 @@ func TestRenderEffectiveConfig(t *testing.T) {
 		"save_interval",
 		"[scrollback]",
 		"restore_allowlist not set",
+		"restore_denylist not set",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("render missing %q in:\n%s", want, out)
@@ -68,5 +69,10 @@ func TestRenderEffectiveConfig(t *testing.T) {
 	cfg.RestoreAllowlist = []string{"nvim", "vim"}
 	if got := cfg.Render(); !strings.Contains(got, `restore_allowlist = ["nvim", "vim"]`) {
 		t.Fatalf("render allowlist wrong:\n%s", got)
+	}
+
+	cfg.RestoreDenylist = []string{"npm", "node"}
+	if got := cfg.Render(); !strings.Contains(got, `restore_denylist = ["npm", "node"]`) {
+		t.Fatalf("render denylist wrong:\n%s", got)
 	}
 }

--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -94,6 +94,11 @@ type Client struct {
 	allowlist    map[string]struct{}
 	allowlistSet bool
 
+	// denylist blocks specific commands from being replayed, keyed by executable
+	// name. It takes precedence over the allowlist: a denied command is never
+	// restored even when the allowlist would permit it.
+	denylist map[string]struct{}
+
 	// resolver lets a program-integration registry override the restore command
 	// for a pane (e.g. `claude --resume <id>`). nil keeps the default behavior.
 	resolver RestoreCommandResolver
@@ -155,6 +160,28 @@ func (client *Client) SetRestoreAllowlist(list []string) {
 		name := executableName(strings.TrimSpace(item))
 		if name != "" {
 			client.allowlist[name] = struct{}{}
+		}
+	}
+}
+
+// SetRestoreDenylist configures which commands RestoreSession must never replay,
+// matched by executable name. It composes with the allowlist and wins over it: a
+// denied command is skipped even when an allowlist would permit it. A nil or
+// empty slice blocks nothing. List entries are normalized to their executable
+// name, so both "node" and "/usr/bin/node" match a pane running node.
+func (client *Client) SetRestoreDenylist(list []string) {
+	if len(list) == 0 {
+		client.denylist = nil
+
+		return
+	}
+
+	client.denylist = make(map[string]struct{}, len(list))
+
+	for _, item := range list {
+		name := executableName(strings.TrimSpace(item))
+		if name != "" {
+			client.denylist[name] = struct{}{}
 		}
 	}
 }
@@ -825,9 +852,14 @@ func (client *Client) restoreWindowCommands(
 }
 
 // commandAllowed reports whether a command with the given executable name may be
-// restored under the current allowlist. With no allowlist configured every
-// command is allowed.
+// restored. The denylist wins over the allowlist: a denied command is never
+// restored. Otherwise, with no allowlist configured every command is allowed;
+// with one configured only listed commands are.
 func (client *Client) commandAllowed(executable string) bool {
+	if _, denied := client.denylist[executable]; denied {
+		return false
+	}
+
 	if !client.allowlistSet {
 		return true
 	}

--- a/internal/tmux/client_test.go
+++ b/internal/tmux/client_test.go
@@ -212,6 +212,58 @@ func TestRestoreAllowlist(t *testing.T) {
 	}
 }
 
+func TestRestoreDenylist(t *testing.T) {
+	client := NewClient("tmux")
+
+	// No denylist configured: everything is allowed.
+	if !client.commandAllowed("node") {
+		t.Fatal("with no denylist, all commands must be allowed")
+	}
+
+	// Configured denylist: listed executables are blocked (path entries normalized).
+	client.SetRestoreDenylist([]string{"node", "/usr/bin/htop", "  npm  "})
+
+	for _, blocked := range []string{"node", "htop", "npm"} {
+		if client.commandAllowed(blocked) {
+			t.Fatalf("%q should be blocked", blocked)
+		}
+	}
+
+	for _, allowed := range []string{"nvim", "vim", "less"} {
+		if !client.commandAllowed(allowed) {
+			t.Fatalf("%q should be allowed", allowed)
+		}
+	}
+
+	// Clearing with nil (or empty) restores allow-all behavior.
+	client.SetRestoreDenylist(nil)
+
+	if !client.commandAllowed("node") {
+		t.Fatal("a nil denylist must allow all commands again")
+	}
+}
+
+func TestRestoreDenylistWinsOverAllowlist(t *testing.T) {
+	client := NewClient("tmux")
+
+	// A command in both lists is blocked: the denylist takes precedence.
+	client.SetRestoreAllowlist([]string{"nvim", "node"})
+	client.SetRestoreDenylist([]string{"node"})
+
+	if !client.commandAllowed("nvim") {
+		t.Fatal("nvim is allowed and not denied -> should be restored")
+	}
+
+	if client.commandAllowed("node") {
+		t.Fatal("node is denied -> must be blocked even though the allowlist permits it")
+	}
+
+	// A command that is neither allowed nor denied stays blocked by the allowlist.
+	if client.commandAllowed("htop") {
+		t.Fatal("htop is not in the allowlist -> should stay blocked")
+	}
+}
+
 func TestExpectedPaneCommandsRespectsAllowlist(t *testing.T) {
 	windows := []snapshot.Window{
 		{

--- a/internal/tmux/integration_test.go
+++ b/internal/tmux/integration_test.go
@@ -165,15 +165,31 @@ func TestRestoreWaitsForCommandsToStart(t *testing.T) {
 // allowlist configured, only permitted commands are replayed; a disallowed
 // command leaves its pane at the shell.
 func TestRestoreAllowlistFiltersCommands(t *testing.T) {
+	assertGuardedRestore(t, "guarded", func(client *tmux.Client) {
+		client.SetRestoreAllowlist([]string{"cat"}) // allow cat, block everything else
+	})
+}
+
+// TestRestoreDenylistBlocksCommands covers issue #203 end-to-end: a command in
+// the denylist is not replayed even with no allowlist configured; other panes
+// still restore normally.
+func TestRestoreDenylistBlocksCommands(t *testing.T) {
+	assertGuardedRestore(t, "denied", func(client *tmux.Client) {
+		client.SetRestoreDenylist([]string{"tail"}) // block tail, restore everything else
+	})
+}
+
+// assertGuardedRestore restores a two-pane session (pane 0 = cat, pane 1 = tail)
+// through a client configured by configure, then asserts the allowed pane runs
+// cat while the blocked pane does not run tail. Both commands block on stdin, so
+// a restored command shows up as the pane's foreground command.
+func assertGuardedRestore(t *testing.T, name string, configure func(*tmux.Client)) {
+	t.Helper()
 	testutil.IsolatedTmux(t)
 
 	client := tmux.NewClient("tmux")
-	client.SetRestoreAllowlist([]string{"cat"}) // allow cat, block everything else
+	configure(client)
 
-	const name = "guarded"
-
-	// Two panes: one runs an allowed command (cat), one a blocked command (tail).
-	// Both block on stdin, so if restored they would show as the foreground cmd.
 	snap := snapshot.SessionSnapshot{
 		Version:     snapshot.FormatVersion,
 		SessionName: name,
@@ -211,7 +227,7 @@ func TestRestoreAllowlistFiltersCommands(t *testing.T) {
 	}
 
 	if cmds["0"] != "cat" {
-		t.Fatalf("allowed pane should run cat, got %q (all: %v)", cmds["0"], cmds)
+		t.Fatalf("permitted pane should run cat, got %q (all: %v)", cmds["0"], cmds)
 	}
 
 	if cmds["1"] == "tail" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a restore command denylist in configuration and restore behavior.
  * Documentation and generated config now show how to define blocked commands and how denylist rules interact with allowlists.

* **Bug Fixes**
  * Restore operations now correctly skip denied commands.
  * Denylist rules take precedence when a command appears in both allowlist and denylist settings.

* **Tests**
  * Expanded coverage for config loading, config rendering, and restore filtering to verify denylist behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->