### PR TITLE
fix(claude-status): clear stale awaiting_decision once the permission is resolved

### DIFF
--- a/cmd/lazy-tmux/claude_hooks.go
+++ b/cmd/lazy-tmux/claude_hooks.go
@@ -32,12 +32,16 @@ func claudeHookSpecs() []claudeHookSpec {
 	// tool finishes. Together they clear a stale awaiting_decision once the
 	// permission is resolved — nothing else fires at the approval moment, so
 	// without them the picker keeps showing "?" while Claude is busy working.
+	// PermissionDenied covers auto-classifier blocks; a MANUAL denial fires no
+	// hook at all, but Claude keeps processing the turn afterwards, so the next
+	// PreToolUse or Stop bounds that stale window to seconds.
 	return []claudeHookSpec{
 		{event: "Notification", matcher: "permission_prompt", state: claude.StateAwaitingDecision},
 		{event: "Notification", matcher: "idle_prompt", state: claude.StateAwaitingInput},
 		{event: "UserPromptSubmit", matcher: "", state: claude.StateWorking},
 		{event: "PreToolUse", matcher: "", state: claude.StateWorking},
 		{event: "PostToolUse", matcher: "", state: claude.StateWorking},
+		{event: "PermissionDenied", matcher: "", state: claude.StateWorking},
 		{event: "Stop", matcher: "", state: claude.StateIdle},
 	}
 }

--- a/cmd/lazy-tmux/claude_hooks.go
+++ b/cmd/lazy-tmux/claude_hooks.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/alchemmist/lazy-tmux/internal/config"
+	"github.com/alchemmist/lazy-tmux/internal/integration/claude"
 )
 
 // claudeHookCommandMarker identifies the hook commands this tool installs, so
@@ -26,11 +27,18 @@ type claudeHookSpec struct {
 }
 
 func claudeHookSpecs() []claudeHookSpec {
+	// PreToolUse fires before the permission prompt (so a subsequent
+	// permission_prompt notification still wins) and PostToolUse fires after a
+	// tool finishes. Together they clear a stale awaiting_decision once the
+	// permission is resolved — nothing else fires at the approval moment, so
+	// without them the picker keeps showing "?" while Claude is busy working.
 	return []claudeHookSpec{
-		{event: "Notification", matcher: "permission_prompt", state: "awaiting_decision"},
-		{event: "Notification", matcher: "idle_prompt", state: "awaiting_input"},
-		{event: "UserPromptSubmit", matcher: "", state: "working"},
-		{event: "Stop", matcher: "", state: "idle"},
+		{event: "Notification", matcher: "permission_prompt", state: claude.StateAwaitingDecision},
+		{event: "Notification", matcher: "idle_prompt", state: claude.StateAwaitingInput},
+		{event: "UserPromptSubmit", matcher: "", state: claude.StateWorking},
+		{event: "PreToolUse", matcher: "", state: claude.StateWorking},
+		{event: "PostToolUse", matcher: "", state: claude.StateWorking},
+		{event: "Stop", matcher: "", state: claude.StateIdle},
 	}
 }
 

