### PR TITLE
feat(restore): regex allow/denylist matched over the full command

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -18,7 +19,8 @@ var (
 	errNoConfigPath      = errors.New(
 		"could not determine a config path (pass --path or set $HOME)",
 	)
-	errConfigExists = errors.New("already exists (use --force to overwrite)")
+	errConfigExists   = errors.New("already exists (use --force to overwrite)")
+	errInvalidPattern = errors.New("invalid regular expression")
 )
 
 type Config struct {
@@ -128,7 +130,37 @@ func LoadFrom(path string) (Config, error) {
 		return cfg, fmt.Errorf("config %s: %w: %v", path, errUnknownConfigKeys, undecoded)
 	}
 
-	return cfg.withFile(file), nil
+	final := cfg.withFile(file)
+
+	err = validateCommandPatterns(final)
+	if err != nil {
+		return cfg, fmt.Errorf("config %s: %w", path, err)
+	}
+
+	return final, nil
+}
+
+func validateCommandPatterns(cfg Config) error {
+	lists := map[string][]string{
+		"restore_allowlist": cfg.RestoreAllowlist,
+		"restore_denylist":  cfg.RestoreDenylist,
+	}
+
+	for key, list := range lists {
+		for _, entry := range list {
+			trimmed := strings.TrimSpace(entry)
+			if trimmed == "" {
+				continue
+			}
+
+			_, err := regexp.Compile(trimmed)
+			if err != nil {
+				return fmt.Errorf("%s %q: %w: %w", key, entry, errInvalidPattern, err)
+			}
+		}
+	}
+
+	return nil
 }
 
 type fileConfig struct {

--- a/internal/config/config_internal_test.go
+++ b/internal/config/config_internal_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -188,6 +189,23 @@ func TestLoadFromInvalidDurationErrors(t *testing.T) {
 
 	if _, err := LoadFrom(path); err == nil {
 		t.Fatal("expected error for invalid duration")
+	}
+}
+
+func TestLoadFromInvalidPatternErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range []string{"restore_allowlist", "restore_denylist"} {
+		path := writeConfig(t, key+" = [\"node .*\", \"(\"]\n")
+
+		_, err := LoadFrom(path)
+		if err == nil {
+			t.Fatalf("%s: expected error for an invalid regex", key)
+		}
+
+		if !errors.Is(err, errInvalidPattern) {
+			t.Fatalf("%s: expected errInvalidPattern, got %v", key, err)
+		}
 	}
 }
 

--- a/internal/config/default.toml
+++ b/internal/config/default.toml
@@ -23,18 +23,22 @@ save_interval = "5m"
 # before returning. "0s" disables waiting (old fire-and-forget behavior).
 restore_timeout = "5s"
 
-# Allowlist of commands lazy-tmux may replay on restore, matched by program
-# name (e.g. "nvim" matches "/usr/bin/nvim main.go"). Omit this key entirely to
-# restore every command (the default). Provide a list to restore only those
-# programs; use an empty list [] to restore no commands at all.
-# restore_allowlist = ["nvim", "vim", "htop", "less", "tail", "ssh"]
+# Allowlist of commands lazy-tmux may replay on restore. Each entry is a regular
+# expression matched against the full command, anchored so it must match the
+# whole line (e.g. "nvim( .*)?" allows nvim with or without arguments, "ssh .*"
+# allows any ssh command). Omit this key entirely to restore every command (the
+# default). Provide a list to restore only matching commands; use an empty list
+# [] to restore no commands at all.
+# restore_allowlist = ["nvim( .*)?", "vim( .*)?", "htop", "less .*", "tail .*", "ssh .*"]
 
