### PR TITLE
feat(picker): animate the working status dot

### DIFF
--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -22,7 +22,11 @@ var (
 
 const statusRefreshInterval = 2 * time.Second
 
+const spinnerInterval = 160 * time.Millisecond
+
 type statusTickMsg struct{}
+
+type spinnerTickMsg struct{}
 
 type pickerRow struct {
 	target     Target
@@ -39,27 +43,29 @@ type pickerRow struct {
 
 //nolint:recvcheck // deliberate value/pointer receiver mix, see above
 type pickerModel struct {
-	sessions    []Session
-	windowSort  []WindowSortKey
-	visible     []pickerRow
-	queryInput  textinput.Model
-	viewport    viewport.Model
-	theme       pickerTheme
-	selected    Target
-	cancelled   bool
-	cursor      int
-	width       int
-	height      int
-	actions     Actions
-	statusMsg   string
-	mode        pickerMode
-	action      actionMode
-	marked      map[string]struct{}
-	palette     bool
-	paletteIdx  int
-	promptInput textinput.Model
-	pending     Target
-	helpOpen    bool
+	sessions     []Session
+	windowSort   []WindowSortKey
+	visible      []pickerRow
+	queryInput   textinput.Model
+	viewport     viewport.Model
+	theme        pickerTheme
+	selected     Target
+	cancelled    bool
+	cursor       int
+	width        int
+	height       int
+	actions      Actions
+	statusMsg    string
+	mode         pickerMode
+	action       actionMode
+	marked       map[string]struct{}
+	palette      bool
+	paletteIdx   int
+	promptInput  textinput.Model
+	pending      Target
+	helpOpen     bool
+	spinnerFrame int
+	spinnerOn    bool
 }
 
 type pickerMode int
@@ -112,6 +118,7 @@ func newPickerModel(sessions []Session, windowSort []WindowSortKey, actions Acti
 		mode:       modeBrowse,
 		action:     actionBrowse,
 		marked:     make(map[string]struct{}),
+		spinnerOn:  true,
 	}
 	model.applyFilter()
 
@@ -119,11 +126,15 @@ func newPickerModel(sessions []Session, windowSort []WindowSortKey, actions Acti
 }
 
 func (m pickerModel) Init() tea.Cmd {
-	return tea.Batch(textinput.Blink, scheduleStatusRefresh())
+	return tea.Batch(textinput.Blink, scheduleStatusRefresh(), scheduleSpinner())
 }
 
 func scheduleStatusRefresh() tea.Cmd {
 	return tea.Tick(statusRefreshInterval, func(time.Time) tea.Msg { return statusTickMsg{} })
+}
+
+func scheduleSpinner() tea.Cmd {
+	return tea.Tick(spinnerInterval, func(time.Time) tea.Msg { return spinnerTickMsg{} })
 }
 
 func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -136,12 +147,9 @@ func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		return m, nil
 	case statusTickMsg:
-		if m.mode == modeBrowse && !m.palette {
-			m.reload()
-			m.renderViewport()
-		}
-
-		return m, scheduleStatusRefresh()
+		return m.handleStatusTick()
+	case spinnerTickMsg:
+		return m.handleSpinnerTick()
 	case tea.MouseWheelMsg:
 		return m.handleWheel(msg)
 	case tea.MouseClickMsg:
@@ -215,6 +223,50 @@ func (m pickerModel) View() tea.View {
 	view.MouseMode = tea.MouseModeCellMotion
 
 	return view
+}
+
+func (m pickerModel) handleStatusTick() (tea.Model, tea.Cmd) {
+	if m.mode == modeBrowse && !m.palette {
+		m.reload()
+		m.renderViewport()
+	}
+
+	cmds := []tea.Cmd{scheduleStatusRefresh()}
+	if m.hasWorkingWindow() && !m.spinnerOn {
+		m.spinnerOn = true
+		cmds = append(cmds, scheduleSpinner())
+	}
+
+	return m, tea.Batch(cmds...)
+}
+
+func (m pickerModel) handleSpinnerTick() (tea.Model, tea.Cmd) {
+	if !m.hasWorkingWindow() {
+		m.spinnerOn = false
+
+		return m, nil
+	}
+
+	m.spinnerFrame++
+
+	if m.mode == modeBrowse && !m.palette {
+		m.applyFilter()
+		m.renderViewport()
+	}
+
+	return m, scheduleSpinner()
+}
+
+func (m pickerModel) hasWorkingWindow() bool {
+	for _, sess := range m.sessions {
+		for _, status := range sess.Statuses {
+			if status == StatusWorking {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func (m pickerModel) handleWheel(msg tea.MouseWheelMsg) (tea.Model, tea.Cmd) {
@@ -791,7 +843,7 @@ func (m *pickerModel) applyFilter() {
 		query = strings.TrimSpace(strings.ToLower(m.queryInput.Value()))
 	}
 
-	rows := filteredTreeRows(m.modeSessions(), query, m.windowSort)
+	rows := filteredTreeRows(m.modeSessions(), query, m.windowSort, m.spinnerFrame)
 	m.visible = m.decorateRows(rows)
 
 	if len(m.visible) == 0 {

--- a/internal/picker/model_internal_test.go
+++ b/internal/picker/model_internal_test.go
@@ -137,6 +137,87 @@ func newTestModel(t *testing.T, rec *recordingActions, sessions ...Session) pick
 	return m
 }
 
+func workingSession(name string) Session {
+	sess := makeSession(name, true, "one")
+	sess.Statuses = map[int]WindowStatus{1: StatusWorking}
+
+	return sess
+}
+
+func TestHasWorkingWindow(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+
+	if !newTestModel(t, rec, workingSession("w")).hasWorkingWindow() {
+		t.Fatal("a working window must be detected")
+	}
+
+	idle := makeSession("i", true, "one")
+	idle.Statuses = map[int]WindowStatus{1: StatusIdle}
+
+	if newTestModel(t, rec, idle).hasWorkingWindow() {
+		t.Fatal("no working window must be reported")
+	}
+}
+
+func TestSpinnerTickAdvancesFrameWhileWorking(t *testing.T) {
+	t.Parallel()
+
+	m := newTestModel(t, &recordingActions{}, workingSession("w"))
+	before := m.spinnerFrame
+
+	next, cmd := m.handleSpinnerTick()
+	updated, _ := next.(pickerModel)
+
+	if updated.spinnerFrame != before+1 {
+		t.Fatalf("frame should advance, got %d want %d", updated.spinnerFrame, before+1)
+	}
+
+	if cmd == nil {
+		t.Fatal("a working spinner tick must reschedule itself")
+	}
+}
+
+func TestSpinnerTickStopsWhenIdle(t *testing.T) {
+	t.Parallel()
+
+	idle := makeSession("i", true, "one")
+	idle.Statuses = map[int]WindowStatus{1: StatusIdle}
+
+	m := newTestModel(t, &recordingActions{}, idle)
+	m.spinnerOn = true
+
+	next, cmd := m.handleSpinnerTick()
+	updated, _ := next.(pickerModel)
+
+	if updated.spinnerOn {
+		t.Fatal("spinner must switch off when no window is working")
+	}
+
+	if cmd != nil {
+		t.Fatal("a stopped spinner must not reschedule")
+	}
+}
+
+func TestStatusTickResumesSpinnerOnWork(t *testing.T) {
+	t.Parallel()
+
+	m := newTestModel(t, &recordingActions{}, workingSession("w"))
+	m.spinnerOn = false
+
+	next, cmd := m.handleStatusTick()
+	updated, _ := next.(pickerModel)
+
+	if !updated.spinnerOn {
+		t.Fatal("a status tick must resume the spinner when a working window exists")
+	}
+
+	if cmd == nil {
+		t.Fatal("status tick must schedule follow-up commands")
+	}
+}
+
 func TestModelNavigationAndSelect(t *testing.T) {
 	t.Parallel()
 

--- a/internal/picker/model_internal_test.go
+++ b/internal/picker/model_internal_test.go
@@ -549,7 +549,7 @@ func TestFilteredTreeRowsAndTable(t *testing.T) {
 
 	sessions := []Session{makeSession("alpha", true, "edit", "shell")}
 
-	rows := filteredTreeRows(sessions, "", DefaultSortOptions().Window)
+	rows := filteredTreeRows(sessions, "", DefaultSortOptions().Window, 0)
 	if len(rows) != 3 {
 		t.Fatalf("expected header + 2 window rows, got %d", len(rows))
 	}

--- a/internal/picker/rows.go
+++ b/internal/picker/rows.go
@@ -11,7 +11,12 @@ import (
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
 )
 
-func filteredTreeRows(sessions []Session, query string, windowSort []WindowSortKey) []pickerRow {
+func filteredTreeRows(
+	sessions []Session,
+	query string,
+	windowSort []WindowSortKey,
+	spinnerFrame int,
+) []pickerRow {
 	rows := make([]pickerRow, 0)
 
 	for _, sess := range sessions {
@@ -48,26 +53,26 @@ func filteredTreeRows(sessions []Session, query string, windowSort []WindowSortK
 				branch = "╰─"
 			}
 
-			windowIdx := win.Index
-
-			status := sess.Statuses[win.Index]
-			state := statusGlyph(status)
-
-			rows = append(rows, pickerRow{
-				target:     Target{SessionName: sess.Record.SessionName, WindowIndex: &windowIdx},
-				item:       fmt.Sprintf("  %s [%d] %s", branch, win.Index, win.Name),
-				captured:   "",
-				wins:       "",
-				state:      state,
-				status:     status,
-				cmd:        windowPreviewCommand(win),
-				windowName: win.Name,
-				selectable: true,
-			})
+			rows = append(rows, windowRow(sess, win, branch, spinnerFrame))
 		}
 	}
 
 	return rows
+}
+
+func windowRow(sess Session, win snapshot.Window, branch string, spinnerFrame int) pickerRow {
+	windowIdx := win.Index
+	status := sess.Statuses[win.Index]
+
+	return pickerRow{
+		target:     Target{SessionName: sess.Record.SessionName, WindowIndex: &windowIdx},
+		item:       fmt.Sprintf("  %s [%d] %s", branch, win.Index, win.Name),
+		state:      statusGlyphFrame(status, spinnerFrame),
+		status:     status,
+		cmd:        windowPreviewCommand(win),
+		windowName: win.Name,
+		selectable: true,
+	}
 }
 
 func (m pickerModel) modeSessions() []Session {

--- a/internal/picker/theme.go
+++ b/internal/picker/theme.go
@@ -57,6 +57,17 @@ const (
 	glyphError            = "✕"
 )
 
+//nolint:gochecknoglobals // static spinner frame table, never mutated
+var workingSpinnerFrames = []string{"◐", "◓", "◑", "◒"}
+
+func statusGlyphFrame(status WindowStatus, frame int) string {
+	if status == StatusWorking {
+		return workingSpinnerFrames[frame%len(workingSpinnerFrames)]
+	}
+
+	return statusGlyph(status)
+}
+
 func statusGlyph(status WindowStatus) string {
 	switch status {
 	case StatusWorking:

--- a/internal/picker/view_internal_test.go
+++ b/internal/picker/view_internal_test.go
@@ -53,13 +53,34 @@ func TestViewRendersStatusDot(t *testing.T) {
 
 	m := newTestModel(t, rec, sess)
 
-	if !strings.Contains(m.View().Content, glyphWorking) {
-		t.Fatal("expected a working status glyph in the rendered view")
+	if !strings.Contains(m.View().Content, workingSpinnerFrames[0]) {
+		t.Fatal("expected the working spinner glyph in the rendered view")
 	}
 
 	plain := makeSession("plain", true, "vim")
 
-	if strings.Contains(newTestModel(t, rec, plain).View().Content, glyphWorking) {
+	if strings.Contains(newTestModel(t, rec, plain).View().Content, workingSpinnerFrames[0]) {
 		t.Fatal("window without a status must not render a glyph")
+	}
+}
+
+func TestStatusGlyphFrameAnimatesWorking(t *testing.T) {
+	t.Parallel()
+
+	for i, frame := range workingSpinnerFrames {
+		if got := statusGlyphFrame(StatusWorking, i); got != frame {
+			t.Fatalf("frame %d: got %q want %q", i, got, frame)
+		}
+	}
+
+	if got := statusGlyphFrame(
+		StatusWorking,
+		len(workingSpinnerFrames),
+	); got != workingSpinnerFrames[0] {
+		t.Fatal("frame index must wrap around")
+	}
+
+	if got := statusGlyphFrame(StatusIdle, 3); got != glyphIdle {
+		t.Fatalf("non-working status must stay static, got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

The picker's Claude status dots were static. This animates the **working** status as a rotating half-circle spinner (`◐ ◓ ◑ ◒`), so a glance at the picker shows which Claude windows are actively generating — the idea borrowed from [ccmux](https://github.com/epilande/ccmux). All other statuses stay static (awaiting-decision `?`, awaiting-input `◌`, idle `○`, error `✕`).

## How it works

- `statusGlyphFrame(status, frame)` returns the spinner frame for `StatusWorking` and the normal static glyph otherwise. `filteredTreeRows` bakes it per render, so the glyph reflects the current frame.
- A dedicated ~160ms spinner tick (`spinnerTickMsg`) advances a single `spinnerFrame` counter and re-renders — separate from the existing 2s data-refresh tick, so animating never refetches session data.
- **Gated on work, like ccmux's ref-counted timer:** the spinner tick only reschedules while at least one visible window is `working`; when none are, it stops (no wasted redraws on an idle picker) and the 2s refresh restarts it when a working window reappears. This matters because a terminal has no partial repaint — every frame is a full-buffer redraw, so 160ms was chosen deliberately (ccmux measured ~5.5% of a core at 100ms).
- Rendering is skipped outside browse mode / palette, but the frame still advances so the animation stays time-consistent.

## Files

- `internal/picker/theme.go`: spinner frames + `statusGlyphFrame`.
- `internal/picker/rows.go`: thread `spinnerFrame` through `filteredTreeRows`; extract `windowRow`.
- `internal/picker/model.go`: `spinnerFrame`/`spinnerOn` state, `scheduleSpinner`, `handleSpinnerTick`/`handleStatusTick`, work-gated ticker.
- Tests: spinner cycles + wraps and non-working stays static; view test asserts the working spinner glyph renders.

## Testing

- `make check` green (build, vet, golangci-lint, test, integration-test); 218 tests.
- Both `lazy-tmux` and `lazy-tmux-fzf` build (animation lives in the native TUI; the fzf path is unaffected).

## Notes

Only the animation ships here. The other ccmux ideas we discussed — jump-to-next-attention, richer `waiting` subtypes, and the "done but unseen" highlight — are tracked separately for post-discussion follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an animated “working” status indicator in the picker, with the symbol advancing frame-by-frame for active windows.
  * The picker now refreshes this working animation independently during browsing for smoother visual feedback.

* **Bug Fixes**
  * Ensured status indicators and rendered rows stay synchronized with the current animation frame.
  * The spinner stops when there are no working windows, and resumes appropriately after status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->