--- a/cmd/lazy-tmux/claude_hooks_test.go
+++ b/cmd/lazy-tmux/claude_hooks_test.go
@@ -76,7 +76,8 @@ func TestApplyClaudeHooksInstallPreservesExisting(t *testing.T) {
 
 	// All hooked events present.
 	for _, event := range []string{
-		"Notification", "UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop",
+		"Notification", "UserPromptSubmit", "PreToolUse", "PostToolUse",
+		"PermissionDenied", "Stop",
 	} {
 		if len(hooks[event]) == 0 {
 			t.Fatalf("event %q missing after install", event)

--- a/cmd/lazy-tmux/claude_hooks_test.go
+++ b/cmd/lazy-tmux/claude_hooks_test.go
@@ -74,8 +74,10 @@ func TestApplyClaudeHooksInstallPreservesExisting(t *testing.T) {
 
 	hooks := parseSettings(t, path)
 
-	// All four events present.
-	for _, event := range []string{"Notification", "UserPromptSubmit", "Stop"} {
+	// All hooked events present.
+	for _, event := range []string{
+		"Notification", "UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop",
+	} {
 		if len(hooks[event]) == 0 {
 			t.Fatalf("event %q missing after install", event)
 		}

--- a/cmd/lazy-tmux/version_test.go
+++ b/cmd/lazy-tmux/version_test.go
@@ -41,9 +41,13 @@ func TestCLIVersionHelp(t *testing.T) {
 	}
 }
 
+// Mutating the package-level version variable must not overlap with the
+// parallel CLI tests that read it through resolveVersion, so these two tests
+// stay serial: Go runs all serial tests to completion before resuming the
+// paused parallel ones.
+//
+//nolint:paralleltest // writes the global version read by parallel tests
 func TestResolveVersionPrefersLdflags(t *testing.T) {
-	t.Parallel()
-
 	orig := version
 	t.Cleanup(func() { version = orig })
 
@@ -53,9 +57,8 @@ func TestResolveVersionPrefersLdflags(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // writes the global version read by parallel tests
 func TestResolveVersionFallbackNonEmpty(t *testing.T) {
-	t.Parallel()
-
 	orig := version
 	t.Cleanup(func() { version = orig })
 

--- a/internal/integration/claude/status.go
+++ b/internal/integration/claude/status.go
@@ -17,7 +17,7 @@ import (
 // State names written by the `lazy-tmux hook claude-status` command and read
 // back here. They map 1:1 onto Claude Code's hook events.
 const (
-	StateWorking          = "working"           // UserPromptSubmit — Claude is generating
+	StateWorking          = "working"           // UserPromptSubmit / PreToolUse / PostToolUse
 	StateAwaitingDecision = "awaiting_decision" // Notification/permission_prompt
 	StateAwaitingInput    = "awaiting_input"    // Notification/idle_prompt
 	StateIdle             = "idle"              // Stop — turn finished


### PR DESCRIPTION
## Summary

The picker could show a stale `?` (awaiting decision) on a Claude window that was actively working. Root cause: **no Claude Code hook event fires at the moment a permission request is resolved**. The event order is:

`PreToolUse` → permission prompt (`Notification/permission_prompt` writes `awaiting_decision`) → user approves (or a permission rule / auto mode allows it) → tool executes → `PostToolUse`.

With hooks only on `Notification`, `UserPromptSubmit` and `Stop`, nothing rewrote the status file after approval — the `?` stuck around until the whole turn ended (`Stop`) or a new prompt was submitted, which for a long agentic turn can be many minutes of misleading "waiting for you".

## Fix

Install two more hooks, both writing `working`:

- **`PostToolUse`** — a tool finished, so the permission was granted and Claude is busy again;
- **`PreToolUse`** — a tool is starting; this also shrinks the stale window between tool calls. It fires *before* the permission prompt, so a genuine `awaiting_decision` notification still overwrites it and the `?` shows exactly while the question is on screen.
- **`PermissionDenied`** — the auto-mode classifier blocked a tool call; Claude keeps working afterwards. A *manual* denial fires no hook event at all (anthropics/claude-code#37153), but Claude continues the turn after one, so the next `PreToolUse`/`Stop` bounds that window to seconds; documented in the spec comment.

The specs now reference the `claude.State*` constants instead of string literals.

Existing installs pick the new hooks up by re-running `lazy-tmux claude-hooks` (the merge is idempotent and preserves user hooks, as before).

Also fixes a flaky data race the race detector started tripping after the paralleltest rollout (#212): both `TestResolveVersion*` tests mutate the package-level `version` variable under `t.Parallel()` while parallel CLI tests read it through `resolveVersion`. They are serial now (serial tests finish before paused parallel ones resume).

## Testing

- `TestApplyClaudeHooksInstallPreservesExisting` now asserts `PreToolUse`/`PostToolUse` groups are installed alongside the original events; idempotency/uninstall tests cover the new specs via the shared marker.
- `make check` green.
- Manual: with the updated hooks, approving a permission flips the dot from amber `?` back to green `●` on the next tool call instead of lingering until the end of the turn.
