### PR TITLE
docs: Update instructions for installing with Homebrew

### DIFF
--- a/docs/src/pages/Installation.tsx
+++ b/docs/src/pages/Installation.tsx
@@ -39,11 +39,12 @@ export function Installation() {
           curl -fsSL https://lazy-tmux.xyz/install.sh | sh -s -- --fzf-engine
         </CodeBlock>
 
-        <p>Or use your package manager. Arch:</p>
+        <p>Or use your package manager.</p>
+        <p>Arch:</p>
         <CodeBlock>yay -S lazy-tmux</CodeBlock>
 
-        <p>MacOS (Homebrew):</p>
-        <CodeBlock>brew install alchemmist/tap/lazy-tmux</CodeBlock>
+        <p>macOS (Homebrew):</p>
+        <CodeBlock>brew install lazy-tmux</CodeBlock>
       </section>
     </>
   );


### PR DESCRIPTION
lazy-tmux can now be installed [directly](https://github.com/Homebrew/homebrew-core/commit/489f7fb966edbae996a39832729d5ef9829b5b95) via [Homebrew](https://brew.sh).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Split package-manager installation instructions into separate Arch Linux and macOS sections.
  * Updated the macOS Homebrew installation command to use the standard package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->