### PR TITLE
fix: join wrapped lines in capture-pane with -J

### DIFF
--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -729,14 +729,24 @@ func newWindowArgs(sessionName string, win snapshot.Window) []string {
 }
 
 // CapturePaneScrollback returns the last `lines` lines of a pane's history,
-// with ANSI escape sequences preserved (-e) so colors survive a restore. A
+// with ANSI escape sequences preserved (-e) so colors survive a restore and
+// wrapped lines joined (-J) so long output stays one logical line. A
 // non-positive lines value defaults to 5000.
 func (client *Client) CapturePaneScrollback(target string, lines int) (string, error) {
 	if lines <= 0 {
 		lines = 5000
 	}
 
-	return client.Output("capture-pane", "-p", "-e", "-S", fmt.Sprintf("-%d", lines), "-t", target)
+	return client.Output(
+		"capture-pane",
+		"-p",
+		"-e",
+		"-J",
+		"-S",
+		fmt.Sprintf("-%d", lines),
+		"-t",
+		target,
+	)
 }
 
 func (client *Client) createAndPopulateWindow(sessionName string, win snapshot.Window) error {

--- a/internal/tmux/client_internal_test.go
+++ b/internal/tmux/client_internal_test.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -521,6 +522,38 @@ func TestPickForegroundCommand(t *testing.T) {
 	// Only a shell present -> nothing to restore.
 	if got := pickForegroundCommand([]string{"100 1 Ss zsh"}, 100); got != "" {
 		t.Fatalf("expected empty for shell-only, got %q", got)
+	}
+}
+
+// argsRunner is a fake tmux runner that records the argv of every command, for
+// asserting how tmux is invoked.
+type argsRunner struct{ calls [][]string }
+
+func (r *argsRunner) runCommand(args ...string) commandResult {
+	r.calls = append(r.calls, args)
+
+	return commandResult{}
+}
+
+func TestCapturePaneScrollbackArgs(t *testing.T) {
+	t.Parallel()
+
+	runner := &argsRunner{}
+	client := NewClientWithRunner("tmux", runner)
+
+	if _, err := client.CapturePaneScrollback("sess:1.0", 0); err != nil {
+		t.Fatalf("CapturePaneScrollback: %v", err)
+	}
+
+	if len(runner.calls) != 1 {
+		t.Fatalf("expected 1 tmux call, got %d", len(runner.calls))
+	}
+
+	// -e keeps colors, -J joins wrapped lines (#37), and a non-positive lines
+	// value falls back to the 5000-line default.
+	want := []string{"tmux", "capture-pane", "-p", "-e", "-J", "-S", "-5000", "-t", "sess:1.0"}
+	if got := runner.calls[0]; !slices.Equal(got, want) {
+		t.Fatalf("capture-pane args:\n got %q\nwant %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

`CapturePaneScrollback` captured pane history with wrapped long lines split at the pane width, so long output (logs, code snippets) arrived as multiple physical lines. Adding `-J` to `capture-pane` joins wrapped lines back into single logical lines.

## Testing

- Manual check against a live tmux server (isolated `TMUX_TMPDIR`, 20-column pane, 30-char line): without `-J` the string is split across lines and a grep for the full string finds nothing; with `-J` it is captured as one line.
- `make check` green (build, vet, golangci-lint, test, integration-test).

Closes #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pane scrollback now includes wrapped lines as they appear in the terminal, making captured output easier to read and more accurate.
  * ANSI color and formatting are still preserved during capture.
* **Bug Fixes**
  * Improved consistency when capturing longer terminal output, especially for wrapped content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->