### PR TITLE
feat(release): semver release targets — make release-patch/minor/major

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MAKEFLAGS += --no-builtin-variables
 
 BINARY := lazy-tmux
 
-.PHONY: check build build-fzf build-all test test-cov integration-test fmt install clean dist dist-tui dist-fzf tag sandbox test-sup-versions docker-hub vet setup-env golangci-lint docs-install docs-dev docs-build docs-preview
+.PHONY: check build build-fzf build-all test test-cov integration-test fmt install clean dist dist-tui dist-fzf release-patch release-minor release-major sandbox test-sup-versions docker-hub vet setup-env golangci-lint docs-install docs-dev docs-build docs-preview
 
 check: build vet golangci-lint test integration-test
 
@@ -57,31 +57,17 @@ dist-tui:
 dist-fzf:
 	goreleaser release --snapshot --clean --id lazy-tmux-fzf
 
-tag:
-	@if ! git diff --quiet || ! git diff --cached --quiet; then \
-		echo "working tree is dirty; commit or stash changes first"; \
-		exit 1; \
-	fi
-	@latest="$$(git tag --list 'v*' --sort=-v:refname | head -n1)"; \
-	if [ -z "$$latest" ]; then \
-		next="v0.1.0"; \
-	else \
-		ver="$${latest#v}"; \
-		IFS=. read -r major minor patch <<< "$$ver"; \
-		case "$${TYPE:-patch}" in \
-			patch) patch=$$((patch+1));; \
-			minor) minor=$$((minor+1)); patch=0;; \
-			major) major=$$((major+1)); minor=0; patch=0;; \
-			*) echo "TYPE must be patch, minor, or major"; exit 1;; \
-		esac; \
-		next="v$${major}.$${minor}.$${patch}"; \
-	fi; \
-	if git rev-parse -q --verify "refs/tags/$$next" >/dev/null; then \
-		echo "tag $$next already exists"; \
-		exit 1; \
-	fi; \
-	echo "tagging $$next"; \
-	git tag -a "$$next" -m "release $$next"
+# Cut a release: guards (main, clean, synced), `make check`, semver tag, push —
+# the release workflow (GoReleaser, Homebrew tap, AUR) picks the tag up from
+# there. Shows the commits being released and asks for confirmation.
+release-patch:
+	./scripts/release.sh patch
+
+release-minor:
+	./scripts/release.sh minor
+
+release-major:
+	./scripts/release.sh major
 
 setup-env:
 	go install gotest.tools/gotestsum@v1.13.0

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -35,7 +35,10 @@ if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
   exit 1
 fi
 
-latest="$(git tag --list 'v*' --sort=-v:refname | head -n1)"
+# Strict vMAJOR.MINOR.PATCH only: a stray prerelease tag (v1.2.3-rc1) would
+# both win the version sort and break the numeric split below.
+latest="$(git tag --list 'v*' --sort=-v:refname |
+  grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)"
 if [ -z "$latest" ]; then
   next="v0.1.0"
 else

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Cut a release: bump the semver tag and push it, letting the release pipeline
+# (GoReleaser -> GitHub release, Homebrew tap, AUR) take over from there.
+#
+# Usage: scripts/release.sh <patch|minor|major>
+# Invoked via `make release-patch` / `release-minor` / `release-major`.
+set -euo pipefail
+
+bump="${1:-}"
+case "$bump" in
+patch | minor | major) ;;
+*)
+  echo "usage: $0 <patch|minor|major>" >&2
+  exit 1
+  ;;
+esac
+
+# Releases are cut from an up-to-date, clean main only: the tag must point at
+# a commit that is already on origin/main, or the pipeline builds something
+# nobody has reviewed.
+branch="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$branch" != "main" ]; then
+  echo "releases are cut from main (currently on $branch)" >&2
+  exit 1
+fi
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "working tree is dirty; commit or stash changes first" >&2
+  exit 1
+fi
+
+git fetch origin main --tags
+if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+  echo "main is not in sync with origin/main; pull or push first" >&2
+  exit 1
+fi
+
+latest="$(git tag --list 'v*' --sort=-v:refname | head -n1)"
+if [ -z "$latest" ]; then
+  next="v0.1.0"
+else
+  ver="${latest#v}"
+  IFS=. read -r major minor patch <<<"$ver"
+  case "$bump" in
+  patch) patch=$((patch + 1)) ;;
+  minor)
+    minor=$((minor + 1))
+    patch=0
+    ;;
+  major)
+    major=$((major + 1))
+    minor=0
+    patch=0
+    ;;
+  esac
+  next="v${major}.${minor}.${patch}"
+fi
+
+if git rev-parse -q --verify "refs/tags/$next" >/dev/null; then
+  echo "tag $next already exists" >&2
+  exit 1
+fi
+
+echo "==> running checks before tagging"
+make check
+
+echo
+echo "==> $bump release: $latest -> $next"
+if [ -n "$latest" ]; then
+  echo
+  git log --oneline --no-decorate "$latest"..HEAD
+  echo
+fi
+
+read -r -p "tag and push $next? [y/N] " answer
+case "$answer" in
+[yY]*) ;;
+*)
+  echo "aborted; nothing was tagged"
+  exit 1
+  ;;
+esac
+
+git tag -a "$next" -m "release $next"
+git push origin "$next"
+
+echo "pushed $next — the release workflow takes it from here:"
+echo "  https://github.com/alchemmist/lazy-tmux/actions/workflows/release.yml"


### PR DESCRIPTION
## Summary

There was no release target — only `make tag`, which bumped **patch** by default (the `TYPE=minor|major` knob was undocumented), never pushed, and ran no checks, so the actual release trigger (pushing the tag) stayed manual and fumble-prone right before the upcoming minor.

This replaces it with three explicit semver targets:

```
make release-patch   # v0.1.25 -> v0.1.26
make release-minor   # v0.1.25 -> v0.2.0
make release-major   # v0.1.25 -> v1.0.0
```

All three are thin wrappers over the new `scripts/release.sh <bump>`, which:

1. refuses to run unless on `main`, with a clean tree, in sync with `origin/main` (fetches first);
2. runs `make check` so a broken tree can never be tagged;
3. computes the next version from the latest `v*` tag (first release still starts at `v0.1.0`);
4. prints the bump and the `git log --oneline` since the previous tag, and asks for confirmation;
5. creates the annotated tag and pushes it — release.yml (GoReleaser → GitHub release, Homebrew tap, AUR) takes over from there.

Alternatives like `svu`/semantic-release (deriving the bump from conventional commits) were considered in the issue and rejected: they add a dependency and let a mistyped commit message silently change the bump, while the human decision here stays explicit.

## Testing

- Sandbox repo (bare origin + clone, stubbed `make`): `minor` v0.2.3→v0.3.0 tagged and pushed; declining the prompt aborts with nothing tagged; `major` v0.3.0→v1.0.0; dirty-tree, non-main, out-of-sync (both ahead and behind) and existing-tag guards all refuse with a clear message.
- `make check` green.

Closes #216


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated `release-patch`, `release-minor`, and `release-major` commands for version updates.
  * Centralized release tagging automation with validation, confirmation prompts, and automatic tag publishing.
* **Bug Fixes**
  * Added safeguards requiring an up-to-date `main` branch and a clean working tree before creating a release tag.
  * Prevents creating duplicate version tags.
* **Chores**
  * Updated release workflow guidance so tag derivation and follow-up steps are handled consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->