### PR TITLE
build: make sandbox install locally built binary instead of release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ cover.html
 # docs site (Vite): dependencies and caches
 node_modules/
 .vite/
+
+# local sandbox binary (make sandbox)
+docker/local-bin/lazy-tmux

--- a/Makefile
+++ b/Makefile
@@ -80,13 +80,17 @@ docker-hub:
 	podman tag lazy-tmux:$$SANDBOX_TAG alchemmist/lazy-tmux:$$SANDBOX_TAG; \
 	podman push alchemmist/lazy-tmux:$$SANDBOX_TAG
 
-# Build and drop into the interactive sandbox. Pick the tmux version with
-# TMUX_VERSION (defaults to 3.6a); each version gets its own cached image tag.
+# Build and drop into the interactive sandbox. The sandbox installs the
+# lazy-tmux binary built from the current working tree (including uncommitted
+# changes), not the last release, so you test the code in front of you. Pick the
+# tmux version with TMUX_VERSION (defaults to 3.6a); each version gets its own
+# cached image tag.
 #   make sandbox                  # tmux 3.6a
 #   make sandbox TMUX_VERSION=3.5a
 TMUX_VERSION ?= 3.6a
 sandbox:
-	podman build --build-arg TMUX_VERSION=$(TMUX_VERSION) -t lazy-tmux:local-$(TMUX_VERSION) -f docker/sandbox.Dockerfile .
+	CGO_ENABLED=0 GOOS=linux GOARCH=$$(go env GOARCH) go build -o docker/local-bin/$(BINARY) ./cmd/$(BINARY)
+	podman build --build-arg TMUX_VERSION=$(TMUX_VERSION) --build-arg LAZY_TMUX_SOURCE=local -t lazy-tmux:local-$(TMUX_VERSION) -f docker/sandbox.Dockerfile .
 	podman run -it --rm lazy-tmux:local-$(TMUX_VERSION)
 
 test-sup-versions:
@@ -109,4 +113,4 @@ docs-preview: docs-build
 	npm --prefix docs run preview
 
 clean:
-	rm -rf bin dist coverage.out cover.html cover.out .cache
+	rm -rf bin dist coverage.out cover.html cover.out .cache docker/local-bin/$(BINARY)

--- a/docker/sandbox.Dockerfile
+++ b/docker/sandbox.Dockerfile
@@ -50,7 +50,19 @@ RUN echo "source /root/.tmux/welcome.sh" >> /root/.zshrc
 COPY docker/welcome.sh /root/.tmux/welcome.sh
 RUN chmod +x /root/.tmux/welcome.sh
 
-RUN curl -fsSL https://lazy-tmux.xyz/install.sh | sh
+# Where the lazy-tmux binary comes from. "release" (default) downloads the
+# latest published release — used by `make docker-hub` for the image the docs
+# tell users to run. "local" installs the binary built from the current working
+# tree (see `make sandbox`), so dev testing runs the code in front of you,
+# including uncommitted changes, instead of the last release.
+ARG LAZY_TMUX_SOURCE=release
+COPY docker/local-bin/ /tmp/lazy-tmux-bin/
+RUN if [ "$LAZY_TMUX_SOURCE" = "local" ]; then \
+        install -m 0755 /tmp/lazy-tmux-bin/lazy-tmux /usr/local/bin/lazy-tmux; \
+    else \
+        curl -fsSL https://lazy-tmux.xyz/install.sh | sh; \
+    fi; \
+    rm -rf /tmp/lazy-tmux-bin
 
 COPY docker/test-versions-inner.sh /test-versions-inner.sh
 RUN chmod +x /test-versions-inner.sh


### PR DESCRIPTION
## What

`make sandbox` now installs the lazy-tmux binary built from the current working tree (including uncommitted changes) instead of downloading the last published release. This makes local dev testing run the code in front of you.

## Why

- The previous `curl … lazy-tmux.xyz/install.sh | sh` step also broke builds on transient TLS/CDN errors.
- Testing the sandbox against the *released* binary meant local changes were never actually exercised.

## How

- `docker/sandbox.Dockerfile` gains a `LAZY_TMUX_SOURCE` build arg: `release` (default) keeps the `curl install.sh` path used by `make docker-hub` / the published `alchemmist/lazy-tmux:latest` image the docs tell users to run; `local` installs a pre-built binary from `docker/local-bin/`.
- `make sandbox` cross-compiles `./cmd/lazy-tmux` for `linux/$(go env GOARCH)` into `docker/local-bin/` and builds with `--build-arg LAZY_TMUX_SOURCE=local`.
- `docker/local-bin/` is kept in the build context via `.gitkeep`; the built binary is gitignored and cleaned by `make clean`.

## Verification

- `make sandbox` image build succeeds; `sha256` of `/usr/local/bin/lazy-tmux` inside the image matches the locally built binary, and `lazy-tmux --version` reports a `+dirty` working-tree build.
- The published-image path is unchanged: `make docker-hub` still defaults to `LAZY_TMUX_SOURCE=release`.