### PR TITLE
fix(picker): count native tmux switches in last-used sort (#196)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -36,6 +36,7 @@ var (
 
 type tmuxSessionManager interface {
 	ListSessions() ([]string, error)
+	SessionsLastAttached() map[string]time.Time
 	CurrentSession() (string, error)
 	SessionExists(name string) bool
 	SocketPath() string

--- a/internal/app/app_internal_test.go
+++ b/internal/app/app_internal_test.go
@@ -469,3 +469,38 @@ func TestParsePickerSortOptions(t *testing.T) {
 		t.Fatal("expected error for bogus sort field")
 	}
 }
+
+func TestMergeLastAttached(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	records := []snapshot.Record{
+		{SessionName: "fresher-attach", LastAccessed: base},
+		{SessionName: "fresher-stored", LastAccessed: base.Add(2 * time.Hour)},
+		{SessionName: "not-live", LastAccessed: base},
+	}
+
+	attached := map[string]time.Time{
+		"fresher-attach": base.Add(time.Hour), // native switch newer -> wins
+		"fresher-stored": base.Add(time.Hour), // older than stored -> keep stored
+		// "not-live" absent: dead/asleep session keeps its stored time.
+	}
+
+	mergeLastAttached(records, attached)
+
+	if got := records[0].LastAccessed; !got.Equal(base.Add(time.Hour)) {
+		t.Fatalf("fresher-attach should take the newer attach time, got %v", got)
+	}
+
+	if got := records[1].LastAccessed; !got.Equal(base.Add(2 * time.Hour)) {
+		t.Fatalf("fresher-stored should keep the newer stored time, got %v", got)
+	}
+
+	if got := records[2].LastAccessed; !got.Equal(base) {
+		t.Fatalf("not-live should be unchanged, got %v", got)
+	}
+
+	// A nil/empty map is a no-op and must not panic.
+	mergeLastAttached(records, nil)
+}

--- a/internal/app/app_picker.go
+++ b/internal/app/app_picker.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/alchemmist/lazy-tmux/internal/integration"
 	"github.com/alchemmist/lazy-tmux/internal/picker"
@@ -22,9 +23,31 @@ func (a *App) pickerRecords(opts PickerSortOptions) ([]snapshot.Record, error) {
 		return nil, errNoSavedSessions
 	}
 
+	// Fold in tmux's own last-attached time so native switches (prefix+L,
+	// switch-client, attach) count toward "last used", not just lazy-tmux's own
+	// restore tracking (#196). Best-effort and live-only: dead/asleep sessions
+	// keep their stored LastAccessed.
+	mergeLastAttached(records, a.tmux.SessionsLastAttached())
+
 	picker.SortSessionRecords(records, opts.Session)
 
 	return records, nil
+}
+
+// mergeLastAttached bumps each record's LastAccessed to tmux's last-attached time
+// when the latter is fresher, so whichever recency signal is newer wins. Records
+// without a live last-attached entry are left untouched.
+func mergeLastAttached(records []snapshot.Record, attached map[string]time.Time) {
+	if len(attached) == 0 {
+		return
+	}
+
+	for i := range records {
+		when, ok := attached[records[i].SessionName]
+		if ok && when.After(records[i].LastAccessed) {
+			records[i].LastAccessed = when
+		}
+	}
 }
 
 func (a *App) pickerSessions(opts PickerSortOptions) ([]picker.Session, error) {

--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -326,6 +326,51 @@ func isNoServerError(err error) bool {
 	}
 }
 
+// SessionsLastAttached returns, per live session, the moment tmux last attached a
+// client to it (#{session_last_attached}, epoch seconds). Sessions never attached
+// (value 0/empty) are omitted. It lets the picker's last-used sort account for
+// native tmux switches — prefix+L, switch-client, attach — which lazy-tmux's own
+// access tracking never sees (#196).
+//
+// Best-effort: any failure (no server running, or a tmux too old to expose the
+// format) yields an empty map, so callers simply fall back to the stored
+// LastAccessed instead of breaking the picker. The epoch comes first so the
+// session name (which may contain the field separator) stays intact as the
+// trailing field.
+func (client *Client) SessionsLastAttached() map[string]time.Time {
+	out, err := client.Output(
+		"list-sessions",
+		"-F",
+		"#{session_last_attached}"+fieldSep+"#{session_name}",
+	)
+	if err != nil {
+		return nil
+	}
+
+	result := make(map[string]time.Time)
+
+	for _, line := range splitLines(out) {
+		fields := splitFieldsN(line, 2)
+		if len(fields) != 2 {
+			continue
+		}
+
+		name := fields[1]
+		if strings.TrimSpace(name) == "" {
+			continue
+		}
+
+		secs, parseErr := strconv.ParseInt(strings.TrimSpace(fields[0]), 10, 64)
+		if parseErr != nil || secs <= 0 {
+			continue // never attached, or unparsable
+		}
+
+		result[name] = time.Unix(secs, 0).UTC()
+	}
+
+	return result
+}
+
 // CurrentSession returns the name of the session the calling client is
 // attached to, as reported by "display-message -p #S". It errors when run
 // outside tmux with no server to answer.

