### PR TITLE
fix(tmux): open the picker when no tmux server is running (#198)

### DIFF
--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -289,7 +289,7 @@ func (client *Client) SessionExists(name string) bool {
 func (client *Client) ListSessions() ([]string, error) {
 	out, err := client.Output("list-sessions", "-F", "#{session_name}")
 	if err != nil {
-		if strings.Contains(err.Error(), "no server running") {
+		if isNoServerError(err) {
 			return nil, nil
 		}
 
@@ -300,6 +300,30 @@ func (client *Client) ListSessions() ([]string, error) {
 	sort.Strings(lines)
 
 	return lines, nil
+}
+
+// isNoServerError reports whether err means "no tmux server is running", which
+// callers treat as zero live sessions rather than a failure. tmux's wording
+// varies by platform and version: Linux typically prints "no server running on
+// <socket>", while macOS fails to connect to the socket and prints "error
+// connecting to <socket> (No such file or directory)". Match both, case-
+// insensitively, since the exact text is not stable (#198).
+func isNoServerError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := strings.ToLower(err.Error())
+
+	switch {
+	case strings.Contains(msg, "no server running"):
+		return true
+	case strings.Contains(msg, "error connecting to") &&
+		strings.Contains(msg, "no such file or directory"):
+		return true
+	default:
+		return false
+	}
 }
 
 // CurrentSession returns the name of the session the calling client is

--- a/internal/tmux/client_internal_test.go
+++ b/internal/tmux/client_internal_test.go
@@ -1,11 +1,64 @@
 package tmux
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
 )
+
+// errFakeRunner is the static base of every errRunner failure; the per-case
+// wording is wrapped around it (err113).
+var errFakeRunner = errors.New("fake runner failure")
+
+// errRunner is a fake tmux runner that fails every command with a fixed error,
+// used to check how error messages are classified (e.g. "no server running").
+type errRunner struct{ msg string }
+
+func (r errRunner) runCommand(_ ...string) commandResult {
+	return commandResult{err: fmt.Errorf("%s: %w", r.msg, errFakeRunner)}
+}
+
+func TestListSessionsTreatsNoServerAsEmpty(t *testing.T) {
+	t.Parallel()
+	// Both wordings mean "no tmux server is running" and must yield zero live
+	// sessions without an error, so the picker still opens (#198).
+	cases := map[string]string{
+		"linux no server running": "tmux list-sessions: exit status 1 (no server running on /tmp/tmux-1000/default)",
+		"macos socket missing": "tmux list-sessions -F #{session_name}: exit status 1 " +
+			"(error connecting to /private/tmp/tmux-501/default (No such file or directory))",
+	}
+
+	for name, msg := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			client := NewClientWithRunner("tmux", errRunner{msg: msg})
+
+			got, err := client.ListSessions()
+			if err != nil {
+				t.Fatalf("no-server error must be swallowed, got %v", err)
+			}
+
+			if got != nil {
+				t.Fatalf("expected nil sessions, got %#v", got)
+			}
+		})
+	}
+}
+
+func TestListSessionsPropagatesRealErrors(t *testing.T) {
+	t.Parallel()
+
+	// A genuine failure (not a missing server) must still surface.
+	client := NewClientWithRunner("tmux", errRunner{msg: "tmux: command not found"})
+
+	if _, err := client.ListSessions(); err == nil {
+		t.Fatal("a real error must propagate, not be swallowed as no-server")
+	}
+}
 
 // pollRunner is a fake tmux runner that reports a pane running the shell until
 // the configured poll, then reports the restored command. It lets us drive


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tmux session listing when the server is not running, so the app now treats that case as “no sessions” instead of showing an error.
  * Expanded error detection to recognize common tmux error message variations across platforms.
  * Confirmed that unrelated tmux failures still surface normally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->