### PR TITLE
feat: add configurable restore handler

### DIFF
--- a/docs/src/pages/Configuration.tsx
+++ b/docs/src/pages/Configuration.tsx
@@ -44,7 +44,8 @@ tmux_bin        = "tmux"                       # tmux binary to use
 data_dir        = "~/.local/share/lazy-tmux"   # where snapshots are stored (~ is expanded)
 save_interval   = "5m"                         # daemon autosave interval (Go duration)
 restore_timeout = "5s"                         # max wait for restored pane commands to start (0 disables)
-restore_handler = ""                           # optional handler run instead of saved commands
+restore_handler = ""                           # optional handler run instead of direct replay
+restore_handler_source = "saved"               # saved | resolved (exact, case-sensitive)
 # restore_handler = "echo"
 # restore_handler = "cowsay -f tux"
 
@@ -68,22 +69,34 @@ lines   = 5000    # max scrollback lines per pane`}</CodeBlock>
         <p className="muted">
           <InlineCode>restore_handler</InlineCode> is empty by default, which
           preserves direct application replay. A non-empty value is a trusted
-          shell prefix that runs instead of the saved command. lazy-tmux appends
-          the normalized saved command as one safely single-quoted argument, so
+          shell prefix that runs instead of direct replay. lazy-tmux appends the
+          selected command source as one safely single-quoted argument, so
           values such as <InlineCode>echo</InlineCode> and{" "}
-          <InlineCode>cowsay -f tux</InlineCode> receive the saved command as a
+          <InlineCode>cowsay -f tux</InlineCode> receive the selected command as a
           single argument. Surrounding whitespace is trimmed, but the prefix is
           not otherwise parsed or home-expanded.
         </p>
         <p className="muted">
-          For terminal safety, C0 control bytes and DEL in a saved command are
-          represented visibly as lowercase <InlineCode>\xNN</InlineCode> text
-          instead of being passed through exactly. Printable text and Unicode
-          remain unchanged.
+          <InlineCode>restore_handler_source</InlineCode> accepts only the exact,
+          case-sensitive values <InlineCode>saved</InlineCode> and{" "}
+          <InlineCode>resolved</InlineCode>; omission defaults to{" "}
+          <InlineCode>saved</InlineCode>. Saved mode passes the normalized
+          snapshot command and suppresses integration output. Resolved mode uses
+          non-empty integration resolver output, then falls back to the normalized
+          snapshot command. A non-empty shell-only resolver result is selected and
+          skipped rather than falling back again. The setting does nothing when
+          the handler is empty, so direct replay behavior is unchanged.
         </p>
         <p className="muted">
-          Handler mode replaces integration resume behavior, leaves empty and
-          shell-only panes untouched, and does not wait for{" "}
+          For terminal safety, C0 control bytes and DEL in the selected command are
+          represented visibly as lowercase <InlineCode>\xNN</InlineCode> text
+          instead of being passed through exactly. Printable text and Unicode
+          remain unchanged. The complete safely quoted handler line is sent as
+          literal tmux input, followed by a separate Enter dispatch.
+        </p>
+        <p className="muted">
+          Both source modes leave empty and shell-only selected commands untouched
+          and do not wait for{" "}
           <InlineCode>restore_timeout</InlineCode>. Handler shell parse errors,
           missing executables, and non-zero exits appear in the pane but cannot
           affect lazy-tmux&apos;s exit code; tmux dispatch failures are still
@@ -115,12 +128,21 @@ lines   = 5000    # max scrollback lines per pane`}</CodeBlock>
         <p className="muted">
           Each regular expression is anchored against the complete selected
           command string. In direct mode that is the effective replay command,
-          including integration output. In handler mode it is the normalized
-          saved command before the handler is added. Therefore{" "}
+          including integration output. In handler mode it is the saved or
+          resolved source before encoding and before the handler is added; the
+          handler invocation itself is never matched. Therefore{" "}
           <InlineCode>nvim</InlineCode> matches only that exact command; use{" "}
           <InlineCode>nvim( .*)?</InlineCode> to also permit arguments. A path
           such as <InlineCode>/usr/bin/nvim main.go</InlineCode> requires a
           pattern that includes the path.
+        </p>
+        <p className="muted">
+          For a Claude pane, <InlineCode>claude</InlineCode> permits the saved
+          source but not <InlineCode>claude --resume sess-9</InlineCode>, while{" "}
+          <InlineCode>claude --resume .*</InlineCode> permits the resolved command
+          but not the saved source. Claude Code is the only current production
+          integration; with <InlineCode>claude.session_id</InlineCode> metadata,
+          resolved mode can pass <InlineCode>claude --resume &lt;session-id&gt;</InlineCode>.
         </p>
 
         <h3 className="cli-subtitle">Restore command denylist</h3>
@@ -133,7 +155,8 @@ lines   = 5000    # max scrollback lines per pane`}</CodeBlock>
           <strong>wins over it</strong> — a command is replayed only when it is
           not denied and (no allowlist is set or it is allowed). It uses the
           same anchored, complete-command matching as the allowlist; an omitted
-          or empty list blocks nothing.
+          or empty list blocks nothing. Like the allowlist, it checks the selected
+          source and never the generated handler invocation.
         </p>
 
         <h3 className="cli-subtitle">Restore settle timeout</h3>
@@ -143,7 +166,10 @@ lines   = 5000    # max scrollback lines per pane`}</CodeBlock>
           <InlineCode>restore_timeout</InlineCode> /{" "}
           <InlineCode>--restore-timeout</InlineCode>), so automation can trust the
           session is fully restored once the command exits. Set it to{" "}
-          <InlineCode>0</InlineCode> to opt out and return immediately.
+          <InlineCode>0</InlineCode> to opt out and return immediately. A non-empty
+          handler is asynchronous and never waits in either source mode; when the
+          handler is empty, direct resolver, filtering, and settle behavior remain
+          unchanged.
         </p>
       </section>
     </>

