### PR TITLE
fix: esc during restore cancels and kills the partial session, returns to picker

### DIFF
--- a/cmd/lazy-tmux/picker.go
+++ b/cmd/lazy-tmux/picker.go
@@ -73,21 +73,27 @@ func runPicker(args []string, stdout, stderr io.Writer) int {
 }
 
 func runTUIPicker(tmuxApp *app.App, sortOpts app.PickerSortOptions, stderr io.Writer) int {
-	target, err := tmuxApp.SelectTargetWithTUISorted(sortOpts)
-	if err != nil {
-		writeErr(stderr, fmt.Errorf("select target: %w", err))
+	for {
+		target, err := tmuxApp.SelectTargetWithTUISorted(sortOpts)
+		if err != nil {
+			writeErr(stderr, fmt.Errorf("select target: %w", err))
 
-		return 1
+			return 1
+		}
+
+		cancelled, err := tmuxApp.RestoreTargetAnimated(target)
+		if err != nil {
+			writeErr(stderr, fmt.Errorf("restore target: %w", err))
+
+			return 1
+		}
+
+		if cancelled {
+			continue
+		}
+
+		return 0
 	}
-
-	err = tmuxApp.RestoreTargetAnimated(target)
-	if err != nil {
-		writeErr(stderr, fmt.Errorf("restore target: %w", err))
-
-		return 1
-	}
-
-	return 0
 }
 
 func runFZFPicker(

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -42,7 +43,7 @@ type tmuxSessionCapturer interface {
 }
 
 type tmuxSessionRestorer interface {
-	RestoreSession(snap snapshot.SessionSnapshot) error
+	RestoreSession(ctx context.Context, snap snapshot.SessionSnapshot) error
 	SwitchClient(target string) error
 	AttachSession(target string) error
 	InsideTmux() bool
@@ -157,7 +158,7 @@ func (a *App) Restore(session string, switchClient bool) error {
 }
 
 func (a *App) RestoreTarget(target PickerTarget, switchClient bool) error {
-	err := a.restoreSessionForTarget(target)
+	err := a.restoreSessionForTarget(context.Background(), target)
 	if err != nil {
 		return err
 	}
@@ -196,7 +197,7 @@ func (a *App) ListRecords() ([]snapshot.Record, error) {
 	return records, nil
 }
 
-func (a *App) restoreSessionForTarget(target PickerTarget) error {
+func (a *App) restoreSessionForTarget(ctx context.Context, target PickerTarget) error {
 	session := strings.TrimSpace(target.SessionName)
 	if session == "" {
 		return errSessionNameEmpty
@@ -207,7 +208,7 @@ func (a *App) restoreSessionForTarget(target PickerTarget) error {
 		return fmt.Errorf("load session: %w", err)
 	}
 
-	err = a.tmux.RestoreSession(snap)
+	err = a.tmux.RestoreSession(ctx, snap)
 	if err != nil && !errors.Is(err, tmux.ErrSessionExists) {
 		return fmt.Errorf("restore session: %w", err)
 	}

--- a/internal/app/app_internal_test.go
+++ b/internal/app/app_internal_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,8 +20,10 @@ type recordingTmux struct {
 	attached string
 }
 
-func (r *recordingTmux) RestoreSession(snapshot.SessionSnapshot) error { return nil }
-func (r *recordingTmux) InsideTmux() bool                              { return r.inside }
+func (r *recordingTmux) RestoreSession(context.Context, snapshot.SessionSnapshot) error {
+	return nil
+}
+func (r *recordingTmux) InsideTmux() bool { return r.inside }
 
 func (r *recordingTmux) SwitchClient(
 	target string,

--- a/internal/app/app_picker.go
+++ b/internal/app/app_picker.go
@@ -1,9 +1,11 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/alchemmist/lazy-tmux/internal/integration"
@@ -123,32 +125,60 @@ func toPickerStatus(status integration.Status) picker.WindowStatus {
 	}
 }
 
-func (a *App) RestoreTargetAnimated(target PickerTarget) error {
+func (a *App) RestoreTargetAnimated(target PickerTarget) (bool, error) {
+	preExisted := a.tmux.SessionExists(strings.TrimSpace(target.SessionName))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	done := make(chan struct{})
 
 	var restoreErr error
 
 	go func() {
-		restoreErr = a.restoreSessionForTarget(target)
+		restoreErr = a.restoreSessionForTarget(ctx, target)
 		close(done)
 	}()
 
-	animErr := picker.RunRestoreAnimation(target.SessionName, done)
+	cancelled, animErr := picker.RunRestoreAnimation(target.SessionName, done)
+	if cancelled {
+		cancel()
+		<-done
+
+		if !preExisted {
+			a.killPartialRestore(target.SessionName)
+		}
+
+		return true, nil
+	}
+
 	<-done
 
 	if restoreErr != nil {
-		return restoreErr
+		return false, restoreErr
 	}
 
 	if animErr != nil {
 		log.Printf("lazy-tmux: restore animation: %v", animErr)
 	}
 
-	return a.handoffToTarget(target, true)
+	return false, a.handoffToTarget(target, true)
+}
+
+func (a *App) killPartialRestore(session string) {
+	name := strings.TrimSpace(session)
+	if name == "" || !a.tmux.SessionExists(name) {
+		return
+	}
+
+	err := a.tmux.KillSession(name)
+	if err != nil {
+		log.Printf("lazy-tmux: cancel restore: kill session %s: %v", name, err)
+	}
 }
 
 func (a *App) RestoreTargetInteractive(target PickerTarget) error {
-	err := a.restoreSessionForTarget(target)
+	err := a.restoreSessionForTarget(context.Background(), target)
 	if err != nil {
 		return err
 	}

--- a/internal/picker/loading.go
+++ b/internal/picker/loading.go
@@ -26,12 +26,13 @@ type (
 )
 
 type loadingModel struct {
-	name    string
-	done    <-chan struct{}
-	width   int
-	height  int
-	frame   int
-	started bool
+	name      string
+	done      <-chan struct{}
+	width     int
+	height    int
+	frame     int
+	started   bool
+	cancelled bool
 
 	theme pickerTheme
 	dim   lipgloss.Style
@@ -90,6 +91,8 @@ func (m loadingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	case tea.KeyPressMsg:
 		if s := msg.String(); s == keyCtrlC || s == keyEsc || s == "q" {
+			m.cancelled = true
+
 			return m, tea.Quit
 		}
 	}
@@ -230,15 +233,17 @@ func fieldGlyph(col, row, cols, rows, phase float64) (rune, int) {
 	}
 }
 
-func RunRestoreAnimation(sessionName string, done <-chan struct{}) error {
+func RunRestoreAnimation(sessionName string, done <-chan struct{}) (bool, error) {
 	if !isTerminal(os.Stdout) {
-		return nil
+		return false, nil
 	}
 
-	_, err := tea.NewProgram(newLoadingModel(sessionName, done)).Run()
+	final, err := tea.NewProgram(newLoadingModel(sessionName, done)).Run()
 	if err != nil {
-		return fmt.Errorf("run restore animation: %w", err)
+		return false, fmt.Errorf("run restore animation: %w", err)
 	}
 
-	return nil
+	model, ok := final.(loadingModel)
+
+	return ok && model.cancelled, nil
 }

--- a/internal/picker/loading_fzf.go
+++ b/internal/picker/loading_fzf.go
@@ -2,6 +2,6 @@
 
 package picker
 
-func RunRestoreAnimation(_ string, _ <-chan struct{}) error {
-	return nil
+func RunRestoreAnimation(_ string, _ <-chan struct{}) (bool, error) {
+	return false, nil
 }

--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -510,7 +510,10 @@ func resolveRestoreFocus(
 	return win, pane
 }
 
-func (client *Client) RestoreSession(sessionSnapshot snapshot.SessionSnapshot) error {
+func (client *Client) RestoreSession(
+	ctx context.Context,
+	sessionSnapshot snapshot.SessionSnapshot,
+) error {
 	if sessionSnapshot.SessionName == "" {
 		return errEmptySessionName
 	}
@@ -532,18 +535,35 @@ func (client *Client) RestoreSession(sessionSnapshot snapshot.SessionSnapshot) e
 		return err
 	}
 
-	for i := 1; i < len(windows); i++ {
-		w := windows[i]
+	for idx := 1; idx < len(windows); idx++ {
+		err = restoreCanceled(ctx)
+		if err != nil {
+			return err
+		}
 
-		err := client.createAndPopulateWindow(sessionSnapshot.SessionName, w)
+		err = client.createAndPopulateWindow(sessionSnapshot.SessionName, windows[idx])
 		if err != nil {
 			return err
 		}
 	}
 
+	err = restoreCanceled(ctx)
+	if err != nil {
+		return err
+	}
+
 	client.selectRestoredFocus(sessionSnapshot, windows)
 
-	client.waitForRestoredCommands(sessionSnapshot.SessionName, windows)
+	client.waitForRestoredCommands(ctx, sessionSnapshot.SessionName, windows)
+
+	return nil
+}
+
+func restoreCanceled(ctx context.Context) error {
+	err := ctx.Err()
+	if err != nil {
+		return fmt.Errorf("restore canceled: %w", err)
+	}
 
 	return nil
 }
@@ -933,7 +953,11 @@ func (client *Client) paneCommands(sessionName string) map[string]string {
 	return result
 }
 
-func (client *Client) waitForRestoredCommands(sessionName string, windows []snapshot.Window) {
+func (client *Client) waitForRestoredCommands(
+	ctx context.Context,
+	sessionName string,
+	windows []snapshot.Window,
+) {
 	if client.settleTimeout <= 0 {
 		return
 	}
@@ -946,6 +970,10 @@ func (client *Client) waitForRestoredCommands(sessionName string, windows []snap
 	deadline := time.Now().Add(client.settleTimeout)
 
 	for {
+		if ctx.Err() != nil {
+			return
+		}
+
 		got := client.paneCommands(sessionName)
 
 		pending := false
@@ -962,7 +990,11 @@ func (client *Client) waitForRestoredCommands(sessionName string, windows []snap
 			return
 		}
 
-		time.Sleep(restoreSettlePollInterval)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(restoreSettlePollInterval):
+		}
 	}
 }
 

--- a/internal/tmux/client_internal_test.go
+++ b/internal/tmux/client_internal_test.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -140,7 +141,7 @@ func TestWaitForRestoredCommandsBlocksUntilStarted(t *testing.T) {
 	client := NewClientWithRunner("tmux", runner)
 	client.SetRestoreTimeout(2 * time.Second)
 
-	client.waitForRestoredCommands("sess", waitTestWindows())
+	client.waitForRestoredCommands(context.Background(), "sess", waitTestWindows())
 
 	if runner.calls < 3 {
 		t.Fatalf("expected to poll until command started, polled %d times", runner.calls)
@@ -155,7 +156,7 @@ func TestWaitForRestoredCommandsRespectsTimeout(t *testing.T) {
 	client.SetRestoreTimeout(150 * time.Millisecond)
 
 	start := time.Now()
-	client.waitForRestoredCommands("sess", waitTestWindows())
+	client.waitForRestoredCommands(context.Background(), "sess", waitTestWindows())
 
 	if elapsed := time.Since(start); elapsed > 2*time.Second {
 		t.Fatalf("wait ignored its timeout, took %v", elapsed)
@@ -166,6 +167,24 @@ func TestWaitForRestoredCommandsRespectsTimeout(t *testing.T) {
 	}
 }
 
+func TestWaitForRestoredCommandsCancels(t *testing.T) {
+	t.Parallel()
+
+	runner := &pollRunner{settleOn: 1 << 30, before: "zsh", after: "cat"}
+	client := NewClientWithRunner("tmux", runner)
+	client.SetRestoreTimeout(10 * time.Second)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	client.waitForRestoredCommands(ctx, "sess", waitTestWindows())
+
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("cancelled wait must return promptly despite 10s timeout, took %v", elapsed)
+	}
+}
+
 func TestWaitForRestoredCommandsDisabled(t *testing.T) {
 	t.Parallel()
 
@@ -173,7 +192,7 @@ func TestWaitForRestoredCommandsDisabled(t *testing.T) {
 	client := NewClientWithRunner("tmux", runner)
 	client.SetRestoreTimeout(0)
 
-	client.waitForRestoredCommands("sess", waitTestWindows())
+	client.waitForRestoredCommands(context.Background(), "sess", waitTestWindows())
 
 	if runner.calls != 0 {
 		t.Fatalf("a disabled timeout must not poll, polled %d times", runner.calls)

--- a/internal/tmux/integration_test.go
+++ b/internal/tmux/integration_test.go
@@ -1,6 +1,7 @@
 package tmux_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -58,7 +59,7 @@ func TestRestoreToleratesBaseIndexMismatch(
 		},
 	}
 
-	if err := client.RestoreSession(snap); err != nil {
+	if err := client.RestoreSession(context.Background(), snap); err != nil {
 		t.Fatalf("restore with stale current_window must not fail: %v", err)
 	}
 
@@ -101,7 +102,7 @@ func TestRestoreToleratesPaneBaseIndexMismatch(
 		},
 	}
 
-	if err := client.RestoreSession(snap); err != nil {
+	if err := client.RestoreSession(context.Background(), snap); err != nil {
 		t.Fatalf("restore under base-index/pane-base-index 1 must not fail: %v", err)
 	}
 
@@ -135,7 +136,7 @@ func TestRestoreWaitsForCommandsToStart(
 		},
 	}
 
-	if err := client.RestoreSession(snap); err != nil {
+	if err := client.RestoreSession(context.Background(), snap); err != nil {
 		t.Fatalf("restore failed: %v", err)
 	}
 
@@ -186,7 +187,7 @@ func assertGuardedRestore(t *testing.T, name string, configure func(*tmux.Client
 		},
 	}
 
-	if err := client.RestoreSession(snap); err != nil {
+	if err := client.RestoreSession(context.Background(), snap); err != nil {
 		t.Fatalf("restore failed: %v", err)
 	}
 
@@ -242,7 +243,7 @@ func TestRestoreHonorsRecordedFocus(
 		},
 	}
 
-	if err := client.RestoreSession(snap); err != nil {
+	if err := client.RestoreSession(context.Background(), snap); err != nil {
 		t.Fatalf("restore failed: %v", err)
 	}
 


### PR DESCRIPTION
## Problem

During the restore loading animation the footer says `esc cancel`, but esc did nothing useful: it stopped the animation, left a black screen, then still threw you into the (half-)restored session. There was no way to back out of a restore.

## Fix

Esc (or `q`/`ctrl+c`) at **any** stage of restore now:
- cancels the in-flight restore via a `context.Context` — the settle wait (`waitForRestoredCommands`, up to `restore_timeout`, default 5s) and the per-window loop bail out immediately instead of running to completion;
- kills the session that the restore was creating (only if it did not already exist before restore, so a live session is never destroyed);
- returns you to the classic picker instead of attaching.

It's fast because the long pole — the settle poll loop — is now interruptible on `ctx.Done()` rather than blocking to the deadline.

## Changes

- `tmux.RestoreSession` / `waitForRestoredCommands` take a `context.Context` and honor cancellation.
- `picker.RunRestoreAnimation` reports whether the user cancelled.
- `App.RestoreTargetAnimated` returns `(cancelled bool, err error)`; on cancel it cancels the context, waits for the restore goroutine to unwind, and kills the partial session.
- `runTUIPicker` loops back to the picker on cancel.
- Non-animated paths (`Restore`/`RestoreTarget`/fzf) pass `context.Background()` — behavior unchanged.

## Verification

- `make build build-fzf`, `make golangci-lint`, `make test` (223 unit) and `make integration-test` all green.
- New unit test `TestWaitForRestoredCommandsCancels`: a cancelled context returns promptly despite a 10s restore timeout.
- All existing restore integration tests pass with the new signature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to cancel an in-progress session restoration.
  * Restorations now stop promptly when cancelled, avoiding unnecessary wait time.
  * The picker returns to target selection after a cancellation.
  * Partially created sessions are cleaned up when restoration is cancelled.

* **Bug Fixes**
  * Improved handling of interrupted animated restorations.
  * Prevented incomplete session restores from being left behind.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->