### PR TITLE
fix(picker): align fzf-engine columns regardless of session-name length (#200)

### DIFF
--- a/internal/picker/fzf.go
+++ b/internal/picker/fzf.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // Sentinel errors of the fzf-driven choosers.
@@ -24,12 +25,50 @@ var (
 // fzfSelectionTimeout bounds how long a non-interactive --filter run may take.
 const fzfSelectionTimeout = 30 * time.Second
 
+// windowLineParts is the minimum tab-field count of a window fzf line: the
+// visible display column plus the hidden session name and window index.
+const windowLineParts = 3
+
 // ErrNoSessions and ErrNoWindows are returned by the choosers when there is
 // nothing to pick from: no saved sessions at all, or sessions without windows.
 var (
 	ErrNoSessions = errors.New("no sessions available")
 	ErrNoWindows  = errors.New("no windows available")
 )
+
+// Upper bounds on how wide a single column may grow, so one very long session
+// name or command can't blow the layout past the terminal. Longer values are
+// truncated with an ellipsis (they still parse back via the hidden fields).
+const (
+	fzfNameMax = 40
+	fzfWinName = 24
+	fzfCmdMax  = 30
+	// fzfColGap separates the visible, space-padded columns. A plain space run
+	// (not a tab) so fzf renders it verbatim instead of snapping to tab stops.
+	fzfColGap = "  "
+)
+
+// padCell right-pads s with spaces to the given rendered cell width, counting
+// full-width glyphs correctly so unicode names still align. A string already at
+// or over width is returned unchanged (callers clamp first).
+func padCell(text string, width int) string {
+	gap := width - ansi.StringWidth(text)
+	if gap <= 0 {
+		return text
+	}
+
+	return text + strings.Repeat(" ", gap)
+}
+
+// clampCell truncates s (ANSI-aware) to max rendered cells, appending an
+// ellipsis when it overflows, so it can never push later columns out of line.
+func clampCell(s string, maxWidth int) string {
+	if ansi.StringWidth(s) <= maxWidth {
+		return s
+	}
+
+	return ansi.Truncate(s, maxWidth, "…")
+}
 
 // runFZF pipes input into fzf and returns the first selected line. With a TTY it
 // runs interactively; without one it uses --filter "" so all lines pass through
@@ -89,6 +128,48 @@ func runFZF(input *bytes.Buffer, withNth string) (string, error) {
 	return selected, nil
 }
 
+// sessionFZFLines renders one aligned line per session. The visible portion is a
+// single, space-padded column (name, captured time, window count) so alignment
+// never depends on fzf's tab-stop rendering (#200); the untruncated session name
+// is appended as a hidden tab-delimited field for parsing the selection back.
+func sessionFZFLines(records []snapshot.Record) []string {
+	type row struct{ name, when, count string }
+
+	rows := make([]row, len(records))
+
+	var nameW, countW int
+
+	for idx, r := range records {
+		name := clampCell(r.SessionName, fzfNameMax)
+		rows[idx] = row{
+			name:  name,
+			when:  r.CapturedAt.Local().Format("2006-01-02 15:04:05"),
+			count: fmt.Sprintf("%dw", r.Windows),
+		}
+
+		nameW = maxInt(nameW, ansi.StringWidth(name))
+		countW = maxInt(countW, ansi.StringWidth(rows[idx].count))
+	}
+
+	lines := make([]string, len(records))
+	for idx, item := range rows {
+		// Right-align the window count so single- and double-digit counts don't
+		// leave ragged trailing widths.
+		display := padCell(
+			item.name,
+			nameW,
+		) + fzfColGap + item.when + fzfColGap + padLeft(
+			item.count,
+			countW,
+		)
+		// Hidden field: the real (unclamped) name, so a truncated display still
+		// restores the right session.
+		lines[idx] = display + "\t" + records[idx].SessionName
+	}
+
+	return lines
+}
+
 // ChooseSessionFZF presents a session-level fzf list (name, captured time,
 // window count) and returns the name of the selected session. It returns
 // ErrNoSessions when records is empty.
@@ -99,36 +180,41 @@ func ChooseSessionFZF(records []snapshot.Record) (string, error) {
 
 	var input bytes.Buffer
 
-	for _, r := range records {
-		line := fmt.Sprintf(
-			"%s\t%s\t%dw\n",
-			r.SessionName,
-			r.CapturedAt.Local().Format("2006-01-02 15:04:05"),
-			r.Windows,
-		)
+	for _, line := range sessionFZFLines(records) {
 		input.WriteString(line)
+		input.WriteByte('\n')
 	}
 
-	selected, err := runFZF(&input, "1,2,3")
+	// Only the first (visible) field is shown and searched; the trailing name
+	// field is a hidden parse handle.
+	selected, err := runFZF(&input, "1")
 	if err != nil {
 		return "", err
 	}
 
 	parts := strings.Split(selected, "\t")
-	if strings.TrimSpace(parts[0]) == "" {
+
+	name := strings.TrimSpace(parts[len(parts)-1])
+	if name == "" {
 		return "", errInvalidFzfOutput
 	}
 
-	return parts[0], nil
+	return name, nil
 }
 
 // windowFZFLines renders one fzf line per window across all sessions, with the
-// windows of each session ordered by windowSort. Each line is tab-delimited:
-// session, window index, window name, command, captured time. Fields 0-1 are
-// parsed back into a Target by parseWindowSelection; the rest are for display
-// and fuzzy matching.
+// windows of each session ordered by windowSort. The visible portion is a single
+// space-padded column (session, index, name, command, captured time) so columns
+// align independently of fzf's tab stops (#200). Two hidden tab-delimited fields
+// follow — the session name and window index — which parseWindowSelection reads
+// back into a Target.
 func windowFZFLines(sessions []Session, windowSort []WindowSortKey) []string {
-	var lines []string
+	type row struct {
+		session, name, cmd, when string
+		index                    int
+	}
+
+	var rows []row
 
 	for _, session := range sessions {
 		windows := make([]snapshot.Window, len(session.Windows))
@@ -148,34 +234,64 @@ func windowFZFLines(sessions []Session, windowSort []WindowSortKey) []string {
 				cmd = "-"
 			}
 
-			lines = append(lines, fmt.Sprintf(
-				"%s\t%d\t%s\t%s\t%s",
-				session.Record.SessionName,
-				window.Index,
-				name,
-				cmd,
-				captured,
-			))
+			rows = append(rows, row{
+				session: session.Record.SessionName,
+				index:   window.Index,
+				name:    clampCell(name, fzfWinName),
+				cmd:     clampCell(cmd, fzfCmdMax),
+				when:    captured,
+			})
 		}
+	}
+
+	var sessW, idxW, nameW, cmdW int
+
+	for _, r := range rows {
+		sessW = maxInt(sessW, ansi.StringWidth(clampCell(r.session, fzfNameMax)))
+		idxW = maxInt(idxW, len(strconv.Itoa(r.index)))
+		nameW = maxInt(nameW, ansi.StringWidth(r.name))
+		cmdW = maxInt(cmdW, ansi.StringWidth(r.cmd))
+	}
+
+	lines := make([]string, len(rows))
+
+	for idx, item := range rows {
+		display := strings.Join([]string{
+			padCell(clampCell(item.session, fzfNameMax), sessW),
+			padLeft(strconv.Itoa(item.index), idxW), // numeric column, right-aligned
+			padCell(item.name, nameW),
+			padCell(item.cmd, cmdW),
+			item.when,
+		}, fzfColGap)
+
+		// Hidden parse fields: real session name + window index.
+		lines[idx] = fmt.Sprintf("%s\t%s\t%d", display, item.session, item.index)
 	}
 
 	return lines
 }
 
 // parseWindowSelection turns a window fzf line back into a Target pointing at the
-// chosen session and window.
+// chosen session and window. The session name and index are the last two hidden
+// tab-delimited fields (the first field is the aligned display column).
 func parseWindowSelection(line string) (Target, error) {
 	parts := strings.Split(line, "\t")
-	if len(parts) < 2 || strings.TrimSpace(parts[0]) == "" {
+	// Display column + the two hidden parse fields (session, window index).
+	if len(parts) < windowLineParts {
 		return Target{}, errInvalidFzfOutput
 	}
 
-	index, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	session := parts[len(parts)-2]
+	if strings.TrimSpace(session) == "" {
+		return Target{}, errInvalidFzfOutput
+	}
+
+	index, err := strconv.Atoi(strings.TrimSpace(parts[len(parts)-1]))
 	if err != nil {
 		return Target{}, fmt.Errorf("invalid window index in fzf output: %w", err)
 	}
 
-	return Target{SessionName: parts[0], WindowIndex: &index}, nil
+	return Target{SessionName: session, WindowIndex: &index}, nil
 }
 
 // ChooseWindowFZF presents a flat, window-level fzf list (one line per window)
@@ -198,10 +314,31 @@ func ChooseWindowFZF(sessions []Session, windowSort []WindowSortKey) (Target, er
 		input.WriteByte('\n')
 	}
 
-	selected, err := runFZF(&input, "1,2,3,4,5")
+	// Only the aligned display column is shown/searched; the trailing session and
+	// index fields are hidden parse handles.
+	selected, err := runFZF(&input, "1")
 	if err != nil {
 		return Target{}, err
 	}
 
 	return parseWindowSelection(selected)
+}
+
+// padLeft left-pads s with spaces to width rendered cells, for right-aligning
+// short numeric columns (e.g. the window index).
+func padLeft(text string, width int) string {
+	gap := width - ansi.StringWidth(text)
+	if gap <= 0 {
+		return text
+	}
+
+	return strings.Repeat(" ", gap) + text
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+
+	return b
 }

--- a/internal/picker/fzf_internal_test.go
+++ b/internal/picker/fzf_internal_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
 	"github.com/alchemmist/lazy-tmux/internal/testutil"
+	"github.com/charmbracelet/x/ansi"
 )
 
 func TestChooseSessionFZFEmpty(t *testing.T) {
@@ -41,22 +42,108 @@ func TestWindowFZFLinesSortedAndFormatted(t *testing.T) {
 		t.Fatalf("expected 2 window lines, got %d: %#v", len(lines), lines)
 	}
 
-	// First line must be window index 1 (editor/nvim) after sorting.
-	first := strings.Split(lines[0], "\t")
-	if first[0] != "work" || first[1] != "1" || first[2] != "editor" || first[3] != "nvim" {
-		t.Fatalf("unexpected first line fields: %#v", first)
+	// First line must be window index 1 (editor/nvim) after sorting; parse the
+	// hidden fields, and confirm the display column carries the visible values.
+	first, err := parseWindowSelection(lines[0])
+	if err != nil {
+		t.Fatalf("parse first line: %v", err)
 	}
 
-	second := strings.Split(lines[1], "\t")
-	if second[1] != "2" || second[2] != "shell" {
-		t.Fatalf("unexpected second line fields: %#v", second)
+	if first.SessionName != "work" || first.WindowIndex == nil || *first.WindowIndex != 1 {
+		t.Fatalf("unexpected first target: %+v", first)
+	}
+
+	if display := strings.SplitN(lines[0], "\t", 2)[0]; !strings.Contains(display, "editor") ||
+		!strings.Contains(display, "nvim") {
+		t.Fatalf("first display column missing name/cmd: %q", display)
+	}
+
+	second, err := parseWindowSelection(lines[1])
+	if err != nil {
+		t.Fatalf("parse second line: %v", err)
+	}
+
+	if second.WindowIndex == nil || *second.WindowIndex != 2 {
+		t.Fatalf("unexpected second target: %+v", second)
+	}
+
+	// The visible column (everything before the first tab) must be the same
+	// rendered width on every row, or fzf would show ragged columns (#200).
+	assertEqualDisplayWidths(t, lines)
+}
+
+func TestSessionFZFLinesAligned(t *testing.T) {
+	t.Parallel()
+
+	records := []snapshot.Record{
+		{
+			SessionName: "tmp",
+			CapturedAt:  time.Date(2026, 7, 1, 16, 18, 42, 0, time.UTC),
+			Windows:     3,
+		},
+		{
+			SessionName: "arcadia-burn",
+			CapturedAt:  time.Date(2026, 6, 30, 18, 11, 15, 0, time.UTC),
+			Windows:     2,
+		},
+		{
+			SessionName: "dotfiles",
+			CapturedAt:  time.Date(2026, 5, 27, 20, 2, 20, 0, time.UTC),
+			Windows:     12,
+		},
+	}
+
+	lines := sessionFZFLines(records)
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(lines))
+	}
+
+	// Different name lengths must not shift the date column: identical display
+	// widths, and the timestamp starts at the same offset on every row.
+	assertEqualDisplayWidths(t, lines)
+
+	off := -1
+
+	for _, line := range lines {
+		display := strings.SplitN(line, "\t", 2)[0]
+
+		at := strings.Index(display, "202") // start of the year in the timestamp
+		if off == -1 {
+			off = at
+		} else if at != off {
+			t.Fatalf("timestamp column misaligned: offset %d != %d in %q", at, off, display)
+		}
+	}
+
+	// The hidden trailing field must carry the real session name for parsing.
+	if got := strings.Split(lines[0], "\t"); got[len(got)-1] != "tmp" {
+		t.Fatalf("hidden name field wrong: %#v", got)
+	}
+}
+
+// assertEqualDisplayWidths checks that the visible column (before the first tab)
+// has the same rendered width on every line.
+func assertEqualDisplayWidths(t *testing.T, lines []string) {
+	t.Helper()
+
+	want := -1
+
+	for _, line := range lines {
+		display := strings.SplitN(line, "\t", 2)[0]
+
+		got := ansi.StringWidth(display)
+		if want == -1 {
+			want = got
+		} else if got != want {
+			t.Fatalf("display width %d != %d for %q", got, want, display)
+		}
 	}
 }
 
 func TestParseWindowSelection(t *testing.T) {
 	t.Parallel()
 
-	target, err := parseWindowSelection("work\t3\teditor\tnvim\t2026-01-02 03:04:05")
+	target, err := parseWindowSelection("editor  nvim  2026-01-02 03:04:05\twork\t3")
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -66,14 +153,14 @@ func TestParseWindowSelection(t *testing.T) {
 	}
 
 	if _, err := parseWindowSelection("work"); err == nil {
-		t.Fatal("expected error for line without a window index")
+		t.Fatal("expected error for line without hidden fields")
 	}
 
-	if _, err := parseWindowSelection("\t1"); err == nil {
+	if _, err := parseWindowSelection("display\t\t1"); err == nil {
 		t.Fatal("expected error for empty session")
 	}
 
-	if _, err := parseWindowSelection("work\tNaN"); err == nil {
+	if _, err := parseWindowSelection("display\twork\tNaN"); err == nil {
 		t.Fatal("expected error for non-numeric window index")
 	}
 }


### PR DESCRIPTION
## Summary

fzf rendered our tab-separated columns at terminal tab stops (every 8 cells), so session and window lists came out ragged — any name crossing a tab stop pushed the rest of its row out of alignment (#200).

- Session and window lines are now a single **space-padded visible column**: cells are measured with ANSI-aware width, clamped with an ellipsis, and padded to the widest entry, so alignment no longer depends on tab stops at all. Window counts are right-aligned.
- The real (untruncated) session name and window index ride along as **hidden tab-delimited fields** (`--with-nth 1` keeps them out of view and out of fuzzy matching); selections are parsed from those trailing fields, so a truncated display still restores the right target.

## Testing

- `TestSessionFZFLinesAligned` asserts equal display width per line and a constant timestamp offset; window-line tests parse the hidden fields; `TestParseWindowSelection` covers the new line shape.
- `make check` green.

Closes #200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved picker output so session and window lists stay aligned, even when names contain ANSI styling or vary in length.
  * Fixed selection handling so the correct session or window is returned reliably from fuzzy search results.
  * Added better validation for malformed selections and clearer timeout/no-selection handling.

* **Tests**
  * Expanded coverage for line alignment, hidden selection fields, and parsing errors to ensure picker results remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