--- a/docs/src/pages/Configuration.tsx
+++ b/docs/src/pages/Configuration.tsx
@@ -7,7 +7,7 @@ export function Configuration() {
     <>
       <Seo
         title="Configuration — lazy-tmux"
-        description="lazy-tmux TOML config file: lookup order, precedence, restore command allow/denylist and restore settle timeout."
+        description="lazy-tmux TOML config file: lookup order, precedence, restore handler, command allow/denylist, and settle timeout."
         slug="configuration"
       />
       <section className="doc-section">
@@ -44,21 +44,51 @@ tmux_bin        = "tmux"                       # tmux binary to use
 data_dir        = "~/.local/share/lazy-tmux"   # where snapshots are stored (~ is expanded)
 save_interval   = "5m"                         # daemon autosave interval (Go duration)
 restore_timeout = "5s"                         # max wait for restored pane commands to start (0 disables)
+restore_handler = ""                           # optional handler run instead of saved commands
+# restore_handler = "echo"
+# restore_handler = "cowsay -f tux"
 
-# Allowlist of commands lazy-tmux may replay on restore, matched by program name.
-# Omit this key to restore every command (default). Provide a list to restore
-# only those programs; use an empty list [] to restore no commands at all.
-restore_allowlist = ["nvim", "vim", "htop", "less", "tail", "ssh"]
+# Allowlist of commands lazy-tmux may replay or handle on restore. Patterns are
+# anchored against the complete selected command. Omit this key to allow every
+# command (default); use an empty list [] to allow no commands at all.
+restore_allowlist = ["nvim( .*)?", "vim( .*)?", "htop", "less .*", "tail .*", "ssh .*"]
 
-# Denylist of commands lazy-tmux must never replay, matched by program name.
+# Denylist of commands lazy-tmux must never replay or handle, using the same
+# complete-command matching.
 # Use this instead of an allowlist when you trust most commands and only want to
 # exclude a few. The denylist wins over the allowlist. Omit or leave empty to
 # block nothing (default).
-restore_denylist = ["npm", "node"]
+restore_denylist = ["npm( .*)?", "node( .*)?"]
 
 [scrollback]
 enabled = false   # capture shell pane scrollback
 lines   = 5000    # max scrollback lines per pane`}</CodeBlock>
+
+        <h3 className="cli-subtitle">Restore handler</h3>
+        <p className="muted">
+          <InlineCode>restore_handler</InlineCode> is empty by default, which
+          preserves direct application replay. A non-empty value is a trusted
+          shell prefix that runs instead of the saved command. lazy-tmux appends
+          the normalized saved command as one safely single-quoted argument, so
+          values such as <InlineCode>echo</InlineCode> and{" "}
+          <InlineCode>cowsay -f tux</InlineCode> receive the saved command as a
+          single argument. Surrounding whitespace is trimmed, but the prefix is
+          not otherwise parsed or home-expanded.
+        </p>
+        <p className="muted">
+          For terminal safety, C0 control bytes and DEL in a saved command are
+          represented visibly as lowercase <InlineCode>\xNN</InlineCode> text
+          instead of being passed through exactly. Printable text and Unicode
+          remain unchanged.
+        </p>
+        <p className="muted">
+          Handler mode replaces integration resume behavior, leaves empty and
+          shell-only panes untouched, and does not wait for{" "}
+          <InlineCode>restore_timeout</InlineCode>. Handler shell parse errors,
+          missing executables, and non-zero exits appear in the pane but cannot
+          affect lazy-tmux&apos;s exit code; tmux dispatch failures are still
+          returned.
+        </p>
 
         <h3 className="cli-subtitle">Restore command allowlist</h3>
         <p className="muted">
@@ -68,22 +98,29 @@ lines   = 5000    # max scrollback lines per pane`}</CodeBlock>
         </p>
         <ul>
           <li>
-            <strong>key omitted</strong> → every command is restored (default).
+            <strong>key omitted</strong> → every eligible command is replayed or
+            handled (default).
           </li>
           <li>
-            <strong>list given</strong> → only those programs are replayed; any
-            other pane is left at the shell.
+            <strong>list given</strong> → only matching commands are replayed or
+            handled; any other pane is left at the shell.
           </li>
           <li>
             <strong>
               empty list <InlineCode>[]</InlineCode>
             </strong>{" "}
-            → no commands are restored at all.
+            → no commands are replayed or handled at all.
           </li>
         </ul>
         <p className="muted">
-          Matching is by program name, so <InlineCode>nvim</InlineCode> also
-          matches <InlineCode>/usr/bin/nvim main.go</InlineCode>.
+          Each regular expression is anchored against the complete selected
+          command string. In direct mode that is the effective replay command,
+          including integration output. In handler mode it is the normalized
+          saved command before the handler is added. Therefore{" "}
+          <InlineCode>nvim</InlineCode> matches only that exact command; use{" "}
+          <InlineCode>nvim( .*)?</InlineCode> to also permit arguments. A path
+          such as <InlineCode>/usr/bin/nvim main.go</InlineCode> requires a
+          pattern that includes the path.
         </p>
 
         <h3 className="cli-subtitle">Restore command denylist</h3>
@@ -94,8 +131,9 @@ lines   = 5000    # max scrollback lines per pane`}</CodeBlock>
           everything and just want to stop a long-running server or a program
           that re-prompts from being replayed. It composes with the allowlist and{" "}
           <strong>wins over it</strong> — a command is replayed only when it is
-          not denied and (no allowlist is set or it is allowed). Matching is by
-          program name, and an omitted or empty list blocks nothing.
+          not denied and (no allowlist is set or it is allowed). It uses the
+          same anchored, complete-command matching as the allowlist; an omitted
+          or empty list blocks nothing.
         </p>
 
         <h3 className="cli-subtitle">Restore settle timeout</h3>

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -76,6 +76,9 @@ func New(cfg config.Config) *App {
 	client := tmux.NewClient(config.ExpandHome(cfg.TmuxBin))
 	client.SetRestoreTimeout(cfg.RestoreTimeout)
 	client.SetRestoreHandler(cfg.RestoreHandler)
+	client.SetRestoreHandlerUseResolver(
+		cfg.RestoreHandlerSource == config.RestoreHandlerSourceResolved,
+	)
 	client.SetRestoreAllowlist(cfg.RestoreAllowlist)
 	client.SetRestoreDenylist(cfg.RestoreDenylist)
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -75,6 +75,7 @@ type App struct {
 func New(cfg config.Config) *App {
 	client := tmux.NewClient(config.ExpandHome(cfg.TmuxBin))
 	client.SetRestoreTimeout(cfg.RestoreTimeout)
+	client.SetRestoreHandler(cfg.RestoreHandler)
 	client.SetRestoreAllowlist(cfg.RestoreAllowlist)
 	client.SetRestoreDenylist(cfg.RestoreDenylist)
 

--- a/internal/app/app_internal_test.go
+++ b/internal/app/app_internal_test.go
@@ -335,51 +335,108 @@ func TestNewWiresRestoreHandler(t *testing.T) {
 	)
 
 	dir := t.TempDir()
-	cfg := config.Default()
-	cfg.DataDir = dir
-	cfg.RestoreHandler = `printf 'restore-handler:%s\n'`
-	a := New(cfg)
-
-	snap := snapshot.SessionSnapshot{
-		Version:     snapshot.FormatVersion,
-		SessionName: "handled",
-		Windows: []snapshot.Window{
-			{
-				Index: 0,
-				Name:  "main",
-				Panes: []snapshot.Pane{
-					{Index: 0, CurrentPath: dir, CurrentCmd: "nvim", RestoreCmd: "nvim main.go"},
-				},
-			},
+	tests := []struct {
+		name   string
+		source string
+		meta   map[string]string
+		want   string
+	}{
+		{
+			name:   "default-saved",
+			source: config.RestoreHandlerSourceSaved,
+			meta:   map[string]string{"claude.session_id": "sess-9"},
+			want:   "claude",
+		},
+		{
+			name:   "programmatic-zero",
+			source: "",
+			meta:   map[string]string{"claude.session_id": "sess-9"},
+			want:   "claude",
+		},
+		{
+			name:   "programmatic-invalid",
+			source: "bogus",
+			meta:   map[string]string{"claude.session_id": "sess-9"},
+			want:   "claude",
+		},
+		{
+			name:   "resolved",
+			source: config.RestoreHandlerSourceResolved,
+			meta:   map[string]string{"claude.session_id": "sess-9"},
+			want:   "claude --resume sess-9",
+		},
+		{
+			name:   "resolved-fallback",
+			source: config.RestoreHandlerSourceResolved,
+			want:   "claude",
 		},
 	}
-	if err := a.store.SaveSession(snap); err != nil {
-		t.Fatalf("save snapshot: %v", err)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := config.Default()
+			cfg.DataDir = dir
+			cfg.RestoreHandler = `printf 'restore-handler:[%s]\n'`
+			cfg.RestoreHandlerSource = test.source
+			a := New(cfg)
+
+			snap := snapshot.SessionSnapshot{
+				Version:     snapshot.FormatVersion,
+				SessionName: test.name,
+				Windows: []snapshot.Window{
+					{
+						Index: 0,
+						Name:  "main",
+						Panes: []snapshot.Pane{
+							{
+								Index:       0,
+								CurrentPath: dir,
+								CurrentCmd:  "claude",
+								RestoreCmd:  "claude",
+								Meta:        test.meta,
+							},
+						},
+					},
+				},
+			}
+			if err := a.store.SaveSession(snap); err != nil {
+				t.Fatalf("save snapshot: %v", err)
+			}
+
+			if err := a.Restore(test.name, false); err != nil {
+				t.Fatalf("restore snapshot: %v", err)
+			}
+
+			wantOutput := "restore-handler:[" + test.want + "]"
+			deadline := time.Now().Add(2 * time.Second)
+			var lastOutput string
+			var lastErr error
+			for time.Now().Before(deadline) {
+				output, err := testutil.TmuxTry(
+					"capture-pane",
+					"-p",
+					"-t",
+					"="+test.name+":0.0",
+				)
+				lastOutput = output
+				lastErr = err
+				if err == nil && strings.Contains(output, wantOutput) {
+					break
+				}
+
+				time.Sleep(20 * time.Millisecond)
+			}
+
+			if !strings.Contains(lastOutput, wantOutput) {
+				t.Fatalf(
+					"handler output %q did not appear: output %q, error %v",
+					wantOutput,
+					lastOutput,
+					lastErr,
+				)
+			}
+		})
 	}
-
-	if err := a.Restore("handled", false); err != nil {
-		t.Fatalf("restore snapshot: %v", err)
-	}
-
-	deadline := time.Now().Add(2 * time.Second)
-	var lastOutput string
-	var lastErr error
-	for time.Now().Before(deadline) {
-		output, err := testutil.TmuxTry("capture-pane", "-p", "-t", "=handled:0.0")
-		lastOutput = output
-		lastErr = err
-		if err == nil && strings.Contains(output, "restore-handler:nvim main.go") {
-			return
-		}
-
-		time.Sleep(20 * time.Millisecond)
-	}
-
-	t.Fatalf(
-		"handler output did not appear in restored pane: output %q, error %v",
-		lastOutput,
-		lastErr,
-	)
 }
 
 //nolint:paralleltest // uses a real shared tmux server via testutil.IsolatedTmux (t.Setenv)

--- a/internal/app/app_internal_test.go
+++ b/internal/app/app_internal_test.go
@@ -1,8 +1,10 @@
 package app
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -318,6 +320,138 @@ func TestSaveAllRestoreSleepWakeup(t *testing.T) {
 	if err := a.Restore("s2", false); err != nil {
 		t.Fatalf("restore existing should be tolerant: %v", err)
 	}
+}
+
+//nolint:paralleltest // uses a real shared tmux server via testutil.IsolatedTmux (t.Setenv)
+func TestNewWiresRestoreHandler(t *testing.T) {
+	testutil.IsolatedTmux(t)
+	testutil.Tmux(t, "set-option", "-g", "default-shell", "/bin/sh")
+	testutil.Tmux(
+		t,
+		"set-option",
+		"-g",
+		"default-command",
+		`IFS= read -r command; eval "$command"; sleep 2`,
+	)
+
+	dir := t.TempDir()
+	cfg := config.Default()
+	cfg.DataDir = dir
+	cfg.RestoreHandler = `printf 'restore-handler:%s\n'`
+	a := New(cfg)
+
+	snap := snapshot.SessionSnapshot{
+		Version:     snapshot.FormatVersion,
+		SessionName: "handled",
+		Windows: []snapshot.Window{
+			{
+				Index: 0,
+				Name:  "main",
+				Panes: []snapshot.Pane{
+					{Index: 0, CurrentPath: dir, CurrentCmd: "nvim", RestoreCmd: "nvim main.go"},
+				},
+			},
+		},
+	}
+	if err := a.store.SaveSession(snap); err != nil {
+		t.Fatalf("save snapshot: %v", err)
+	}
+
+	if err := a.Restore("handled", false); err != nil {
+		t.Fatalf("restore snapshot: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var lastOutput string
+	var lastErr error
+	for time.Now().Before(deadline) {
+		output, err := testutil.TmuxTry("capture-pane", "-p", "-t", "=handled:0.0")
+		lastOutput = output
+		lastErr = err
+		if err == nil && strings.Contains(output, "restore-handler:nvim main.go") {
+			return
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatalf(
+		"handler output did not appear in restored pane: output %q, error %v",
+		lastOutput,
+		lastErr,
+	)
+}
+
+//nolint:paralleltest // uses a real shared tmux server via testutil.IsolatedTmux (t.Setenv)
+func TestRestoreHandlerEncodesTerminalControlBytes(t *testing.T) {
+	if _, err := os.Stat("/bin/bash"); err != nil {
+		t.Skip("/bin/bash is required for the terminal-control regression")
+	}
+
+	testutil.IsolatedTmux(t)
+	testutil.Tmux(t, "set-option", "-g", "default-shell", "/bin/bash")
+	testutil.Tmux(
+		t,
+		"set-option",
+		"-g",
+		"default-command",
+		"exec /bin/bash --noprofile --norc -i",
+	)
+
+	dir := t.TempDir()
+	markerPath := filepath.Join(dir, "exploit-executed")
+	quotedMarkerPath := "'" + strings.ReplaceAll(markerPath, "'", "'\\''") + "'"
+	cfg := config.Default()
+	cfg.DataDir = dir
+	cfg.RestoreHandler = `printf '\x53AFE_HANDLER_RAN\n'; :`
+	a := New(cfg)
+
+	snap := snapshot.SessionSnapshot{
+		Version:     snapshot.FormatVersion,
+		SessionName: "control-safe",
+		Windows: []snapshot.Window{
+			{
+				Index: 0,
+				Name:  "main",
+				Panes: []snapshot.Pane{
+					{
+						Index:       0,
+						CurrentPath: dir,
+						CurrentCmd:  "touch",
+						RestoreCmd:  "\x15touch -- " + quotedMarkerPath + "\n#",
+					},
+				},
+			},
+		},
+	}
+	if err := a.store.SaveSession(snap); err != nil {
+		t.Fatalf("save snapshot: %v", err)
+	}
+
+	if err := a.Restore("control-safe", false); err != nil {
+		t.Fatalf("restore snapshot: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var lastOutput string
+	var lastErr error
+	for time.Now().Before(deadline) {
+		output, err := testutil.TmuxTry("capture-pane", "-p", "-t", "=control-safe:0.0")
+		lastOutput = output
+		lastErr = err
+		if err == nil && strings.Contains(output, "SAFE_HANDLER_RAN") {
+			_, statErr := os.Stat(markerPath)
+			if !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("exploit marker stat error = %v, want os.ErrNotExist", statErr)
+			}
+
+			return
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatalf("safe handler marker did not appear: output %q, error %v", lastOutput, lastErr)
 }
 
 //nolint:paralleltest // uses a real shared tmux server via testutil.IsolatedTmux (t.Setenv)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,18 +19,20 @@ var (
 	errNoConfigPath      = errors.New(
 		"could not determine a config path (pass --path or set $HOME)",
 	)
-	errConfigExists   = errors.New("already exists (use --force to overwrite)")
-	errInvalidPattern = errors.New("invalid regular expression")
+	errConfigExists                = errors.New("already exists (use --force to overwrite)")
+	errInvalidPattern              = errors.New("invalid regular expression")
+	errInvalidRestoreHandlerSource = errors.New(`must be "saved" or "resolved"`)
 )
 
 type Config struct {
-	TmuxBin        string
-	DataDir        string
-	SaveInterval   time.Duration
-	RestoreTimeout time.Duration
-	RestoreHandler string
-	Scrollback     ScrollbackConfig
-	Integrations   IntegrationsConfig
+	TmuxBin              string
+	DataDir              string
+	SaveInterval         time.Duration
+	RestoreTimeout       time.Duration
+	RestoreHandler       string
+	RestoreHandlerSource string
+	Scrollback           ScrollbackConfig
+	Integrations         IntegrationsConfig
 
 	RestoreAllowlist []string
 
@@ -58,16 +60,20 @@ const (
 	defaultRestoreTimeout = 5 * time.Second
 	defaultClaudeHome     = "~/.claude"
 
+	RestoreHandlerSourceSaved    = "saved"
+	RestoreHandlerSourceResolved = "resolved"
+
 	DefaultScrollbackLines = 5000
 )
 
 func Default() Config {
 	return Config{
-		TmuxBin:        defaultTmuxBin,
-		DataDir:        store.DefaultDataDir(),
-		SaveInterval:   defaultSaveInterval,
-		RestoreTimeout: defaultRestoreTimeout,
-		RestoreHandler: "",
+		TmuxBin:              defaultTmuxBin,
+		DataDir:              store.DefaultDataDir(),
+		SaveInterval:         defaultSaveInterval,
+		RestoreTimeout:       defaultRestoreTimeout,
+		RestoreHandler:       "",
+		RestoreHandlerSource: RestoreHandlerSourceSaved,
 		Scrollback: ScrollbackConfig{
 			Enabled: false,
 			Lines:   DefaultScrollbackLines,
@@ -134,12 +140,30 @@ func LoadFrom(path string) (Config, error) {
 
 	final := cfg.withFile(file)
 
+	err = validateRestoreHandlerSource(final)
+	if err != nil {
+		return cfg, fmt.Errorf("config %s: %w", path, err)
+	}
+
 	err = validateCommandPatterns(final)
 	if err != nil {
 		return cfg, fmt.Errorf("config %s: %w", path, err)
 	}
 
 	return final, nil
+}
+
+func validateRestoreHandlerSource(cfg Config) error {
+	switch cfg.RestoreHandlerSource {
+	case RestoreHandlerSourceSaved, RestoreHandlerSourceResolved:
+		return nil
+	default:
+		return fmt.Errorf(
+			"restore_handler_source %q: %w",
+			cfg.RestoreHandlerSource,
+			errInvalidRestoreHandlerSource,
+		)
+	}
 }
 
 func validateCommandPatterns(cfg Config) error {
@@ -166,15 +190,16 @@ func validateCommandPatterns(cfg Config) error {
 }
 
 type fileConfig struct {
-	TmuxBin          *string               `toml:"tmux_bin"`
-	DataDir          *string               `toml:"data_dir"`
-	SaveInterval     *duration             `toml:"save_interval"`
-	RestoreTimeout   *duration             `toml:"restore_timeout"`
-	RestoreHandler   *string               `toml:"restore_handler"`
-	RestoreAllowlist *[]string             `toml:"restore_allowlist"`
-	RestoreDenylist  *[]string             `toml:"restore_denylist"`
-	Scrollback       *fileScrollbackConf   `toml:"scrollback"`
-	Integrations     *fileIntegrationsConf `toml:"integrations"`
+	TmuxBin              *string               `toml:"tmux_bin"`
+	DataDir              *string               `toml:"data_dir"`
+	SaveInterval         *duration             `toml:"save_interval"`
+	RestoreTimeout       *duration             `toml:"restore_timeout"`
+	RestoreHandler       *string               `toml:"restore_handler"`
+	RestoreHandlerSource *string               `toml:"restore_handler_source"`
+	RestoreAllowlist     *[]string             `toml:"restore_allowlist"`
+	RestoreDenylist      *[]string             `toml:"restore_denylist"`
+	Scrollback           *fileScrollbackConf   `toml:"scrollback"`
+	Integrations         *fileIntegrationsConf `toml:"integrations"`
 }
 
 type fileScrollbackConf struct {
@@ -211,6 +236,10 @@ func (cfg Config) withFile(file fileConfig) Config {
 
 	if file.RestoreHandler != nil {
 		cfg.RestoreHandler = strings.TrimSpace(*file.RestoreHandler)
+	}
+
+	if file.RestoreHandlerSource != nil {
+		cfg.RestoreHandlerSource = *file.RestoreHandlerSource
 	}
 
 	if file.RestoreAllowlist != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	DataDir        string
 	SaveInterval   time.Duration
 	RestoreTimeout time.Duration
+	RestoreHandler string
 	Scrollback     ScrollbackConfig
 	Integrations   IntegrationsConfig
 
@@ -66,6 +67,7 @@ func Default() Config {
 		DataDir:        store.DefaultDataDir(),
 		SaveInterval:   defaultSaveInterval,
 		RestoreTimeout: defaultRestoreTimeout,
+		RestoreHandler: "",
 		Scrollback: ScrollbackConfig{
 			Enabled: false,
 			Lines:   DefaultScrollbackLines,
@@ -168,6 +170,7 @@ type fileConfig struct {
 	DataDir          *string               `toml:"data_dir"`
 	SaveInterval     *duration             `toml:"save_interval"`
 	RestoreTimeout   *duration             `toml:"restore_timeout"`
+	RestoreHandler   *string               `toml:"restore_handler"`
 	RestoreAllowlist *[]string             `toml:"restore_allowlist"`
 	RestoreDenylist  *[]string             `toml:"restore_denylist"`
 	Scrollback       *fileScrollbackConf   `toml:"scrollback"`
@@ -204,6 +207,10 @@ func (cfg Config) withFile(file fileConfig) Config {
 
 	if file.RestoreTimeout != nil {
 		cfg.RestoreTimeout = file.RestoreTimeout.Duration
+	}
+
+	if file.RestoreHandler != nil {
+		cfg.RestoreHandler = strings.TrimSpace(*file.RestoreHandler)
 	}
 
 	if file.RestoreAllowlist != nil {

--- a/internal/config/config_internal_test.go
+++ b/internal/config/config_internal_test.go
@@ -36,6 +36,10 @@ func TestDefault(t *testing.T) {
 		t.Fatalf("expected empty default restore handler, got %q", cfg.RestoreHandler)
 	}
 
+	if cfg.RestoreHandlerSource != RestoreHandlerSourceSaved {
+		t.Fatalf("expected saved default restore handler source, got %q", cfg.RestoreHandlerSource)
+	}
+
 	if cfg.Scrollback.Enabled {
 		t.Fatal("expected scrollback disabled by default")
 	}
@@ -199,6 +203,98 @@ func TestLoadFromNonStringRestoreHandlerErrors(t *testing.T) {
 
 	if _, err := LoadFrom(writeConfig(t, "restore_handler = 42\n")); err == nil {
 		t.Fatal("expected error for non-string restore_handler")
+	}
+}
+
+func TestLoadFromRestoreHandlerSource(t *testing.T) {
+	t.Parallel()
+
+	for _, source := range []string{RestoreHandlerSourceSaved, RestoreHandlerSourceResolved} {
+		t.Run(source, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := LoadFrom(
+				writeConfig(t, "restore_handler_source = "+strconv.Quote(source)+"\n"),
+			)
+			if err != nil {
+				t.Fatalf("load: %v", err)
+			}
+
+			if cfg.RestoreHandlerSource != source {
+				t.Fatalf("restore_handler_source: got %q want %q", cfg.RestoreHandlerSource, source)
+			}
+		})
+	}
+}
+
+func TestLoadFromOmittedRestoreHandlerSourceUsesSaved(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := LoadFrom(writeConfig(t, "tmux_bin = \"tmux\"\n"))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if cfg.RestoreHandlerSource != RestoreHandlerSourceSaved {
+		t.Fatalf(
+			"restore_handler_source: got %q want %q",
+			cfg.RestoreHandlerSource,
+			RestoreHandlerSourceSaved,
+		)
+	}
+}
+
+func TestLoadFromRejectsInvalidRestoreHandlerSource(t *testing.T) {
+	t.Parallel()
+
+	invalid := []string{
+		"",
+		" ",
+		"\t",
+		" saved",
+		"saved ",
+		" resolved ",
+		"Saved",
+		"SAVED",
+		"Resolved",
+		"bogus",
+	}
+
+	for _, source := range invalid {
+		t.Run(strconv.Quote(source), func(t *testing.T) {
+			t.Parallel()
+
+			path := writeConfig(t, "restore_handler_source = "+strconv.Quote(source)+"\n")
+			_, err := LoadFrom(path)
+			if err == nil {
+				t.Fatal("expected invalid restore_handler_source error")
+			}
+
+			for _, want := range []string{
+				path,
+				"restore_handler_source",
+				strconv.Quote(source),
+				strconv.Quote(RestoreHandlerSourceSaved),
+				strconv.Quote(RestoreHandlerSourceResolved),
+			} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error %q does not contain %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadFromNonStringRestoreHandlerSourceErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadFrom(writeConfig(t, "restore_handler_source = 42\n"))
+	if err == nil {
+		t.Fatal("expected error for non-string restore_handler_source")
+	}
+
+	if !strings.Contains(err.Error(), "restore_handler_source") {
+		t.Fatalf("error must identify restore_handler_source, got %v", err)
 	}
 }
 

--- a/internal/config/config_internal_test.go
+++ b/internal/config/config_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -29,6 +30,10 @@ func TestDefault(t *testing.T) {
 
 	if cfg.RestoreTimeout != 5*time.Second {
 		t.Fatalf("expected 5s default restore timeout, got %s", cfg.RestoreTimeout)
+	}
+
+	if cfg.RestoreHandler != "" {
+		t.Fatalf("expected empty default restore handler, got %q", cfg.RestoreHandler)
 	}
 
 	if cfg.Scrollback.Enabled {
@@ -129,6 +134,71 @@ func TestLoadFromPartialFileKeepsDefaults(t *testing.T) {
 
 	if cfg.Scrollback.Lines != 5000 {
 		t.Fatalf("scrollback lines default lost: %d", cfg.Scrollback.Lines)
+	}
+}
+
+func TestLoadFromDisabledRestoreHandlerUsesDefault(t *testing.T) {
+	t.Setenv("LAZY_TMUX_DATA_DIR", "/data")
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "omitted", body: "tmux_bin = \"tmux\"\n"},
+		{name: "empty", body: "restore_handler = \"\"\n"},
+		{name: "whitespace", body: "restore_handler = \"  \\t  \"\n"},
+	}
+
+	for _, test := range tests {
+		cfg, err := LoadFrom(writeConfig(t, test.body))
+		if err != nil {
+			t.Fatalf("%s: load: %v", test.name, err)
+		}
+
+		if !reflect.DeepEqual(cfg, Default()) {
+			t.Fatalf("%s: disabled handler should yield defaults, got %+v", test.name, cfg)
+		}
+	}
+}
+
+func TestLoadFromRestoreHandler(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		input string
+		want  string
+	}{
+		"trims surrounding whitespace": {
+			input: "  cowsay -f tux  ",
+			want:  "cowsay -f tux",
+		},
+		"does not expand home": {
+			input: "~/bin/show-command --flag",
+			want:  "~/bin/show-command --flag",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			path := writeConfig(t, "restore_handler = "+strconv.Quote(tc.input)+"\n")
+
+			cfg, err := LoadFrom(path)
+			if err != nil {
+				t.Fatalf("load: %v", err)
+			}
+
+			if cfg.RestoreHandler != tc.want {
+				t.Fatalf("restore_handler: got %q want %q", cfg.RestoreHandler, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadFromNonStringRestoreHandlerErrors(t *testing.T) {
+	t.Parallel()
+
+	if _, err := LoadFrom(writeConfig(t, "restore_handler = 42\n")); err == nil {
+		t.Fatal("expected error for non-string restore_handler")
 	}
 }
 

--- a/internal/config/default.toml
+++ b/internal/config/default.toml
@@ -23,30 +23,42 @@ save_interval = "5m"
 # before returning. "0s" disables waiting (old fire-and-forget behavior).
 restore_timeout = "5s"
 
-# Optional trusted shell prefix to run instead of replaying saved pane commands.
-# The normalized saved command is appended as one safely single-quoted argument.
+# Optional trusted shell prefix to run instead of directly replaying pane commands.
+# The source selected below is appended as one safely single-quoted argument.
 # Control bytes (C0 and DEL) are represented visibly as lowercase \xNN text
 # rather than passed through exactly; printable text and Unicode stay unchanged.
 # Empty (the default) preserves direct replay. For example, use "echo" to print
-# saved commands or "cowsay -f tux" to display them. The prefix is trusted shell
+# selected commands or "cowsay -f tux" to display them. The prefix is trusted shell
 # source: surrounding whitespace is trimmed, but lazy-tmux does not otherwise
-# parse it or expand ~. Handler mode replaces
-# integration resume commands, leaves empty and shell-only panes untouched, and
-# does not wait for restore_timeout. Handler parse, not-found, and exit failures
-# appear in the pane and do not affect lazy-tmux's exit code; tmux dispatch
-# failures are still returned.
+# parse it or expand ~. Handler mode leaves empty and shell-only selected sources
+# untouched and does not wait for restore_timeout. Handler parse, not-found, and
+# exit failures appear in the pane and do not affect lazy-tmux's exit code; tmux
+# dispatch failures are still returned. The complete safely quoted handler line
+# is sent with literal tmux input, followed by a separate Enter dispatch.
 restore_handler = ""
 # restore_handler = "echo"
 # restore_handler = "cowsay -f tux"
+
+# Command source passed to a non-empty restore_handler. Only the exact,
+# case-sensitive values "saved" and "resolved" are accepted; omission defaults
+# to "saved". "saved" passes the normalized snapshot command and suppresses
+# integration output. "resolved" uses non-empty integration resolver output and
+# otherwise falls back to the normalized snapshot command. A non-empty shell-only
+# resolver result is selected and skipped, not replaced by the saved command.
+# This setting is inert when restore_handler is empty, so direct resolver,
+# filtering, replay, and restore_timeout behavior remain unchanged.
+restore_handler_source = "saved"
 
 # Allowlist of commands lazy-tmux may replay or handle on restore. Each entry is
 # a regular expression matched against the complete selected command, anchored
 # so it must match the whole line (e.g. "nvim( .*)?" allows nvim with or without
 # arguments, and "ssh .*" allows any ssh command). In direct mode this is the
-# effective replay command; in handler mode it is the normalized saved command
-# before the handler is added. Omit this key entirely to allow every command (the
-# default). Provide a list to allow only matching commands; use an empty list []
-# to allow no commands at all.
+# effective replay command; in handler mode it is the saved or resolved source
+# selected above, before encoding and before the handler is added. The handler
+# invocation itself is never matched. For example, "claude" permits only the
+# saved source while "claude --resume .*" permits a resolved resume command.
+# Omit this key entirely to allow every command (the default). Provide a list to
+# allow only matching commands; use an empty list [] to allow no commands at all.
 # restore_allowlist = ["nvim( .*)?", "vim( .*)?", "htop", "less .*", "tail .*", "ssh .*"]
 
 # Denylist of commands lazy-tmux must never replay or handle on restore. Entries
@@ -69,7 +81,9 @@ lines = 5000
 # on save and replays a smarter command on restore. During direct replay,
 # integrations compose with restore_allowlist: if an allowlist is set, the
 # replayed command must match it (e.g. "claude .*" to permit the
-# `claude --resume <id>` restore command).
+# `claude --resume <id>` restore command). Claude Code is the only current
+# production integration. Handler source "resolved" can pass that resume command
+# when `claude.session_id` metadata is present; "saved" never consults it.
 [integrations]
 # Master switch for all program integrations.
 enabled = true

--- a/internal/config/default.toml
+++ b/internal/config/default.toml
@@ -6,7 +6,7 @@
 #   ~/.config/lazy-tmux/lazy-tmux.toml
 #
 # Every key is optional; omitted keys fall back to the built-in defaults.
-# Command-line flags override anything set here.
+# Command-line flags override corresponding settings set here.
 # Run `lazy-tmux config show` to see the effective config actually being read.
 
 # tmux binary to invoke. A leading ~ is expanded. Set this if your tmux is a
@@ -23,16 +23,34 @@ save_interval = "5m"
 # before returning. "0s" disables waiting (old fire-and-forget behavior).
 restore_timeout = "5s"
 
-# Allowlist of commands lazy-tmux may replay on restore. Each entry is a regular
-# expression matched against the full command, anchored so it must match the
-# whole line (e.g. "nvim( .*)?" allows nvim with or without arguments, "ssh .*"
-# allows any ssh command). Omit this key entirely to restore every command (the
-# default). Provide a list to restore only matching commands; use an empty list
-# [] to restore no commands at all.
+# Optional trusted shell prefix to run instead of replaying saved pane commands.
+# The normalized saved command is appended as one safely single-quoted argument.
+# Control bytes (C0 and DEL) are represented visibly as lowercase \xNN text
+# rather than passed through exactly; printable text and Unicode stay unchanged.
+# Empty (the default) preserves direct replay. For example, use "echo" to print
+# saved commands or "cowsay -f tux" to display them. The prefix is trusted shell
+# source: surrounding whitespace is trimmed, but lazy-tmux does not otherwise
+# parse it or expand ~. Handler mode replaces
+# integration resume commands, leaves empty and shell-only panes untouched, and
+# does not wait for restore_timeout. Handler parse, not-found, and exit failures
+# appear in the pane and do not affect lazy-tmux's exit code; tmux dispatch
+# failures are still returned.
+restore_handler = ""
+# restore_handler = "echo"
+# restore_handler = "cowsay -f tux"
+
+# Allowlist of commands lazy-tmux may replay or handle on restore. Each entry is
+# a regular expression matched against the complete selected command, anchored
+# so it must match the whole line (e.g. "nvim( .*)?" allows nvim with or without
+# arguments, and "ssh .*" allows any ssh command). In direct mode this is the
+# effective replay command; in handler mode it is the normalized saved command
+# before the handler is added. Omit this key entirely to allow every command (the
+# default). Provide a list to allow only matching commands; use an empty list []
+# to allow no commands at all.
 # restore_allowlist = ["nvim( .*)?", "vim( .*)?", "htop", "less .*", "tail .*", "ssh .*"]
 
-# Denylist of commands lazy-tmux must never replay on restore. Each entry is a
-# regular expression matched against the full command (anchored). Use this
+# Denylist of commands lazy-tmux must never replay or handle on restore. Entries
+# use the same complete-command, anchored matching described above. Use this
 # instead of an allowlist when you trust most commands and only want to exclude
 # a few. Write a literal command to block exactly it (e.g.
 # "node ./scripts/heavy-watch\.js --poll"), or wildcard the arguments (e.g.
@@ -48,9 +66,10 @@ lines = 5000
 
 # Program integrations adapt interactive programs to lazy-tmux's save/restore.
 # When a pane runs a supported program, lazy-tmux records program-specific state
-# on save and replays a smarter command on restore. Integrations compose with
-# restore_allowlist: if an allowlist is set, the replayed command must match it
-# (e.g. "claude .*" to permit the `claude --resume <id>` restore command).
+# on save and replays a smarter command on restore. During direct replay,
+# integrations compose with restore_allowlist: if an allowlist is set, the
+# replayed command must match it (e.g. "claude .*" to permit the
+# `claude --resume <id>` restore command).
 [integrations]
 # Master switch for all program integrations.
 enabled = true

--- a/internal/config/gen.go
+++ b/internal/config/gen.go
@@ -62,6 +62,7 @@ func (c Config) Render() string {
 	fmt.Fprintf(&buf, "data_dir        = %s\n", strconv.Quote(c.DataDir))
 	fmt.Fprintf(&buf, "save_interval   = %s\n", strconv.Quote(c.SaveInterval.String()))
 	fmt.Fprintf(&buf, "restore_timeout = %s\n", strconv.Quote(c.RestoreTimeout.String()))
+	fmt.Fprintf(&buf, "restore_handler = %s\n", strconv.Quote(c.RestoreHandler))
 
 	if c.RestoreAllowlist == nil {
 		buf.WriteString("# restore_allowlist not set (every command is restored)\n")

--- a/internal/config/gen.go
+++ b/internal/config/gen.go
@@ -63,6 +63,11 @@ func (c Config) Render() string {
 	fmt.Fprintf(&buf, "save_interval   = %s\n", strconv.Quote(c.SaveInterval.String()))
 	fmt.Fprintf(&buf, "restore_timeout = %s\n", strconv.Quote(c.RestoreTimeout.String()))
 	fmt.Fprintf(&buf, "restore_handler = %s\n", strconv.Quote(c.RestoreHandler))
+	restoreHandlerSource := RestoreHandlerSourceSaved
+	if c.RestoreHandlerSource == RestoreHandlerSourceResolved {
+		restoreHandlerSource = RestoreHandlerSourceResolved
+	}
+	fmt.Fprintf(&buf, "restore_handler_source = %s\n", strconv.Quote(restoreHandlerSource))
 
 	if c.RestoreAllowlist == nil {
 		buf.WriteString("# restore_allowlist not set (every command is restored)\n")

--- a/internal/config/gen_internal_test.go
+++ b/internal/config/gen_internal_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -30,8 +31,17 @@ func TestGenerateConfigWritesLoadableTemplate(t *testing.T) {
 		t.Fatal("generated content != embedded template")
 	}
 
-	if _, err := LoadFrom(path); err != nil {
+	if !strings.Contains(string(data), `restore_handler = ""`) {
+		t.Fatal("generated config does not document restore_handler")
+	}
+
+	cfg, err := LoadFrom(path)
+	if err != nil {
 		t.Fatalf("generated config does not load: %v", err)
+	}
+
+	if cfg.RestoreHandler != "" {
+		t.Fatalf("generated config restore_handler: got %q", cfg.RestoreHandler)
 	}
 }
 
@@ -62,6 +72,7 @@ func TestRenderEffectiveConfig(t *testing.T) {
 	for _, want := range []string{
 		`tmux_bin        = "tmux"`,
 		"save_interval",
+		`restore_handler = ""`,
 		"[scrollback]",
 		"restore_allowlist not set",
 		"restore_denylist not set",
@@ -79,5 +90,36 @@ func TestRenderEffectiveConfig(t *testing.T) {
 	cfg.RestoreDenylist = []string{"npm", "node"}
 	if got := cfg.Render(); !strings.Contains(got, `restore_denylist = ["npm", "node"]`) {
 		t.Fatalf("render denylist wrong:\n%s", got)
+	}
+}
+
+func TestRenderRestoreHandlerRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	for name, handler := range map[string]string{
+		"empty":     "",
+		"non-empty": "cowsay -f tux",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := Default()
+			cfg.RestoreHandler = handler
+
+			out := cfg.Render()
+			wantLine := `restore_handler = ` + strconv.Quote(handler)
+			if !strings.Contains(out, wantLine) {
+				t.Fatalf("render missing %q in:\n%s", wantLine, out)
+			}
+
+			loaded, err := LoadFrom(writeConfig(t, out))
+			if err != nil {
+				t.Fatalf("load rendered config: %v", err)
+			}
+
+			if loaded.RestoreHandler != handler {
+				t.Fatalf("round trip: got %q want %q", loaded.RestoreHandler, handler)
+			}
+		})
 	}
 }

--- a/internal/config/gen_internal_test.go
+++ b/internal/config/gen_internal_test.go
@@ -35,6 +35,10 @@ func TestGenerateConfigWritesLoadableTemplate(t *testing.T) {
 		t.Fatal("generated config does not document restore_handler")
 	}
 
+	if !strings.Contains(string(data), `restore_handler_source = "saved"`) {
+		t.Fatal("generated config does not document restore_handler_source")
+	}
+
 	cfg, err := LoadFrom(path)
 	if err != nil {
 		t.Fatalf("generated config does not load: %v", err)
@@ -42,6 +46,10 @@ func TestGenerateConfigWritesLoadableTemplate(t *testing.T) {
 
 	if cfg.RestoreHandler != "" {
 		t.Fatalf("generated config restore_handler: got %q", cfg.RestoreHandler)
+	}
+
+	if cfg.RestoreHandlerSource != RestoreHandlerSourceSaved {
+		t.Fatalf("generated config restore_handler_source: got %q", cfg.RestoreHandlerSource)
 	}
 }
 
@@ -73,6 +81,7 @@ func TestRenderEffectiveConfig(t *testing.T) {
 		`tmux_bin        = "tmux"`,
 		"save_interval",
 		`restore_handler = ""`,
+		`restore_handler_source = "saved"`,
 		"[scrollback]",
 		"restore_allowlist not set",
 		"restore_denylist not set",
@@ -90,6 +99,50 @@ func TestRenderEffectiveConfig(t *testing.T) {
 	cfg.RestoreDenylist = []string{"npm", "node"}
 	if got := cfg.Render(); !strings.Contains(got, `restore_denylist = ["npm", "node"]`) {
 		t.Fatalf("render denylist wrong:\n%s", got)
+	}
+}
+
+func TestRenderRestoreHandlerSourceRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{name: "default", source: RestoreHandlerSourceSaved, want: RestoreHandlerSourceSaved},
+		{
+			name:   "resolved",
+			source: RestoreHandlerSourceResolved,
+			want:   RestoreHandlerSourceResolved,
+		},
+		{name: "zero", source: "", want: RestoreHandlerSourceSaved},
+		{name: "invalid", source: "bogus", want: RestoreHandlerSourceSaved},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := Default()
+			cfg.RestoreHandlerSource = test.source
+			out := cfg.Render()
+			wantLine := `restore_handler_source = ` + strconv.Quote(test.want)
+			if strings.Count(out, "restore_handler_source = ") != 1 {
+				t.Fatalf("render must contain exactly one source line:\n%s", out)
+			}
+			if !strings.Contains(out, wantLine) {
+				t.Fatalf("render missing %q in:\n%s", wantLine, out)
+			}
+
+			loaded, err := LoadFrom(writeConfig(t, out))
+			if err != nil {
+				t.Fatalf("load rendered config: %v", err)
+			}
+			if loaded.RestoreHandlerSource != test.want {
+				t.Fatalf("round trip: got %q want %q", loaded.RestoreHandlerSource, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -87,7 +87,8 @@ type Client struct {
 
 	denylist []*regexp.Regexp
 
-	resolver RestoreCommandResolver
+	restoreHandler string
+	resolver       RestoreCommandResolver
 }
 
 type RestoreCommandResolver interface {
@@ -119,6 +120,10 @@ func NewClientWithRunner(bin string, cmdRunner commandRunner) *Client {
 
 func (client *Client) SetRestoreTimeout(timeout time.Duration) {
 	client.settleTimeout = timeout
+}
+
+func (client *Client) SetRestoreHandler(handler string) {
+	client.restoreHandler = strings.TrimSpace(handler)
 }
 
 func (client *Client) SetRestoreAllowlist(list []string) {
@@ -796,6 +801,40 @@ func normalizedCommand(restore, current string) string {
 	return restore
 }
 
+func quoteShellArgument(argument string) string {
+	return "'" + strings.ReplaceAll(argument, "'", "'\\''") + "'"
+}
+
+func encodeHandlerArgument(command string) string {
+	const (
+		hexDigits     = "0123456789abcdef"
+		nibbleBits    = 4
+		lowNibbleMask = 0x0f
+	)
+
+	var encoded strings.Builder
+	encoded.Grow(len(command))
+
+	for i := range len(command) {
+		byteValue := command[i]
+		if byteValue >= ' ' && byteValue != '\x7f' {
+			encoded.WriteByte(byteValue)
+
+			continue
+		}
+
+		encoded.WriteString(`\x`)
+		encoded.WriteByte(hexDigits[byteValue>>nibbleBits])
+		encoded.WriteByte(hexDigits[byteValue&lowNibbleMask])
+	}
+
+	return encoded.String()
+}
+
+func restoreHandlerCommand(handler, command string) string {
+	return strings.TrimSpace(handler) + " " + quoteShellArgument(encodeHandlerArgument(command))
+}
+
 func isShellCommand(cmd string) bool {
 	base := executableName(cmd)
 	shells := map[string]struct{}{
@@ -847,6 +886,32 @@ func (client *Client) restoreWindowCommands(
 	sort.Slice(panes, func(i, j int) bool { return panes[i].Index < panes[j].Index })
 
 	for _, pane := range panes {
+		if client.restoreHandler != "" {
+			cmd := normalizedCommand(pane.RestoreCmd, pane.CurrentCmd)
+			if strings.TrimSpace(cmd) == "" || isShellCommand(cmd) {
+				continue
+			}
+
+			if !client.commandAllowed(cmd) {
+				continue
+			}
+
+			target := sessionPaneTarget(sessionName, windowIndex, pane.Index)
+			line := restoreHandlerCommand(client.restoreHandler, cmd)
+
+			_, err := client.Output("send-keys", "-l", "-t", target, line)
+			if err != nil {
+				return err
+			}
+
+			_, err = client.Output("send-keys", "-t", target, "C-m")
+			if err != nil {
+				return err
+			}
+
+			continue
+		}
+
 		cmd := client.effectiveRestoreCommand(pane)
 		if strings.TrimSpace(cmd) == "" {
 			continue
@@ -893,6 +958,9 @@ func matchesAny(patterns []*regexp.Regexp, command string) bool {
 
 func (client *Client) expectedPaneCommands(windows []snapshot.Window) map[string]string {
 	want := make(map[string]string)
+	if client.restoreHandler != "" {
+		return want
+	}
 
 	for _, window := range windows {
 		for _, pane := range window.Panes {

--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -87,8 +87,9 @@ type Client struct {
 
 	denylist []*regexp.Regexp
 
-	restoreHandler string
-	resolver       RestoreCommandResolver
+	restoreHandler            string
+	restoreHandlerUseResolver bool
+	resolver                  RestoreCommandResolver
 }
 
 type RestoreCommandResolver interface {
@@ -124,6 +125,10 @@ func (client *Client) SetRestoreTimeout(timeout time.Duration) {
 
 func (client *Client) SetRestoreHandler(handler string) {
 	client.restoreHandler = strings.TrimSpace(handler)
+}
+
+func (client *Client) SetRestoreHandlerUseResolver(useResolver bool) {
+	client.restoreHandlerUseResolver = useResolver
 }
 
 func (client *Client) SetRestoreAllowlist(list []string) {
@@ -835,6 +840,14 @@ func restoreHandlerCommand(handler, command string) string {
 	return strings.TrimSpace(handler) + " " + quoteShellArgument(encodeHandlerArgument(command))
 }
 
+func (client *Client) handlerRestoreCommand(pane snapshot.Pane) string {
+	if client.restoreHandlerUseResolver {
+		return client.effectiveRestoreCommand(pane)
+	}
+
+	return normalizedCommand(pane.RestoreCmd, pane.CurrentCmd)
+}
+
 func isShellCommand(cmd string) bool {
 	base := executableName(cmd)
 	shells := map[string]struct{}{
@@ -887,7 +900,7 @@ func (client *Client) restoreWindowCommands(
 
 	for _, pane := range panes {
 		if client.restoreHandler != "" {
-			cmd := normalizedCommand(pane.RestoreCmd, pane.CurrentCmd)
+			cmd := client.handlerRestoreCommand(pane)
 			if strings.TrimSpace(cmd) == "" || isShellCommand(cmd) {
 				continue
 			}
@@ -923,7 +936,7 @@ func (client *Client) restoreWindowCommands(
 
 		target := sessionPaneTarget(sessionName, windowIndex, pane.Index)
 
-		_, err := client.Output("send-keys", "-t", target, cmd, "C-m")
+		_, err := client.Output("send-keys", "-t", target, "--", cmd, "C-m")
 		if err != nil {
 			return err
 		}

--- a/internal/tmux/client_internal_test.go
+++ b/internal/tmux/client_internal_test.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"errors"
 	"fmt"
+	"io"
 	"slices"
 	"testing"
 	"time"
@@ -180,6 +181,21 @@ func TestWaitForRestoredCommandsDisabled(t *testing.T) {
 	}
 }
 
+func TestWaitForRestoredCommandsSkipsHandlerActions(t *testing.T) {
+	t.Parallel()
+
+	runner := &pollRunner{settleOn: 1, before: "zsh", after: "cat"}
+	client := NewClientWithRunner("tmux", runner)
+	client.SetRestoreHandler("echo")
+	client.SetRestoreTimeout(2 * time.Second)
+
+	client.waitForRestoredCommands("sess", waitTestWindows())
+
+	if runner.calls != 0 {
+		t.Fatalf("handler actions must not poll, polled %d times", runner.calls)
+	}
+}
+
 func TestFieldSepIsPrintableASCII(t *testing.T) {
 	t.Parallel()
 
@@ -267,6 +283,17 @@ func TestExpectedPaneCommands(t *testing.T) {
 		if got[key] != exe {
 			t.Fatalf("expectedPaneCommands[%q]=%q want %q (full %#v)", key, got[key], exe, got)
 		}
+	}
+}
+
+func TestExpectedPaneCommandsEmptyWithRestoreHandler(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient("tmux")
+	client.SetRestoreHandler("echo")
+
+	if got := client.expectedPaneCommands(waitTestWindows()); len(got) != 0 {
+		t.Fatalf("handler mode must have no settle expectations, got %#v", got)
 	}
 }
 
@@ -473,6 +500,278 @@ func TestNormalizedCommand(t *testing.T) {
 		if got := normalizedCommand(c.restore, c.current); got != c.want {
 			t.Fatalf("normalizedCommand(%q,%q)=%q want %q", c.restore, c.current, got, c.want)
 		}
+	}
+}
+
+func TestRestoreHandlerCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		source   string
+		expected string
+	}{
+		{name: "plain", source: "nvim", expected: "echo 'nvim'"},
+		{name: "spaces", source: "nvim main.go", expected: "echo 'nvim main.go'"},
+		{name: "single quote", source: "printf 'hello'", expected: "echo 'printf '\\''hello'\\'''"},
+		{name: "semicolon", source: "one; two", expected: "echo 'one; two'"},
+		{name: "dollar substitution", source: "$(touch file)", expected: "echo '$(touch file)'"},
+		{name: "backticks", source: "`touch file`", expected: "echo '`touch file`'"},
+		{name: "backslash", source: `printf \\n`, expected: `echo 'printf \\n'`},
+		{name: "double quote", source: `printf "hello"`, expected: `echo 'printf "hello"'`},
+		{name: "newline", source: "first\nsecond", expected: `echo 'first\x0asecond'`},
+		{
+			name:     "representative controls",
+			source:   "nul\x00tab\tesc\x1bctrl-u\x15del\x7f",
+			expected: `echo 'nul\x00tab\x09esc\x1bctrl-u\x15del\x7f'`,
+		},
+		{
+			name:     "unicode",
+			source:   "nvim café/\u65e5\u672c\u8a9e",
+			expected: "echo 'nvim café/\u65e5\u672c\u8a9e'",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := restoreHandlerCommand("  echo  ", test.source); got != test.expected {
+				t.Fatalf("restoreHandlerCommand() = %q, want %q", got, test.expected)
+			}
+		})
+	}
+}
+
+func TestEncodeHandlerArgumentEncodesEveryUnsafeByte(t *testing.T) {
+	t.Parallel()
+
+	unsafe := make([]byte, 0, 33)
+	for b := range byte(' ') {
+		unsafe = append(unsafe, b)
+	}
+	unsafe = append(unsafe, '\x7f')
+
+	for _, b := range unsafe {
+		encoded := encodeHandlerArgument(string([]byte{b}))
+		want := fmt.Sprintf(`\x%02x`, b)
+		if encoded != want {
+			t.Fatalf("encodeHandlerArgument(%#02x) = %q, want %q", b, encoded, want)
+		}
+	}
+}
+
+func TestEncodeHandlerArgumentHasNoUnsafeBytes(t *testing.T) {
+	t.Parallel()
+
+	input := "safe\x00\n\t\x1b\x15\x7f café/\u65e5\u672c\u8a9e"
+	encoded := encodeHandlerArgument(input)
+	want := "safe\\x00\\x0a\\x09\\x1b\\x15\\x7f café/\u65e5\u672c\u8a9e"
+	if encoded != want {
+		t.Fatalf("encodeHandlerArgument() = %q, want %q", encoded, want)
+	}
+
+	for i := range len(encoded) {
+		if encoded[i] < ' ' || encoded[i] == '\x7f' {
+			t.Fatalf("encoded output contains unsafe byte %#02x at offset %d", encoded[i], i)
+		}
+	}
+}
+
+type restoreCommandRunner struct {
+	calls  [][]string
+	failAt int
+	err    error
+}
+
+func (r *restoreCommandRunner) runCommand(args ...string) commandResult {
+	r.calls = append(r.calls, append([]string(nil), args...))
+	if len(r.calls) == r.failAt {
+		return commandResult{err: r.err}
+	}
+
+	return commandResult{}
+}
+
+func restoreTestWindow(panes ...snapshot.Pane) snapshot.Window {
+	return snapshot.Window{Index: 1, Panes: panes}
+}
+
+func commandCallsEqual(got, want [][]string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+
+	for i := range want {
+		if !slices.Equal(got[i], want[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func TestRestoreHandlerSelectsNormalizedSavedCommand(t *testing.T) {
+	t.Parallel()
+
+	runner := &restoreCommandRunner{}
+	client := NewClientWithRunner("tmux", runner)
+	client.SetRestoreHandler("  cowsay -f tux  ")
+
+	window := restoreTestWindow(
+		snapshot.Pane{Index: 0, RestoreCmd: "nvim main.go", CurrentCmd: "nvim"},
+		snapshot.Pane{Index: 1, RestoreCmd: "zsh", CurrentCmd: "htop"},
+		snapshot.Pane{Index: 2},
+		snapshot.Pane{Index: 3, RestoreCmd: "   ", CurrentCmd: "bash"},
+		snapshot.Pane{Index: 4, RestoreCmd: "/bin/fish", CurrentCmd: "-zsh"},
+	)
+
+	if err := client.restoreWindowCommands("work", window, 1); err != nil {
+		t.Fatalf("restoreWindowCommands: %v", err)
+	}
+
+	want := [][]string{
+		{"tmux", "send-keys", "-l", "-t", "=work:1.0", "cowsay -f tux 'nvim main.go'"},
+		{"tmux", "send-keys", "-t", "=work:1.0", "C-m"},
+		{"tmux", "send-keys", "-l", "-t", "=work:1.1", "cowsay -f tux 'htop'"},
+		{"tmux", "send-keys", "-t", "=work:1.1", "C-m"},
+	}
+	if !commandCallsEqual(runner.calls, want) {
+		t.Fatalf("handler dispatch calls:\n got %q\nwant %q", runner.calls, want)
+	}
+}
+
+func TestRestoreHandlerDispatchContainsNoSavedControlBytes(t *testing.T) {
+	t.Parallel()
+
+	unsafe := make([]byte, 0, 33)
+	for b := range byte(' ') {
+		unsafe = append(unsafe, b)
+	}
+	unsafe = append(unsafe, '\x7f')
+
+	runner := &restoreCommandRunner{}
+	client := NewClientWithRunner("tmux", runner)
+	client.SetRestoreHandler("echo")
+	window := restoreTestWindow(snapshot.Pane{RestoreCmd: "cmd" + string(unsafe) + "end"})
+
+	if err := client.restoreWindowCommands("work", window, 1); err != nil {
+		t.Fatalf("restoreWindowCommands: %v", err)
+	}
+
+	if len(runner.calls) != 2 {
+		t.Fatalf("got %d dispatch calls, want 2: %q", len(runner.calls), runner.calls)
+	}
+
+	line := runner.calls[0][len(runner.calls[0])-1]
+	for i := range len(line) {
+		if line[i] < ' ' || line[i] == '\x7f' {
+			t.Fatalf("handler send-keys contains unsafe byte %#02x at offset %d", line[i], i)
+		}
+	}
+}
+
+func TestRestoreHandlerFiltersSavedCommandBeforeWrapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		allowlist []string
+		denylist  []string
+		wantCalls int
+	}{
+		{name: "saved command allowed", allowlist: []string{"nvim( .*)?"}, wantCalls: 2},
+		{name: "handler prefix does not allow source", allowlist: []string{"echo.*"}},
+		{
+			name:      "deny wins",
+			allowlist: []string{"nvim( .*)?"},
+			denylist:  []string{"nvim .*"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := &restoreCommandRunner{}
+			client := NewClientWithRunner("tmux", runner)
+			client.SetRestoreHandler("echo")
+			client.SetRestoreAllowlist(test.allowlist)
+			client.SetRestoreDenylist(test.denylist)
+
+			window := restoreTestWindow(snapshot.Pane{RestoreCmd: "nvim main.go"})
+			if err := client.restoreWindowCommands("work", window, 1); err != nil {
+				t.Fatalf("restoreWindowCommands: %v", err)
+			}
+
+			if len(runner.calls) != test.wantCalls {
+				t.Fatalf(
+					"got %d dispatch calls, want %d: %q",
+					len(runner.calls),
+					test.wantCalls,
+					runner.calls,
+				)
+			}
+		})
+	}
+}
+
+func TestRestoreHandlerDisabledPreservesDirectDispatch(t *testing.T) {
+	t.Parallel()
+
+	for _, handler := range []string{"", "   \t\n"} {
+		runner := &restoreCommandRunner{}
+		client := NewClientWithRunner("tmux", runner)
+		client.SetRestoreHandler(handler)
+
+		window := restoreTestWindow(snapshot.Pane{RestoreCmd: "nvim main.go"})
+		if err := client.restoreWindowCommands("work", window, 1); err != nil {
+			t.Fatalf("restoreWindowCommands: %v", err)
+		}
+
+		want := [][]string{{"tmux", "send-keys", "-t", "=work:1.0", "nvim main.go", "C-m"}}
+		if !commandCallsEqual(runner.calls, want) {
+			t.Fatalf("direct dispatch calls:\n got %q\nwant %q", runner.calls, want)
+		}
+	}
+}
+
+func TestRestoreHandlerDispatchErrors(t *testing.T) {
+	t.Parallel()
+
+	dispatchErr := io.ErrUnexpectedEOF
+	tests := []struct {
+		name      string
+		failAt    int
+		wantCalls int
+	}{
+		{name: "literal text", failAt: 1, wantCalls: 1},
+		{name: "enter", failAt: 2, wantCalls: 2},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := &restoreCommandRunner{failAt: test.failAt, err: dispatchErr}
+			client := NewClientWithRunner("tmux", runner)
+			client.SetRestoreHandler("echo")
+
+			window := restoreTestWindow(snapshot.Pane{RestoreCmd: "nvim main.go"})
+			err := client.restoreWindowCommands("work", window, 1)
+			if !errors.Is(err, dispatchErr) {
+				t.Fatalf("restoreWindowCommands error = %v, want %v", err, dispatchErr)
+			}
+
+			if len(runner.calls) != test.wantCalls {
+				t.Fatalf(
+					"got %d dispatch calls, want %d: %q",
+					len(runner.calls),
+					test.wantCalls,
+					runner.calls,
+				)
+			}
+		})
 	}
 }
 

--- a/internal/tmux/client_internal_test.go
+++ b/internal/tmux/client_internal_test.go
@@ -137,14 +137,21 @@ func waitTestWindows() []snapshot.Window {
 func TestWaitForRestoredCommandsBlocksUntilStarted(t *testing.T) {
 	t.Parallel()
 
-	runner := &pollRunner{settleOn: 3, before: "zsh", after: "cat"}
-	client := NewClientWithRunner("tmux", runner)
-	client.SetRestoreTimeout(2 * time.Second)
+	for _, useResolver := range []bool{false, true} {
+		runner := &pollRunner{settleOn: 3, before: "zsh", after: "cat"}
+		client := NewClientWithRunner("tmux", runner)
+		client.SetRestoreHandlerUseResolver(useResolver)
+		client.SetRestoreTimeout(2 * time.Second)
 
-	client.waitForRestoredCommands("sess", waitTestWindows())
+		client.waitForRestoredCommands("sess", waitTestWindows())
 
-	if runner.calls < 3 {
-		t.Fatalf("expected to poll until command started, polled %d times", runner.calls)
+		if runner.calls < 3 {
+			t.Fatalf(
+				"source resolver %t: expected to poll until command started, polled %d times",
+				useResolver,
+				runner.calls,
+			)
+		}
 	}
 }
 
@@ -184,15 +191,22 @@ func TestWaitForRestoredCommandsDisabled(t *testing.T) {
 func TestWaitForRestoredCommandsSkipsHandlerActions(t *testing.T) {
 	t.Parallel()
 
-	runner := &pollRunner{settleOn: 1, before: "zsh", after: "cat"}
-	client := NewClientWithRunner("tmux", runner)
-	client.SetRestoreHandler("echo")
-	client.SetRestoreTimeout(2 * time.Second)
+	for _, useResolver := range []bool{false, true} {
+		runner := &pollRunner{settleOn: 1, before: "zsh", after: "cat"}
+		client := NewClientWithRunner("tmux", runner)
+		client.SetRestoreHandler("echo")
+		client.SetRestoreHandlerUseResolver(useResolver)
+		client.SetRestoreTimeout(2 * time.Second)
 
-	client.waitForRestoredCommands("sess", waitTestWindows())
+		client.waitForRestoredCommands("sess", waitTestWindows())
 
-	if runner.calls != 0 {
-		t.Fatalf("handler actions must not poll, polled %d times", runner.calls)
+		if runner.calls != 0 {
+			t.Fatalf(
+				"source resolver %t: handler actions must not poll, polled %d times",
+				useResolver,
+				runner.calls,
+			)
+		}
 	}
 }
 
@@ -289,11 +303,18 @@ func TestExpectedPaneCommands(t *testing.T) {
 func TestExpectedPaneCommandsEmptyWithRestoreHandler(t *testing.T) {
 	t.Parallel()
 
-	client := NewClient("tmux")
-	client.SetRestoreHandler("echo")
+	for _, useResolver := range []bool{false, true} {
+		client := NewClient("tmux")
+		client.SetRestoreHandler("echo")
+		client.SetRestoreHandlerUseResolver(useResolver)
 
-	if got := client.expectedPaneCommands(waitTestWindows()); len(got) != 0 {
-		t.Fatalf("handler mode must have no settle expectations, got %#v", got)
+		if got := client.expectedPaneCommands(waitTestWindows()); len(got) != 0 {
+			t.Fatalf(
+				"source resolver %t: handler mode must have no settle expectations, got %#v",
+				useResolver,
+				got,
+			)
+		}
 	}
 }
 
@@ -641,7 +662,7 @@ func TestRestoreHandlerSelectsNormalizedSavedCommand(t *testing.T) {
 	}
 }
 
-func TestRestoreHandlerDispatchContainsNoSavedControlBytes(t *testing.T) {
+func TestRestoreHandlerDispatchContainsNoSelectedControlBytes(t *testing.T) {
 	t.Parallel()
 
 	unsafe := make([]byte, 0, 33)
@@ -650,24 +671,69 @@ func TestRestoreHandlerDispatchContainsNoSavedControlBytes(t *testing.T) {
 	}
 	unsafe = append(unsafe, '\x7f')
 
+	command := "cmd '$(touch nope);`false` " + string(unsafe) + " café/\u65e5\u672c\u8a9e end"
+	for _, useResolver := range []bool{false, true} {
+		runner := &restoreCommandRunner{}
+		client := NewClientWithRunner("tmux", runner)
+		client.SetRestoreHandler("echo")
+		client.SetRestoreHandlerUseResolver(useResolver)
+		if useResolver {
+			client.SetRestoreResolver(fakeResolver{matchCmd: "source", override: command})
+		}
+		window := restoreTestWindow(snapshot.Pane{CurrentCmd: "source", RestoreCmd: command})
+
+		if err := client.restoreWindowCommands("work", window, 1); err != nil {
+			t.Fatalf("source resolver %t: restoreWindowCommands: %v", useResolver, err)
+		}
+
+		if len(runner.calls) != 2 {
+			t.Fatalf(
+				"source resolver %t: got %d dispatch calls, want 2: %q",
+				useResolver,
+				len(runner.calls),
+				runner.calls,
+			)
+		}
+
+		line := runner.calls[0][len(runner.calls[0])-1]
+		wantLine := restoreHandlerCommand("echo", command)
+		if line != wantLine {
+			t.Fatalf("source resolver %t: line = %q, want %q", useResolver, line, wantLine)
+		}
+		for i := range len(line) {
+			if line[i] < ' ' || line[i] == '\x7f' {
+				t.Fatalf(
+					"source resolver %t: handler send-keys contains unsafe byte %#02x at offset %d",
+					useResolver,
+					line[i],
+					i,
+				)
+			}
+		}
+	}
+}
+
+func TestRestoreHandlerSavedShellAndEmptySourcesDoNotResolve(t *testing.T) {
+	t.Parallel()
+
 	runner := &restoreCommandRunner{}
+	resolver := &countingResolver{override: "nvim"}
 	client := NewClientWithRunner("tmux", runner)
 	client.SetRestoreHandler("echo")
-	window := restoreTestWindow(snapshot.Pane{RestoreCmd: "cmd" + string(unsafe) + "end"})
+	client.SetRestoreResolver(resolver)
 
+	window := restoreTestWindow(
+		snapshot.Pane{Index: 0, RestoreCmd: "", CurrentCmd: "zsh"},
+		snapshot.Pane{Index: 1, RestoreCmd: "/bin/bash", CurrentCmd: "fish -l"},
+	)
 	if err := client.restoreWindowCommands("work", window, 1); err != nil {
 		t.Fatalf("restoreWindowCommands: %v", err)
 	}
-
-	if len(runner.calls) != 2 {
-		t.Fatalf("got %d dispatch calls, want 2: %q", len(runner.calls), runner.calls)
+	if len(runner.calls) != 0 {
+		t.Fatalf("shell/empty sources dispatched %q", runner.calls)
 	}
-
-	line := runner.calls[0][len(runner.calls[0])-1]
-	for i := range len(line) {
-		if line[i] < ' ' || line[i] == '\x7f' {
-			t.Fatalf("handler send-keys contains unsafe byte %#02x at offset %d", line[i], i)
-		}
+	if resolver.calls != 0 {
+		t.Fatalf("saved source consulted resolver %d times", resolver.calls)
 	}
 }
 
@@ -729,10 +795,31 @@ func TestRestoreHandlerDisabledPreservesDirectDispatch(t *testing.T) {
 			t.Fatalf("restoreWindowCommands: %v", err)
 		}
 
-		want := [][]string{{"tmux", "send-keys", "-t", "=work:1.0", "nvim main.go", "C-m"}}
+		want := [][]string{
+			{"tmux", "send-keys", "-t", "=work:1.0", "--", "nvim main.go", "C-m"},
+		}
 		if !commandCallsEqual(runner.calls, want) {
 			t.Fatalf("direct dispatch calls:\n got %q\nwant %q", runner.calls, want)
 		}
+	}
+}
+
+func TestRestoreDirectDispatchTreatsLeadingDashAsCommandText(t *testing.T) {
+	t.Parallel()
+
+	runner := &restoreCommandRunner{}
+	client := NewClientWithRunner("tmux", runner)
+	window := restoreTestWindow(snapshot.Pane{RestoreCmd: "-bash", CurrentCmd: "-bash"})
+
+	if err := client.restoreWindowCommands("naps", window, 0); err != nil {
+		t.Fatalf("restoreWindowCommands: %v", err)
+	}
+
+	want := [][]string{
+		{"tmux", "send-keys", "-t", "=naps:0.0", "--", "-bash", "C-m"},
+	}
+	if !commandCallsEqual(runner.calls, want) {
+		t.Fatalf("direct dispatch calls:\n got %q\nwant %q", runner.calls, want)
 	}
 }
 
@@ -750,28 +837,34 @@ func TestRestoreHandlerDispatchErrors(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
+		for _, useResolver := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/resolver=%t", test.name, useResolver), func(t *testing.T) {
+				t.Parallel()
 
-			runner := &restoreCommandRunner{failAt: test.failAt, err: dispatchErr}
-			client := NewClientWithRunner("tmux", runner)
-			client.SetRestoreHandler("echo")
+				runner := &restoreCommandRunner{failAt: test.failAt, err: dispatchErr}
+				client := NewClientWithRunner("tmux", runner)
+				client.SetRestoreHandler("echo")
+				client.SetRestoreHandlerUseResolver(useResolver)
+				if useResolver {
+					client.SetRestoreResolver(fakeResolver{override: "nvim main.go"})
+				}
 
-			window := restoreTestWindow(snapshot.Pane{RestoreCmd: "nvim main.go"})
-			err := client.restoreWindowCommands("work", window, 1)
-			if !errors.Is(err, dispatchErr) {
-				t.Fatalf("restoreWindowCommands error = %v, want %v", err, dispatchErr)
-			}
+				window := restoreTestWindow(snapshot.Pane{RestoreCmd: "nvim main.go"})
+				err := client.restoreWindowCommands("work", window, 1)
+				if !errors.Is(err, dispatchErr) {
+					t.Fatalf("restoreWindowCommands error = %v, want %v", err, dispatchErr)
+				}
 
-			if len(runner.calls) != test.wantCalls {
-				t.Fatalf(
-					"got %d dispatch calls, want %d: %q",
-					len(runner.calls),
-					test.wantCalls,
-					runner.calls,
-				)
-			}
-		})
+				if len(runner.calls) != test.wantCalls {
+					t.Fatalf(
+						"got %d dispatch calls, want %d: %q",
+						len(runner.calls),
+						test.wantCalls,
+						runner.calls,
+					)
+				}
+			})
+		}
 	}
 }
 

--- a/internal/tmux/resolver_internal_test.go
+++ b/internal/tmux/resolver_internal_test.go
@@ -114,3 +114,35 @@ func TestRestoreResolverRespectsAllowlist(t *testing.T) {
 		}
 	}
 }
+
+func TestRestoreHandlerSuppressesResolverOutput(t *testing.T) {
+	t.Parallel()
+
+	runner := &recordingRunner{}
+	client := NewClientWithRunner("tmux", runner)
+	client.SetRestoreResolver(fakeResolver{matchCmd: "claude", override: "claude --resume s"})
+	client.SetRestoreHandler("echo")
+
+	window := snapshot.Window{
+		Index: 1,
+		Panes: []snapshot.Pane{{Index: 0, CurrentCmd: "claude", RestoreCmd: "claude"}},
+	}
+
+	if err := client.restoreWindowCommands("work", window, 1); err != nil {
+		t.Fatalf("restoreWindowCommands: %v", err)
+	}
+
+	want := [][]string{
+		{"tmux", "send-keys", "-l", "-t", "=work:1.0", "echo 'claude'"},
+		{"tmux", "send-keys", "-t", "=work:1.0", "C-m"},
+	}
+	if len(runner.calls) != len(want) {
+		t.Fatalf("got %d calls, want %d: %q", len(runner.calls), len(want), runner.calls)
+	}
+
+	for i := range want {
+		if strings.Join(runner.calls[i], "\x00") != strings.Join(want[i], "\x00") {
+			t.Fatalf("call %d = %q, want %q", i, runner.calls[i], want[i])
+		}
+	}
+}

--- a/internal/tmux/resolver_internal_test.go
+++ b/internal/tmux/resolver_internal_test.go
@@ -1,18 +1,26 @@
 package tmux
 
 import (
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
 )
 
 type recordingRunner struct {
-	calls [][]string
+	calls         [][]string
+	listPaneCalls int
 }
 
 func (r *recordingRunner) runCommand(args ...string) commandResult {
 	r.calls = append(r.calls, append([]string(nil), args...))
+	if len(args) > 1 && args[1] == "list-panes" {
+		r.listPaneCalls++
+
+		return commandResult{stdout: "1 0 claude\n"}
+	}
 
 	return commandResult{}
 }
@@ -25,6 +33,21 @@ type fakeResolver struct {
 func (f fakeResolver) Resolve(pane snapshot.Pane) string {
 	if pane.CurrentCmd == f.matchCmd {
 		return f.override
+	}
+
+	return ""
+}
+
+type countingResolver struct {
+	matchCmd string
+	override string
+	calls    int
+}
+
+func (r *countingResolver) Resolve(pane snapshot.Pane) string {
+	r.calls++
+	if r.matchCmd == "" || pane.CurrentCmd == r.matchCmd {
+		return r.override
 	}
 
 	return ""
@@ -115,34 +138,238 @@ func TestRestoreResolverRespectsAllowlist(t *testing.T) {
 	}
 }
 
-func TestRestoreHandlerSuppressesResolverOutput(t *testing.T) {
+func TestRestoreHandlerSourceSelection(t *testing.T) {
 	t.Parallel()
 
-	runner := &recordingRunner{}
-	client := NewClientWithRunner("tmux", runner)
-	client.SetRestoreResolver(fakeResolver{matchCmd: "claude", override: "claude --resume s"})
-	client.SetRestoreHandler("echo")
-
-	window := snapshot.Window{
-		Index: 1,
-		Panes: []snapshot.Pane{{Index: 0, CurrentCmd: "claude", RestoreCmd: "claude"}},
+	tests := []struct {
+		name        string
+		useResolver bool
+		wantLine    string
+		wantCalls   int
+	}{
+		{name: "saved zero value", wantLine: "echo 'claude'"},
+		{
+			name:        "resolved",
+			useResolver: true,
+			wantLine:    "echo 'claude --resume s'",
+			wantCalls:   1,
+		},
 	}
 
-	if err := client.restoreWindowCommands("work", window, 1); err != nil {
-		t.Fatalf("restoreWindowCommands: %v", err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := &recordingRunner{}
+			resolver := &countingResolver{matchCmd: "claude", override: "claude --resume s"}
+			client := NewClientWithRunner("tmux", runner)
+			client.SetRestoreResolver(resolver)
+			client.SetRestoreHandler("echo")
+			client.SetRestoreHandlerUseResolver(test.useResolver)
+
+			window := restoreTestWindow(
+				snapshot.Pane{Index: 0, CurrentCmd: "claude", RestoreCmd: "claude"},
+			)
+			if err := client.restoreWindowCommands("work", window, 1); err != nil {
+				t.Fatalf("restoreWindowCommands: %v", err)
+			}
+
+			want := [][]string{
+				{"tmux", "send-keys", "-l", "-t", "=work:1.0", test.wantLine},
+				{"tmux", "send-keys", "-t", "=work:1.0", "C-m"},
+			}
+			if !commandCallsEqual(runner.calls, want) {
+				t.Fatalf("handler calls:\n got %q\nwant %q", runner.calls, want)
+			}
+			if resolver.calls != test.wantCalls {
+				t.Fatalf("resolver calls: got %d want %d", resolver.calls, test.wantCalls)
+			}
+		})
+	}
+}
+
+func TestRestoreHandlerResolvedSourceFallsBack(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		resolver RestoreCommandResolver
+	}{
+		{name: "no resolver"},
+		{name: "non-match", resolver: &countingResolver{matchCmd: "other", override: "override"}},
+		{name: "missing metadata", resolver: &countingResolver{override: ""}},
+		{name: "empty result", resolver: &countingResolver{override: ""}},
+		{name: "whitespace result", resolver: &countingResolver{override: "  \t  "}},
 	}
 
-	want := [][]string{
-		{"tmux", "send-keys", "-l", "-t", "=work:1.0", "echo 'claude'"},
-		{"tmux", "send-keys", "-t", "=work:1.0", "C-m"},
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := &recordingRunner{}
+			client := NewClientWithRunner("tmux", runner)
+			client.SetRestoreHandler("echo")
+			client.SetRestoreHandlerUseResolver(true)
+			client.SetRestoreResolver(test.resolver)
+
+			window := restoreTestWindow(
+				snapshot.Pane{Index: 0, CurrentCmd: "claude", RestoreCmd: "claude --saved"},
+			)
+			if err := client.restoreWindowCommands("work", window, 1); err != nil {
+				t.Fatalf("restoreWindowCommands: %v", err)
+			}
+
+			want := [][]string{
+				{"tmux", "send-keys", "-l", "-t", "=work:1.0", "echo 'claude --saved'"},
+				{"tmux", "send-keys", "-t", "=work:1.0", "C-m"},
+			}
+			if !commandCallsEqual(runner.calls, want) {
+				t.Fatalf("fallback calls:\n got %q\nwant %q", runner.calls, want)
+			}
+		})
 	}
-	if len(runner.calls) != len(want) {
-		t.Fatalf("got %d calls, want %d: %q", len(runner.calls), len(want), runner.calls)
+}
+
+func TestRestoreHandlerResolvedShellSourceIsSkipped(t *testing.T) {
+	t.Parallel()
+
+	for _, shell := range []string{"bash", "/bin/zsh", "fish -l"} {
+		t.Run(shell, func(t *testing.T) {
+			t.Parallel()
+
+			runner := &recordingRunner{}
+			resolver := &countingResolver{override: shell}
+			client := NewClientWithRunner("tmux", runner)
+			client.SetRestoreResolver(resolver)
+			client.SetRestoreHandler("echo")
+			client.SetRestoreHandlerUseResolver(true)
+
+			window := restoreTestWindow(snapshot.Pane{RestoreCmd: "nvim", CurrentCmd: "nvim"})
+			if err := client.restoreWindowCommands("work", window, 1); err != nil {
+				t.Fatalf("restoreWindowCommands: %v", err)
+			}
+			if resolver.calls != 1 {
+				t.Fatalf("resolver calls: got %d want 1", resolver.calls)
+			}
+			if len(runner.calls) != 0 {
+				t.Fatalf("shell resolver result must be skipped, got %q", runner.calls)
+			}
+		})
+	}
+}
+
+func TestRestoreHandlerFiltersSelectedSource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		useResolver bool
+		allowlist   []string
+		wantLine    string
+	}{
+		{name: "saved allows saved", allowlist: []string{"claude"}, wantLine: "echo 'claude'"},
+		{name: "saved blocks resolved pattern", allowlist: []string{"claude --resume .*"}},
+		{
+			name:        "resolved blocks saved pattern",
+			useResolver: true,
+			allowlist:   []string{"claude"},
+		},
+		{
+			name:        "resolved allows resolved",
+			useResolver: true,
+			allowlist:   []string{"claude --resume .*"},
+			wantLine:    "echo 'claude --resume s'",
+		},
+		{name: "handler prefix never allows saved", allowlist: []string{"echo.*"}},
+		{
+			name:        "handler prefix never allows resolved",
+			useResolver: true,
+			allowlist:   []string{"echo.*"},
+		},
 	}
 
-	for i := range want {
-		if strings.Join(runner.calls[i], "\x00") != strings.Join(want[i], "\x00") {
-			t.Fatalf("call %d = %q, want %q", i, runner.calls[i], want[i])
-		}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			runner := &recordingRunner{}
+			client := NewClientWithRunner("tmux", runner)
+			client.SetRestoreResolver(
+				fakeResolver{matchCmd: "claude", override: "claude --resume s"},
+			)
+			client.SetRestoreHandler("echo")
+			client.SetRestoreHandlerUseResolver(test.useResolver)
+			client.SetRestoreAllowlist(test.allowlist)
+
+			window := restoreTestWindow(
+				snapshot.Pane{CurrentCmd: "claude", RestoreCmd: "claude"},
+			)
+			if err := client.restoreWindowCommands("work", window, 1); err != nil {
+				t.Fatalf("restoreWindowCommands: %v", err)
+			}
+
+			if test.wantLine == "" {
+				if len(runner.calls) != 0 {
+					t.Fatalf("blocked source dispatched %q", runner.calls)
+				}
+
+				return
+			}
+
+			if len(runner.calls) != 2 || runner.calls[0][len(runner.calls[0])-1] != test.wantLine {
+				t.Fatalf("handler calls = %q, want line %q", runner.calls, test.wantLine)
+			}
+		})
+	}
+}
+
+func TestRestoreHandlerSourceIsInertWithoutHandler(t *testing.T) {
+	t.Parallel()
+
+	for _, useResolver := range []bool{false, true} {
+		t.Run(fmt.Sprintf("handler resolver %t", useResolver), func(t *testing.T) {
+			t.Parallel()
+
+			runner := &recordingRunner{}
+			resolver := &countingResolver{matchCmd: "claude", override: "claude --resume s"}
+			client := NewClientWithRunner("tmux", runner)
+			client.SetRestoreResolver(resolver)
+			client.SetRestoreHandlerUseResolver(useResolver)
+			client.SetRestoreAllowlist([]string{"claude --resume .*"})
+
+			window := restoreTestWindow(
+				snapshot.Pane{CurrentCmd: "claude", RestoreCmd: "claude"},
+			)
+			if err := client.restoreWindowCommands("work", window, 1); err != nil {
+				t.Fatalf("restoreWindowCommands: %v", err)
+			}
+
+			want := [][]string{
+				{"tmux", "send-keys", "-t", "=work:1.0", "--", "claude --resume s", "C-m"},
+			}
+			if !commandCallsEqual(runner.calls, want) {
+				t.Fatalf("direct calls:\n got %q\nwant %q", runner.calls, want)
+			}
+			if resolver.calls != 1 {
+				t.Fatalf("resolver calls: got %d want 1", resolver.calls)
+			}
+
+			expected := client.expectedPaneCommands([]snapshot.Window{window})
+			if expected["1.0"] != "claude" {
+				t.Fatalf("expected commands = %#v", expected)
+			}
+
+			client.SetRestoreTimeout(time.Second)
+			client.waitForRestoredCommands("work", []snapshot.Window{window})
+			if runner.listPaneCalls != 1 {
+				t.Fatalf("settle list-panes calls: got %d want 1", runner.listPaneCalls)
+			}
+			if resolver.calls != 3 {
+				t.Fatalf(
+					"resolver calls after restore/expected/settle: got %d want 3",
+					resolver.calls,
+				)
+			}
+		})
 	}
 }


### PR DESCRIPTION
> **AI Megamind** - By: OpenCode / openai/gpt-5.6-sol

## What changed

- Added `restore_handler`, which runs a configured command for each restored pane instead of directly replaying the pane command.
- Added `restore_handler_source = "saved" | "resolved"`:
  - `saved` is the default and passes the captured command.
  - `resolved` passes integration output when available, such as `claude --resume <session-id>`, with the saved command as fallback.
- Documented the new settings and added unit plus isolated-tmux coverage.

## Why

Full application restoration is provider-specific, but restored panes should still show what was running. The resolved source also lets integrations provide more useful context—for example, the exact Claude resume command—without executing it.

## How

```toml
restore_handler = "note"
restore_handler_source = "resolved"
```

The selected command is filtered, control bytes are rendered safely as `\xNN`, and the result is passed to the handler as one shell-quoted argument. Direct replay remains unchanged when no handler is configured.

Verified with `make check` (306 race tests and 311 container integration tests), isolated tmux tests, lint, build, and docs build.

Run artifacts: `.tmp/megamind-restore-command/plans/follow-up-final.md`, `.tmp/megamind-restore-command/reviews/follow-up-validated-findings.md`, `.tmp/megamind-restore-command/reviews/follow-up-fixed-review.md`, `.tmp/megamind-restore-command/final/follow-up-local-gates.md`.

Closes #239.