--- a/internal/tmux/client_internal_test.go
+++ b/internal/tmux/client_internal_test.go
@@ -60,6 +60,65 @@ func TestListSessionsPropagatesRealErrors(t *testing.T) {
 	}
 }
 
+// stdoutRunner is a fake tmux runner that returns a fixed stdout (and optional
+// error) for every command, for exercising output parsing without a real server.
+type stdoutRunner struct {
+	out string
+	err error
+}
+
+func (r stdoutRunner) runCommand(_ ...string) commandResult {
+	return commandResult{stdout: r.out, err: r.err}
+}
+
+// errFakeNoServer mimics tmux's no-server failure for best-effort paths.
+var errFakeNoServer = errors.New("no server running")
+
+func TestSessionsLastAttached(t *testing.T) {
+	t.Parallel()
+
+	// Lines are "<epoch>|<name>"; a name may itself contain the separator, and it
+	// is the trailing field so it stays intact. Epoch 0 = never attached.
+	out := "1751385600" + fieldSep + "work\n" +
+		"0" + fieldSep + "never\n" +
+		"1751472000" + fieldSep + "a" + fieldSep + "b\n"
+
+	got := NewClientWithRunner("tmux", stdoutRunner{out: out}).SessionsLastAttached()
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 attached sessions (never-attached dropped), got %#v", got)
+	}
+
+	if want := time.Unix(1751385600, 0).UTC(); !got["work"].Equal(want) {
+		t.Fatalf("work: got %v want %v", got["work"], want)
+	}
+
+	// The separator-bearing name must survive as a whole key.
+	if _, ok := got["a"+fieldSep+"b"]; !ok {
+		t.Fatalf("expected name with separator preserved, got %#v", got)
+	}
+
+	if _, ok := got["never"]; ok {
+		t.Fatal("a never-attached session (epoch 0) must be omitted")
+	}
+}
+
+func TestSessionsLastAttachedBestEffortOnError(t *testing.T) {
+	t.Parallel()
+
+	// No server / unsupported format: return nil, never an error, so the picker
+	// falls back to stored LastAccessed.
+	got := NewClientWithRunner(
+		"tmux",
+		stdoutRunner{err: errFakeNoServer},
+	).
+		SessionsLastAttached()
+
+	if got != nil {
+		t.Fatalf("expected nil on error, got %#v", got)
+	}
+}
+
 // pollRunner is a fake tmux runner that reports a pane running the shell until
 // the configured poll, then reports the restored command. It lets us drive
 // waitForRestoredCommands deterministically without a real tmux server.


### PR DESCRIPTION
## Summary

The picker's last-used sort only counted accesses that went through lazy-tmux itself (restore/wakeup/picker), so sessions you switched to natively — `prefix+L`, `switch-client`, plain `attach` — never bubbled up. The order felt wrong for anyone mixing native tmux navigation with the picker.

- New `Client.SessionsLastAttached()` reads `#{session_last_attached}` (epoch seconds) per live session in a single `list-sessions` call. The epoch comes first in the format string so a session name containing the field separator survives as the trailing field.
- `pickerRecords` merges those timestamps into each record's `LastAccessed` (taking whichever is newer) before sorting, so native switches count toward last-used.
- Best-effort by design: any failure (no server running, tmux too old for the format) yields an empty map and the picker silently falls back to the stored `LastAccessed` — it can never break the picker.
- Sessions never attached (epoch 0) are omitted rather than treated as accessed at 1970.

## Testing

- Unit: `TestSessionsLastAttached` (epoch parsing, never-attached dropped, separator-bearing names preserved), `TestSessionsLastAttachedBestEffortOnError` (nil on error, no failure), `TestMergeLastAttached` (newer-wins merge).
- `make check` green.

Closes #196
