### PR TITLE
feat: jump to windows by index in the TUI picker

### DIFF
--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -524,7 +524,15 @@ func (m pickerModel) helpHints() string {
 		pairs = []hint{{"any key", "close help"}}
 	default:
 		pairs = []hint{
-			{"↵", "select"}, hintMove, {"⌘/ctrl+digit", "jump"}, {"/", "commands"}, {"?", "help"}, {keyEsc, "quit"},
+			{
+				"↵",
+				"select",
+			},
+			hintMove,
+			{"⌘/ctrl+digit", "jump"},
+			{"/", "commands"},
+			{"?", "help"},
+			{keyEsc, "quit"},
 		}
 	}
 

--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -524,7 +524,7 @@ func (m pickerModel) helpHints() string {
 		pairs = []hint{{"any key", "close help"}}
 	default:
 		pairs = []hint{
-			{"↵", "select"}, hintMove, {"/", "commands"}, {"?", "help"}, {keyEsc, "quit"},
+			{"↵", "select"}, hintMove, {"⌘/ctrl+digit", "jump"}, {"/", "commands"}, {"?", "help"}, {keyEsc, "quit"},
 		}
 	}
 
@@ -547,6 +547,14 @@ func (m pickerModel) helpHints() string {
 }
 
 func (m pickerModel) handleBrowseKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, bool) {
+	if windowIndex, ok := windowJumpIndex(msg); ok {
+		if m.jumpToWindow(windowIndex) {
+			m.renderViewport()
+		}
+
+		return m, nil, true
+	}
+
 	switch msg.String() {
 	case keyCtrlC, "ctrl+q", keyEsc:
 		m.cancelled = true
@@ -584,6 +592,30 @@ func (m pickerModel) handleBrowseKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, b
 	}
 
 	return m, nil, false
+}
+
+func windowJumpIndex(msg tea.KeyPressMsg) (int, bool) {
+	if msg.Mod&(tea.ModCtrl|tea.ModMeta|tea.ModSuper) == 0 ||
+		msg.Code < '0' || msg.Code > '9' {
+		return 0, false
+	}
+
+	return int(msg.Code - '0'), true
+}
+
+func (m *pickerModel) jumpToWindow(index int) bool {
+	for rowIndex, row := range m.visible {
+		if row.target.WindowIndex == nil || *row.target.WindowIndex != index {
+			continue
+		}
+
+		m.cursor = rowIndex
+		m.ensureCursorVisible()
+
+		return true
+	}
+
+	return false
 }
 
 func (m *pickerModel) applyActionResult(err error) {

--- a/internal/picker/model_internal_test.go
+++ b/internal/picker/model_internal_test.go
@@ -292,7 +292,11 @@ func TestModelJumpToFirstVisibleWindowByIndex(t *testing.T) {
 	if m.visible[m.cursor].target.SessionName != "beta" ||
 		m.visible[m.cursor].target.WindowIndex == nil ||
 		*m.visible[m.cursor].target.WindowIndex != 1 {
-		t.Fatalf("ctrl+1 should jump to beta window 1, got cursor=%d row=%+v", m.cursor, m.visible[m.cursor])
+		t.Fatalf(
+			"ctrl+1 should jump to beta window 1, got cursor=%d row=%+v",
+			m.cursor,
+			m.visible[m.cursor],
+		)
 	}
 }
 
@@ -303,8 +307,13 @@ func TestModelJumpToWindowSupportsCommandModifier(t *testing.T) {
 	m := newTestModel(t, rec, makeSession("alpha", false, "one", "two"))
 	m = feed(t, m, keySuper('2'))
 
-	if m.visible[m.cursor].target.WindowIndex == nil || *m.visible[m.cursor].target.WindowIndex != 2 {
-		t.Fatalf("command+2 should jump to window 2, got cursor=%d row=%+v", m.cursor, m.visible[m.cursor])
+	if m.visible[m.cursor].target.WindowIndex == nil ||
+		*m.visible[m.cursor].target.WindowIndex != 2 {
+		t.Fatalf(
+			"command+2 should jump to window 2, got cursor=%d row=%+v",
+			m.cursor,
+			m.visible[m.cursor],
+		)
 	}
 }
 

--- a/internal/picker/model_internal_test.go
+++ b/internal/picker/model_internal_test.go
@@ -21,6 +21,7 @@ func keyRune(r rune) tea.KeyPressMsg {
 func keyCode(code rune) tea.KeyPressMsg { return tea.KeyPressMsg{Code: code} }
 func keyCtrl(r rune) tea.KeyPressMsg    { return tea.KeyPressMsg{Code: r, Mod: tea.ModCtrl} }
 func keyAlt(r rune) tea.KeyPressMsg     { return tea.KeyPressMsg{Code: r, Mod: tea.ModAlt} }
+func keySuper(r rune) tea.KeyPressMsg   { return tea.KeyPressMsg{Code: r, Mod: tea.ModSuper} }
 
 func feed(t *testing.T, m pickerModel, msg tea.Msg) pickerModel {
 	t.Helper()
@@ -271,6 +272,53 @@ func TestModelNavigationAndSelect(t *testing.T) {
 	if m.selected.SessionName != "alpha" || m.selected.WindowIndex == nil ||
 		*m.selected.WindowIndex != 2 {
 		t.Fatalf("enter should select alpha window 2, got %+v", m.selected)
+	}
+}
+
+func TestModelJumpToFirstVisibleWindowByIndex(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	m := newTestModel(t, rec,
+		makeSession("alpha", false, "one", "needle"),
+		makeSession("beta", true, "needle", "three"),
+	)
+
+	for _, r := range "needle" {
+		m = feed(t, m, keyRune(r))
+	}
+	m = feed(t, m, keyCtrl('1'))
+
+	if m.visible[m.cursor].target.SessionName != "beta" ||
+		m.visible[m.cursor].target.WindowIndex == nil ||
+		*m.visible[m.cursor].target.WindowIndex != 1 {
+		t.Fatalf("ctrl+1 should jump to beta window 1, got cursor=%d row=%+v", m.cursor, m.visible[m.cursor])
+	}
+}
+
+func TestModelJumpToWindowSupportsCommandModifier(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	m := newTestModel(t, rec, makeSession("alpha", false, "one", "two"))
+	m = feed(t, m, keySuper('2'))
+
+	if m.visible[m.cursor].target.WindowIndex == nil || *m.visible[m.cursor].target.WindowIndex != 2 {
+		t.Fatalf("command+2 should jump to window 2, got cursor=%d row=%+v", m.cursor, m.visible[m.cursor])
+	}
+}
+
+func TestModelJumpToMissingWindowDoesNothing(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingActions{}
+	m := newTestModel(t, rec, makeSession("alpha", false, "one", "two"))
+	m.cursor = 2
+	before := m.cursor
+	m = feed(t, m, keyCtrl('9'))
+
+	if m.cursor != before {
+		t.Fatalf("missing window index should keep cursor at %d, got %d", before, m.cursor)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a modifier-plus-digit shortcut for jumping to the first visible window with a matching tmux window index.

## Behavior

- Ctrl+digit works on Linux and Windows.
- Meta/Super+digit supports terminal Command/Windows key reporting on macOS and compatible terminals.
- Searches the current filtered result from top to bottom.
- Ignores session header rows.
- Does nothing when the index is not present.
- Works with an empty query and with active fuzzy search.

## Validation

- go test -race ./...
- go vet ./...
- go build ./cmd/lazy-tmux
- go build -tags lazy_fzf ./cmd/lazy-tmux

make fmt and make test could not run locally because golangci-lint and gotestsum are not installed.

Closes #259.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ctrl/Meta/Super + number shortcuts for quickly jumping to visible windows by index.
  * Updated help hints to display the new shortcuts.

* **Bug Fixes**
  * Unavailable window numbers no longer move the current selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->