### PR TITLE
fix: preserve explicitly launched shell across save and restore

### DIFF
--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -961,7 +961,11 @@ func normalizedCommand(restore, current string) string {
 		return current
 	}
 
-	return ""
+	// A shell in RestoreCmd is deliberate: capture only records a shell when
+	// the user explicitly launched one inside the pane (issue #66), so replay
+	// it. CurrentCmd stays dropped — for an idle pane it is just the default
+	// shell.
+	return restore
 }
 
 func isShellCommand(cmd string) bool {
@@ -1274,10 +1278,16 @@ type psProcess struct {
 }
 
 // collectCandidateProcesses parses ps output lines into candidate foreground
-// processes, skipping unparsable lines, the pane's shell process itself and
-// shell commands.
-func collectCandidateProcesses(lines []string, panePID int) []psProcess {
-	allProcesses := make([]psProcess, 0, len(lines))
+// processes, skipping unparsable lines and the pane's shell process itself.
+// Non-shell processes are the preferred candidates; shells are returned
+// separately as a fallback — a shell that is not the pane's own process was
+// launched explicitly (e.g. fish started from zsh) and must survive a restore
+// (issue #66). Only foreground ("+") shells qualify: background shells are
+// prompt/completion helpers, not user intent.
+func collectCandidateProcesses(lines []string, panePID int) ([]psProcess, []psProcess) {
+	nonShell := make([]psProcess, 0, len(lines))
+
+	var shells []psProcess
 
 	for _, line := range lines {
 		pid, ppid, stat, cmd, ok := parsePSLine(line)
@@ -1285,35 +1295,50 @@ func collectCandidateProcesses(lines []string, panePID int) []psProcess {
 			continue
 		}
 
-		// Skip the shell process itself
+		// Skip the pane's own shell process
 		if pid == panePID {
 			continue
 		}
 
-		// Skip shell commands
-		if isShellCommand(cmd) {
-			continue
-		}
-
-		allProcesses = append(allProcesses, psProcess{
+		process := psProcess{
 			pid:  pid,
 			ppid: ppid,
 			stat: stat,
 			cmd:  cmd,
-		})
+		}
+
+		if isShellCommand(cmd) {
+			if strings.Contains(stat, "+") {
+				shells = append(shells, process)
+			}
+
+			continue
+		}
+
+		nonShell = append(nonShell, process)
 	}
 
-	return allProcesses
+	return nonShell, shells
 }
 
 // pickForegroundCommand chooses the command to restore for a pane from ps
 // output: among non-shell processes it prefers a foreground ("+") root process
 // (one whose parent is outside the candidate set), then any root process, then
-// any foreground process, then the first candidate.
+// any foreground process, then the first candidate. With no non-shell
+// candidates it falls back to an explicitly launched shell (issue #66).
 func pickForegroundCommand(lines []string, panePID int) string {
-	// First pass: collect all non-shell processes
-	allProcesses := collectCandidateProcesses(lines, panePID)
+	nonShell, shells := collectCandidateProcesses(lines, panePID)
 
+	if cmd := pickFromCandidates(nonShell); cmd != "" {
+		return cmd
+	}
+
+	return pickFromCandidates(shells)
+}
+
+// pickFromCandidates applies the root/foreground preference order to one
+// candidate set.
+func pickFromCandidates(allProcesses []psProcess) string {
 	if len(allProcesses) == 0 {
 		return ""
 	}

--- a/internal/tmux/client_internal_test.go
+++ b/internal/tmux/client_internal_test.go
@@ -274,13 +274,14 @@ func TestExpectedPaneCommands(t *testing.T) {
 			Index: 1,
 			Panes: []snapshot.Pane{
 				{Index: 0, RestoreCmd: "nvim main.go"}, // real command -> nvim
-				{Index: 1, RestoreCmd: "zsh"},          // shell only -> skipped
+				{Index: 1, RestoreCmd: "fish"},         // launched shell -> replayed (issue #66)
 			},
 		},
 		{
 			Index: 2,
 			Panes: []snapshot.Pane{
 				{Index: 0, CurrentCmd: "htop -d 5"}, // falls back to current command
+				{Index: 1, CurrentCmd: "zsh"},       // default shell -> skipped
 			},
 		},
 	}
@@ -288,7 +289,7 @@ func TestExpectedPaneCommands(t *testing.T) {
 	// No allowlist configured -> every real command is expected.
 	got := NewClient("tmux").expectedPaneCommands(windows)
 
-	want := map[string]string{"1.0": "nvim", "2.0": "htop"}
+	want := map[string]string{"1.0": "nvim", "1.1": "fish", "2.0": "htop"}
 	if len(got) != len(want) {
 		t.Fatalf("expectedPaneCommands size: got %#v want %#v", got, want)
 	}
@@ -481,8 +482,9 @@ func TestNormalizedCommand(t *testing.T) {
 		restore, current, want string
 	}{
 		{"nvim", "zsh", "nvim"}, // restore wins when it is a real command
-		{"zsh", "nvim", "nvim"}, // restore is a shell -> use current
-		{"zsh", "bash", ""},     // both shells -> nothing to restore
+		{"zsh", "nvim", "nvim"}, // restore is a shell -> prefer a real current
+		{"fish", "zsh", "fish"}, // explicitly launched shell is replayed (issue #66)
+		{"", "zsh", ""},         // default shell only -> nothing to restore
 		{`"htop"`, "", "htop"},  // quotes stripped
 	}
 
@@ -518,9 +520,37 @@ func TestPickForegroundCommand(t *testing.T) {
 		t.Fatalf("expected foreground nvim, got %q", got)
 	}
 
-	// Only a shell present -> nothing to restore.
+	// Only the pane's own shell present -> nothing to restore.
 	if got := pickForegroundCommand([]string{"100 1 Ss zsh"}, 100); got != "" {
 		t.Fatalf("expected empty for shell-only, got %q", got)
+	}
+
+	// A foreground shell launched inside the pane is kept (issue #66).
+	launched := []string{
+		"100 1 Ss zsh",    // the pane's own shell
+		"300 100 S+ fish", // user ran fish from zsh
+	}
+	if got := pickForegroundCommand(launched, 100); got != "fish" {
+		t.Fatalf("expected launched fish, got %q", got)
+	}
+
+	// A background shell is a prompt/completion helper, not user intent.
+	helper := []string{
+		"100 1 Ss zsh",
+		"301 100 S zsh -c helper",
+	}
+	if got := pickForegroundCommand(helper, 100); got != "" {
+		t.Fatalf("expected empty for background shell helper, got %q", got)
+	}
+
+	// A real command wins over a launched shell (nvim started from fish).
+	nested := []string{
+		"100 1 Ss zsh",
+		"300 100 S fish",
+		"400 300 S+ nvim",
+	}
+	if got := pickForegroundCommand(nested, 100); got != "nvim" {
+		t.Fatalf("expected nvim over launched shell, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

A shell the user explicitly started inside a pane (e.g. `fish` or `bash` launched from their default `zsh`) did not survive a save/restore cycle: after restore the pane came back with only the default shell (#66).

Both sides of the pipeline conflated "a shell process" with "the pane's default shell":

- **Capture** (`pickForegroundCommand`) skipped every shell among the `ps` candidates, so a pane whose foreground was a user-launched shell recorded an empty `RestoreCmd`.
- **Restore** (`normalizedCommand`) dropped any shell it saw, so even a recorded one would never be replayed.

Now:

- Capture keeps shells that are **not the pane's own process** (pid ≠ pane pid) **and are in the foreground** (`+` in `ps` stat) as a fallback candidate set — pid ≠ pane pid means the user launched it, and requiring foreground filters out transient prompt/completion helpers. Non-shell commands still win (running `nvim` inside fish restores `nvim`, as before).
- Restore replays a shell recorded in `RestoreCmd` — capture only records one deliberately now. A shell in `CurrentCmd` alone is still dropped: for an idle pane that is just the default shell, and old snapshots never carry a shell in `RestoreCmd`, so existing behavior is unchanged.

This also fixes the sibling case of `bash script.sh`, which was previously discarded as "a shell".

## Testing

- New unit cases: `TestNormalizedCommand` (explicit shell replayed, default shell still skipped), `TestPickForegroundCommand` (launched foreground shell kept, background shell helper ignored, real command wins over launched shell), `TestExpectedPaneCommands` (settle-wait predictor expects the launched shell).
- Live tmux round-trip (isolated `TMUX_TMPDIR` + temp data dir): `zsh` pane → run `bash` → save records `restore_cmd: bash` → kill session → `wakeup` → `pane_current_command` is `bash` again. Control: a plain idle `zsh` pane records no `restore_cmd` and restores without a nested shell being typed.
- `make check` green (build, vet, golangci-lint, test, integration-test).

Closes #66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command restoration in terminal panes so the correct foreground command is more reliably replayed.
  * Explicitly launched shells are now preserved when appropriate, while background helpers and the pane’s own shell are ignored.
  * Fixed fallback behavior so pane command recovery no longer ends up blank when a usable command is available.
  * Better prioritizes real foreground commands over shell wrappers in nested process cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->