### PR TITLE
feat(cli): ascii crescent-moon banner in the help output (#38)

### DIFF
--- a/cmd/lazy-tmux/cli_test.go
+++ b/cmd/lazy-tmux/cli_test.go
@@ -48,6 +48,11 @@ func TestCLIHelpVariants(t *testing.T) {
 		if !strings.Contains(out, "tmux session snapshots with lazy restore") {
 			t.Fatalf("%s: expected help text, got %q", arg, out)
 		}
+
+		// The help banner leads with the ascii crescent-moon logo (#38).
+		if !strings.Contains(out, asciiMoon) {
+			t.Fatalf("%s: expected the ascii moon banner in help", arg)
+		}
 	}
 }
 

--- a/cmd/lazy-tmux/main.go
+++ b/cmd/lazy-tmux/main.go
@@ -91,8 +91,20 @@ func writeErr(w io.Writer, err error) {
 	}
 }
 
+// asciiMoon is the crescent-moon-and-star banner shown at the top of the help
+// text, echoing the pixel-art "night" logo (#38).
+const asciiMoon = `      ▄████▄
+    ▄██▀▀        ·
+   ▐██▘       ✦
+   ▐██▌
+   ▐██▖          ·
+    ▀██▄▄
+      ▀████▀`
+
 func printUsage(w io.Writer) {
-	_, _ = fmt.Fprintf(w, `lazy-tmux - tmux session snapshots with lazy restore
+	_, _ = fmt.Fprintf(w, `%s
+
+lazy-tmux - tmux session snapshots with lazy restore
 
 Usage:
   lazy-tmux <command> [flags]
@@ -114,5 +126,5 @@ Commands:
   version    Print the version
 
 Run 'lazy-tmux <command> -h' for more details.
-`)
+`, asciiMoon)
 }


### PR DESCRIPTION
## Summary

The top-level help output was plain text. It now leads with a small ASCII crescent-moon-and-star banner echoing the project's pixel-art night logo, so `lazy-tmux`, `lazy-tmux --help` and `lazy-tmux help` open with a bit of identity instead of a wall of text.

- `asciiMoon` is a single package-level constant printed once at the top of `printUsage`; the rest of the help text is unchanged.
- Only the top-level usage gets the banner — per-command help (`lazy-tmux save -h` etc.) stays compact and script-friendly.

## Testing

- `TestCLIHelpVariants` now asserts the banner is present in all three help invocations (`help`, `-h`, `--help`).
- `make test` green.

Closes #38