-# Denylist of commands lazy-tmux must never replay on restore, matched by program
-# name. Use this instead of an allowlist when you trust most commands and only
-# want to exclude a few (e.g. long-running servers). The denylist wins over the
-# allowlist: a denied command is skipped even if the allowlist would permit it.
-# Omit or leave empty to block nothing (the default).
-# restore_denylist = ["htop", "npm", "node"]
+# Denylist of commands lazy-tmux must never replay on restore. Each entry is a
+# regular expression matched against the full command (anchored). Use this
+# instead of an allowlist when you trust most commands and only want to exclude
+# a few. Write a literal command to block exactly it (e.g.
+# "node ./scripts/heavy-watch\.js --poll"), or wildcard the arguments (e.g.
+# "node .*"). The denylist wins over the allowlist: a denied command is skipped
+# even if the allowlist would permit it. Omit or leave empty to block nothing.
+# restore_denylist = ["htop", "npm .*", "node .*"]
 
 [scrollback]
 # Capture and replay shell pane scrollback on save/restore.
@@ -45,8 +49,8 @@ lines = 5000
 # Program integrations adapt interactive programs to lazy-tmux's save/restore.
 # When a pane runs a supported program, lazy-tmux records program-specific state
 # on save and replays a smarter command on restore. Integrations compose with
-# restore_allowlist: if an allowlist is set, the program must be in it (e.g.
-# "claude") for its command to be replayed.
+# restore_allowlist: if an allowlist is set, the replayed command must match it
+# (e.g. "claude .*" to permit the `claude --resume <id>` restore command).
 [integrations]
 # Master switch for all program integrations.
 enabled = true

--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"sort"
 	"strconv"
@@ -81,10 +82,10 @@ type Client struct {
 	runner        commandRunner
 	settleTimeout time.Duration
 
-	allowlist    map[string]struct{}
+	allowlist    []*regexp.Regexp
 	allowlistSet bool
 
-	denylist map[string]struct{}
+	denylist []*regexp.Regexp
 
 	resolver RestoreCommandResolver
 }
@@ -129,14 +130,7 @@ func (client *Client) SetRestoreAllowlist(list []string) {
 	}
 
 	client.allowlistSet = true
