### PR TITLE
fix: use borderless popup (-B) for the picker keybinding

### DIFF
--- a/cmd/lazy-tmux/cli_test.go
+++ b/cmd/lazy-tmux/cli_test.go
@@ -190,12 +190,8 @@ func TestCLISetupPrintsKeybinds(t *testing.T) {
 		}
 	}
 
-	if !strings.Contains(out, "-w 75% -h 85%") {
-		t.Fatalf("expected single-percent popup geometry, got %q", out)
-	}
-
-	if !strings.Contains(out, "display-popup -B ") {
-		t.Fatalf("expected borderless popup (-B), got %q", out)
+	if !strings.Contains(out, "bind-key f display-popup -B -E 'lazy-tmux picker'") {
+		t.Fatalf("expected borderless popup binding, got %q", out)
 	}
 
 	if strings.Contains(out, "%%") {

--- a/cmd/lazy-tmux/setup.go
+++ b/cmd/lazy-tmux/setup.go
@@ -27,7 +27,7 @@ func runSetup(args []string, stdout, stderr io.Writer) int {
 	const daemonCmd = "run-shell -b 'lazy-tmux daemon --interval 3m --scrollback " +
 		">/tmp/lazy-tmux.log 2>&1 || tmux display-message \"lazy-tmux daemon already running\"'"
 
-	const popupKey = "bind-key f display-popup -B -w 75% -h 85% -E 'lazy-tmux picker'"
+	const popupKey = "bind-key f display-popup -B -E 'lazy-tmux picker'"
 
 	const saveKey = "bind-key C-s run-shell 'lazy-tmux save --all --scrollback && " +
 		"tmux display-message \"All sessions saved successfully!\"'"

--- a/docker/tmux.conf.example
+++ b/docker/tmux.conf.example
@@ -4,5 +4,5 @@ setw -g xterm-keys on
 run-shell "bash /root/.tmux/themes/nord-tmux/nord.tmux"
 
 run-shell -b 'lazy-tmux daemon --interval 1m --scrollback > /tmp/lazy-tmux.log 2>&1 || tmux display-message "lazy-tmux daemon already running"'
-bind-key f display-popup -w 75% -h 85% -E 'lazy-tmux picker'
+bind-key f display-popup -B -E 'lazy-tmux picker'
 bind-key C-s run-shell 'lazy-tmux save --all --scrollback && tmux display-message "All sessions saved successfully!"'

--- a/examples/tmux.conf.snippet
+++ b/examples/tmux.conf.snippet
@@ -2,4 +2,4 @@
 run-shell -b 'lazy-tmux daemon --interval 5m >/tmp/lazy-tmux.log 2>&1'
 run-shell -b 'lazy-tmux bootstrap --session last >/tmp/lazy-tmux-bootstrap.log 2>&1'
 bind-key s run-shell 'lazy-tmux save --all'
-bind-key f display-popup -E -w 100% -h 100% 'lazy-tmux picker'
+bind-key f display-popup -B -E 'lazy-tmux picker'


### PR DESCRIPTION
## Problem

Opening the picker in a tmux `display-popup` drew **two** borders: tmux's own popup border plus the picker TUI's frame. Doubled frames look off.

## Fix

Use `-B` (no tmux popup border) so only the picker's own frame shows. Standardize the recommended binding everywhere to:

```
bind-key f display-popup -B -E 'lazy-tmux picker'
```

- `lazy-tmux setup` now emits this exact line (dropped the `-w 75% -h 85%` sizing — tmux defaults to 50%×50%, and popup size is documented separately as an opt-in tweak on the Quick tmux setup page).
- `docker/tmux.conf.example` (sandbox config) updated to match.
- `cli_test.go` asserts the exact borderless binding.

The demo GIF is updated on the docs PR to show the single-frame popup.

## Verification

- `make build`, `make golangci-lint`, `make test` green.
- `lazy-tmux setup` output confirmed to print `bind-key f display-popup -B -E 'lazy-tmux picker'`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the `f` keybinding to launch the picker in a borderless, automatically sized popup.
  * Removed fixed popup width and height settings for more adaptive display behavior.
* **Tests**
  * Updated setup output validation to reflect the new picker keybinding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->