-	client.allowlist = make(map[string]struct{}, len(list))
-
-	for _, item := range list {
-		name := executableName(strings.TrimSpace(item))
-		if name != "" {
-			client.allowlist[name] = struct{}{}
-		}
-	}
+	client.allowlist = compileCommandPatterns(list)
 }
 
 func (client *Client) SetRestoreDenylist(list []string) {
@@ -146,14 +140,27 @@ func (client *Client) SetRestoreDenylist(list []string) {
 		return
 	}
 
-	client.denylist = make(map[string]struct{}, len(list))
+	client.denylist = compileCommandPatterns(list)
+}
+
+func compileCommandPatterns(list []string) []*regexp.Regexp {
+	patterns := make([]*regexp.Regexp, 0, len(list))
 
 	for _, item := range list {
-		name := executableName(strings.TrimSpace(item))
-		if name != "" {
-			client.denylist[name] = struct{}{}
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
 		}
+
+		re, err := regexp.Compile("^(?:" + item + ")$")
+		if err != nil {
+			continue
+		}
+
+		patterns = append(patterns, re)
 	}
+
+	return patterns
 }
 
 func (client *Client) SetRestoreResolver(resolver RestoreCommandResolver) {
@@ -845,7 +852,7 @@ func (client *Client) restoreWindowCommands(
 			continue
 		}
 
-		if !client.commandAllowed(executableName(cmd)) {
+		if !client.commandAllowed(cmd) {
 			continue
 		}
 
@@ -860,8 +867,10 @@ func (client *Client) restoreWindowCommands(
 	return nil
 }
 
-func (client *Client) commandAllowed(executable string) bool {
-	if _, denied := client.denylist[executable]; denied {
+func (client *Client) commandAllowed(command string) bool {
+	command = strings.TrimSpace(command)
+
+	if matchesAny(client.denylist, command) {
 		return false
 	}
 
@@ -869,9 +878,17 @@ func (client *Client) commandAllowed(executable string) bool {
 		return true
 	}
 
-	_, ok := client.allowlist[executable]
+	return matchesAny(client.allowlist, command)
+}
 
-	return ok
+func matchesAny(patterns []*regexp.Regexp, command string) bool {
+	for _, re := range patterns {
+		if re.MatchString(command) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (client *Client) expectedPaneCommands(windows []snapshot.Window) map[string]string {
@@ -879,8 +896,10 @@ func (client *Client) expectedPaneCommands(windows []snapshot.Window) map[string
 
 	for _, window := range windows {
 		for _, pane := range window.Panes {
-			exe := executableName(client.effectiveRestoreCommand(pane))
-			if exe == "" || !client.commandAllowed(exe) {
+			cmd := client.effectiveRestoreCommand(pane)
+
+			exe := executableName(cmd)
+			if exe == "" || !client.commandAllowed(cmd) {
 				continue
 			}
 

--- a/internal/tmux/client_internal_test.go
+++ b/internal/tmux/client_internal_test.go
@@ -275,19 +275,19 @@ func TestRestoreAllowlist(t *testing.T) {
 
 	client := NewClient("tmux")
 
-	if !client.commandAllowed("nvim") || !client.commandAllowed("rm") {
+	if !client.commandAllowed("nvim main.go") || !client.commandAllowed("rm -rf x") {
 		t.Fatal("with no allowlist, all commands must be allowed")
 	}
 
-	client.SetRestoreAllowlist([]string{"nvim", "/usr/bin/htop", "  tmux  "})
+	client.SetRestoreAllowlist([]string{"nvim( .*)?", "ssh .*", "htop"})
 
-	for _, allowed := range []string{"nvim", "htop", "tmux"} {
+	for _, allowed := range []string{"nvim", "nvim main.go", "ssh host", "htop"} {
 		if !client.commandAllowed(allowed) {
 			t.Fatalf("%q should be allowed", allowed)
 		}
 	}
 
-	for _, blocked := range []string{"rm", "bash", "node"} {
+	for _, blocked := range []string{"nvimble", "htop -d 5", "ssh", "node app.js"} {
 		if client.commandAllowed(blocked) {
 			t.Fatalf("%q should be blocked", blocked)
 		}
@@ -311,19 +311,25 @@ func TestRestoreDenylist(t *testing.T) {
 
 	client := NewClient("tmux")
 
-	if !client.commandAllowed("node") {
+	if !client.commandAllowed("node app.js") {
 		t.Fatal("with no denylist, all commands must be allowed")
 	}
 
-	client.SetRestoreDenylist([]string{"node", "/usr/bin/htop", "  npm  "})
+	client.SetRestoreDenylist(
+		[]string{`node ./scripts/heavy-watch\.js --poll`, "htop( .*)?", "npm .*"},
+	)
 
-	for _, blocked := range []string{"node", "htop", "npm"} {
+	for _, blocked := range []string{
+		"node ./scripts/heavy-watch.js --poll", "htop", "htop -d 5", "npm install",
+	} {
 		if client.commandAllowed(blocked) {
 			t.Fatalf("%q should be blocked", blocked)
 		}
 	}
 
-	for _, allowed := range []string{"nvim", "vim", "less"} {
+	for _, allowed := range []string{
+		"node ./scripts/heavy-watch.js", "node app.js", "nvim", "npm",
+	} {
 		if !client.commandAllowed(allowed) {
 			t.Fatalf("%q should be allowed", allowed)
 		}
@@ -331,7 +337,7 @@ func TestRestoreDenylist(t *testing.T) {
 
 	client.SetRestoreDenylist(nil)
 
-	if !client.commandAllowed("node") {
+	if !client.commandAllowed("node app.js") {
 		t.Fatal("a nil denylist must allow all commands again")
 	}
 }
@@ -341,14 +347,14 @@ func TestRestoreDenylistWinsOverAllowlist(t *testing.T) {
 
 	client := NewClient("tmux")
 
-	client.SetRestoreAllowlist([]string{"nvim", "node"})
-	client.SetRestoreDenylist([]string{"node"})
+	client.SetRestoreAllowlist([]string{"nvim( .*)?", "node .*"})
+	client.SetRestoreDenylist([]string{"node .*"})
 
-	if !client.commandAllowed("nvim") {
+	if !client.commandAllowed("nvim main.go") {
 		t.Fatal("nvim is allowed and not denied -> should be restored")
 	}
 
-	if client.commandAllowed("node") {
+	if client.commandAllowed("node app.js") {
 		t.Fatal("node is denied -> must be blocked even though the allowlist permits it")
 	}
 
@@ -364,19 +370,34 @@ func TestExpectedPaneCommandsRespectsAllowlist(t *testing.T) {
 		{
 			Index: 1,
 			Panes: []snapshot.Pane{
-				{Index: 0, RestoreCmd: "nvim"},
+				{Index: 0, RestoreCmd: "nvim main.go"},
 				{Index: 1, RestoreCmd: "htop"},
 			},
 		},
 	}
 
 	client := NewClient("tmux")
-	client.SetRestoreAllowlist([]string{"nvim"})
+	client.SetRestoreAllowlist([]string{"nvim .*"})
 
 	got := client.expectedPaneCommands(windows)
 
 	if len(got) != 1 || got["1.0"] != "nvim" {
 		t.Fatalf("allowlist should keep only nvim, got %#v", got)
+	}
+}
+
+func TestCompileCommandPatternsSkipsInvalid(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient("tmux")
+	client.SetRestoreDenylist([]string{"node .*", "(", "  "})
+
+	if client.commandAllowed("node app.js") {
+		t.Fatal("valid pattern in the list must still block")
+	}
+
+	if !client.commandAllowed("nvim") {
+		t.Fatal("an invalid/empty pattern must be skipped, not match everything")
 	}
 }
 


### PR DESCRIPTION
## Summary

`restore_allowlist` / `restore_denylist` matched only by **executable name** (`executableName(cmd)` → basename of the first field), so the finest control possible was "the program `node`". You could not block one specific long command, nor block a command by shape with wildcarded arguments.

Now each list entry is a **regular expression matched against the full command**, anchored end to end (`^(?:entry)$`):

- a literal command blocks exactly it — `node ./scripts/heavy-watch\.js --poll`;
- wildcard the arguments — `node .*`, `docker compose .* up`;
- `nvim( .*)?` allows `nvim` with or without arguments.

Precedence is unchanged (denylist still wins over allowlist; no list = allow all; empty allowlist = allow nothing).

**Backward compatibility is intentionally dropped** (agreed pre-release, while the user base is small and migrating is cheap): a bare `nvim` now matches only the exact command `nvim`, not `nvim main.go`. Old name-based configs must be rewritten as regexes (e.g. `nvim` → `nvim( .*)?`). The shipped `default.toml` examples were updated accordingly, so this is the right moment to lay it down cleanly rather than bolt compatibility shims on later.

## Behavior details

- Matching is against the exact command lazy-tmux would replay (`effectiveRestoreCommand`), the same string that goes to `send-keys` — including integration commands like `claude --resume <id>` (permit with `claude .*`).
- Invalid regex is a **startup error**, not a silent skip: config load fails with the offending list, entry and the compile error (`restore_denylist "(bad": invalid regular expression: ...`). Empty/whitespace entries are ignored.

## Files

- `internal/tmux/client.go`: allow/denylists become `[]*regexp.Regexp`; `compileCommandPatterns` (anchored) + `matchesAny`; `commandAllowed` takes the full command; both call sites pass the full command.
- `internal/config/config.go`: `validateCommandPatterns` rejects invalid regexes at load.
- `internal/config/default.toml`: examples/docs rewritten for regex.
- Tests: rewritten allow/deny/precedence tests for regex semantics, invalid-pattern-skipped test, and a config-level invalid-regex rejection test.

## Testing

- `make check` green (build, vet, golangci-lint, test, integration-test); 217 tests.
- Manual: invalid regex in config → `lazy-tmux list` exits 1 with a clear message; valid regex loads and `config show` echoes it.

Closes #226


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restore allow/deny rules now support regular expressions, letting you match full commands and arguments more flexibly.
  * Deny rules still take priority over allow rules.

* **Bug Fixes**
  * Invalid filter patterns are now detected during config loading, with clearer errors instead of failing later.
  * Empty entries are ignored, improving resilience of restore settings.

* **Documentation**
  * Updated restore filter guidance to explain regex matching and how allow/deny lists behave.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->