### PR TITLE
fix(claude): resolve each pane's session by its own pid

### DIFF
--- a/internal/integration/claude/claude.go
+++ b/internal/integration/claude/claude.go
@@ -1,6 +1,8 @@
 package claude
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,6 +42,15 @@ func (i *Integration) Matches(pane snapshot.Pane) bool {
 }
 
 func (i *Integration) Capture(pane snapshot.Pane) (map[string]string, error) {
+	// Multiple panes can run Claude Code in the same cwd at once. Pin the
+	// match to the pane's own live process first — latestSessionID below
+	// only looks at the directory and can't tell those panes apart, it
+	// just returns whichever transcript in that project happened to be
+	// written most recently across every pane sharing the cwd.
+	if sessionID, ok := i.sessionIDFromLiveProcess(pane.ForegroundPID, pane.CurrentPath); ok {
+		return map[string]string{metaSessionID: sessionID}, nil
+	}
+
 	sessionID, ok := i.latestSessionID(pane.CurrentPath)
 	if !ok {
 		return map[string]string{}, nil
@@ -94,6 +105,45 @@ func (i *Integration) latestSessionID(cwd string) (string, bool) {
 	}
 
 	return newestID, found
+}
+
+// liveSession mirrors the subset of ~/.claude/sessions/<pid>.json this
+// integration cares about. Same file status.go already reads via
+// claudeSession/freshestLiveSession, just keyed by a specific pid here
+// instead of scanned by cwd.
+type liveSession struct {
+	SessionID string `json:"sessionId"`
+	CWD       string `json:"cwd"`
+}
+
+func (i *Integration) sessionIDFromLiveProcess(pid int, cwd string) (string, bool) {
+	if pid <= 0 || strings.TrimSpace(i.home) == "" {
+		return "", false
+	}
+
+	path := filepath.Join(i.home, "sessions", fmt.Sprintf("%d.json", pid))
+
+	// #nosec G304 -- fixed subdirectory under the user's Claude home, pid is numeric
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+
+	var sess liveSession
+	if json.Unmarshal(data, &sess) != nil {
+		return "", false
+	}
+
+	sess.SessionID = strings.TrimSpace(sess.SessionID)
+	if sess.SessionID == "" {
+		return "", false
+	}
+
+	if cwd != "" && sess.CWD != "" && sess.CWD != cwd {
+		return "", false
+	}
+
+	return sess.SessionID, true
 }
 
 func EncodeProjectDir(cwd string) string {

--- a/internal/integration/claude/claude_internal_test.go
+++ b/internal/integration/claude/claude_internal_test.go
@@ -3,6 +3,7 @@ package claude
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -61,6 +62,104 @@ func TestCaptureMissingProjectDir(t *testing.T) {
 
 	if len(meta) != 0 {
 		t.Fatalf("missing dir should yield no meta, got %v", meta)
+	}
+}
+
+func writeLiveSession(t *testing.T, home string, pid int, sessionID, cwd string) {
+	t.Helper()
+
+	dir := filepath.Join(home, "sessions")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	body := `{"pid":` + strconv.Itoa(pid) + `,"sessionId":"` + sessionID + `","cwd":"` + cwd + `"}`
+
+	path := filepath.Join(dir, strconv.Itoa(pid)+".json")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write live session: %v", err)
+	}
+}
+
+func TestCaptureDisambiguatesPanesInSameDirectory(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	cwd := "/Users/me/code/proj"
+
+	// Same directory, single transcript on disk — latestSessionID alone
+	// can't tell the two panes apart, both would resolve to this one.
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	writeTranscript(t, home, cwd, "either-pane-session", base)
+
+	writeLiveSession(t, home, 1001, "session-a", cwd)
+	writeLiveSession(t, home, 1002, "session-b", cwd)
+
+	integ := New(home, "")
+
+	metaA, err := integ.Capture(snapshot.Pane{CurrentPath: cwd, CurrentCmd: "claude", ForegroundPID: 1001})
+	if err != nil {
+		t.Fatalf("capture pane a: %v", err)
+	}
+
+	metaB, err := integ.Capture(snapshot.Pane{CurrentPath: cwd, CurrentCmd: "claude", ForegroundPID: 1002})
+	if err != nil {
+		t.Fatalf("capture pane b: %v", err)
+	}
+
+	if metaA["session_id"] != "session-a" {
+		t.Fatalf("pane a: expected session-a, got %q", metaA["session_id"])
+	}
+
+	if metaB["session_id"] != "session-b" {
+		t.Fatalf("pane b: expected session-b, got %q", metaB["session_id"])
+	}
+}
+
+func TestCaptureFallsBackWhenNoLiveSessionFile(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	cwd := "/Users/me/code/proj"
+
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	writeTranscript(t, home, cwd, "from-directory", base)
+
+	integ := New(home, "")
+
+	// No ~/.claude/sessions/9999.json — must fall back to the directory scan.
+	meta, err := integ.Capture(snapshot.Pane{CurrentPath: cwd, CurrentCmd: "claude", ForegroundPID: 9999})
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+
+	if meta["session_id"] != "from-directory" {
+		t.Fatalf("expected fallback to directory scan, got %q", meta["session_id"])
+	}
+}
+
+func TestCaptureIgnoresLiveSessionForDifferentCwd(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	cwd := "/Users/me/code/proj"
+
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	writeTranscript(t, home, cwd, "from-directory", base)
+
+	// A reused/stale pid whose session file points at a different cwd
+	// entirely — must not be trusted, falls back to the directory scan.
+	writeLiveSession(t, home, 1003, "stale-session", "/Users/me/code/other-proj")
+
+	integ := New(home, "")
+
+	meta, err := integ.Capture(snapshot.Pane{CurrentPath: cwd, CurrentCmd: "claude", ForegroundPID: 1003})
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+
+	if meta["session_id"] != "from-directory" {
+		t.Fatalf("cwd mismatch should be ignored, got %q", meta["session_id"])
 	}
 }
 

--- a/internal/snapshot/types.go
+++ b/internal/snapshot/types.go
@@ -33,6 +33,13 @@ type Pane struct {
 	Scrollback  *ScrollbackRef `json:"scrollback,omitempty"`
 	IsActive    bool           `json:"is_active"`
 
+	// ForegroundPID is the pid resolved by foregroundCommand at capture time.
+	// In-memory only (never persisted): integrations use it during the same
+	// save() call to disambiguate panes that share a cwd (see the claude
+	// integration's Capture, which needs the exact pid to tell apart
+	// multiple Claude Code panes running in the same directory).
+	ForegroundPID int `json:"-"`
+
 	Meta map[string]string `json:"meta,omitempty"`
 }
 

--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -746,16 +746,17 @@ func (client *Client) capturePanes(name string, window *snapshot.Window) error {
 
 		pIdx, _ := strconv.Atoi(parts[0])
 		panePID, _ := strconv.Atoi(strings.TrimSpace(parts[2]))
-		restoreCmd, _ := client.foregroundCommand(parts[3], panePID)
+		restoreCmd, foregroundPID, _ := client.foregroundCommand(parts[3], panePID)
 
 		pane := snapshot.Pane{
-			Index:       pIdx,
-			IsActive:    parts[1] == "1",
-			CurrentCmd:  parts[4],
-			CurrentPath: parts[5],
-			RestoreCmd:  strings.TrimSpace(restoreCmd),
-			Scrollback:  nil,
-			Meta:        codexSessionMeta(parts[6]),
+			Index:         pIdx,
+			IsActive:      parts[1] == "1",
+			CurrentCmd:    parts[4],
+			CurrentPath:   parts[5],
+			RestoreCmd:    strings.TrimSpace(restoreCmd),
+			Scrollback:    nil,
+			Meta:          codexSessionMeta(parts[6]),
+			ForegroundPID: foregroundPID,
 		}
 		if pane.IsActive {
 			window.ActivePane = pane.Index
@@ -1130,10 +1131,10 @@ func writePaneTTY(path, content string) error {
 	return nil
 }
 
-func (client *Client) foregroundCommand(paneTTY string, panePID int) (string, error) {
+func (client *Client) foregroundCommand(paneTTY string, panePID int) (string, int, error) {
 	tty := strings.TrimSpace(paneTTY)
 	if tty == "" {
-		return "", nil
+		return "", 0, nil
 	}
 
 	candidates := []string{tty}
@@ -1172,12 +1173,12 @@ func (client *Client) foregroundCommand(paneTTY string, panePID int) (string, er
 	}
 
 	if err != nil {
-		return "", fmt.Errorf("get output: %w", err)
+		return "", 0, fmt.Errorf("get output: %w", err)
 	}
 
-	command := pickForegroundCommand(splitLines(string(out)), panePID)
+	command, pid := pickForegroundCommand(splitLines(string(out)), panePID)
 	if command != "" {
-		return command, nil
+		return command, pid, nil
 	}
 
 	// Some terminal wrappers give the child process a different tty from the
@@ -1186,7 +1187,7 @@ func (client *Client) foregroundCommand(paneTTY string, panePID int) (string, er
 	return client.fallbackForegroundCommand(panePID)
 }
 
-func (client *Client) fallbackForegroundCommand(panePID int) (string, error) {
+func (client *Client) fallbackForegroundCommand(panePID int) (string, int, error) {
 	cmd := exec.CommandContext( // #nosec G204 -- fixed "ps" binary and numeric pane PID
 		context.Background(),
 		"ps",
@@ -1202,13 +1203,15 @@ func (client *Client) fallbackForegroundCommand(panePID int) (string, error) {
 	)
 	allOut, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("get process list: %w", err)
+		return "", 0, fmt.Errorf("get process list: %w", err)
 	}
 
-	return pickForegroundCommand(
+	command, pid := pickForegroundCommand(
 		processTreeLines(splitLines(string(allOut)), panePID),
 		panePID,
-	), nil
+	)
+
+	return command, pid, nil
 }
 
 func processTreeLines(lines []string, rootPID int) []string {
@@ -1300,19 +1303,19 @@ func collectCandidateProcesses(lines []string, panePID int) ([]psProcess, []psPr
 	return nonShell, shells
 }
 
-func pickForegroundCommand(lines []string, panePID int) string {
+func pickForegroundCommand(lines []string, panePID int) (string, int) {
 	nonShell, shells := collectCandidateProcesses(lines, panePID)
 
-	if cmd := pickFromCandidates(nonShell); cmd != "" {
-		return cmd
+	if cmd, pid := pickFromCandidates(nonShell); cmd != "" {
+		return cmd, pid
 	}
 
 	return pickFromCandidates(shells)
 }
 
-func pickFromCandidates(allProcesses []psProcess) string {
+func pickFromCandidates(allProcesses []psProcess) (string, int) {
 	if len(allProcesses) == 0 {
-		return ""
+		return "", 0
 	}
 
 	allPIDs := make(map[int]struct{}, len(allProcesses))
@@ -1331,24 +1334,24 @@ func pickFromCandidates(allProcesses []psProcess) string {
 	if len(rootProcesses) > 0 {
 		for _, p := range rootProcesses {
 			if strings.Contains(p.stat, "+") {
-				return p.cmd
+				return p.cmd, p.pid
 			}
 		}
 
-		return rootProcesses[0].cmd
+		return rootProcesses[0].cmd, rootProcesses[0].pid
 	}
 
 	for _, p := range allProcesses {
 		if strings.Contains(p.stat, "+") {
-			return p.cmd
+			return p.cmd, p.pid
 		}
 	}
 
 	if len(allProcesses) > 0 {
-		return allProcesses[0].cmd
+		return allProcesses[0].cmd, allProcesses[0].pid
 	}
 
-	return ""
+	return "", 0
 }
 
 const (

--- a/internal/tmux/client_internal_test.go
+++ b/internal/tmux/client_internal_test.go
@@ -517,11 +517,11 @@ func TestPickForegroundCommand(t *testing.T) {
 		"200 100 S+ nvim",
 	}
 
-	if got := pickForegroundCommand(lines, 100); got != "nvim" {
+	if got, _ := pickForegroundCommand(lines, 100); got != "nvim" {
 		t.Fatalf("expected foreground nvim, got %q", got)
 	}
 
-	if got := pickForegroundCommand([]string{"100 1 Ss zsh"}, 100); got != "" {
+	if got, _ := pickForegroundCommand([]string{"100 1 Ss zsh"}, 100); got != "" {
 		t.Fatalf("expected empty for shell-only, got %q", got)
 	}
 
@@ -529,15 +529,15 @@ func TestPickForegroundCommand(t *testing.T) {
 		"100 1 Ss zsh",
 		"300 100 S+ fish",
 	}
-	if got := pickForegroundCommand(launched, 100); got != "fish" {
-		t.Fatalf("expected launched fish, got %q", got)
+	if got, pid := pickForegroundCommand(launched, 100); got != "fish" || pid != 300 {
+		t.Fatalf("expected launched fish/300, got %q/%d", got, pid)
 	}
 
 	helper := []string{
 		"100 1 Ss zsh",
 		"301 100 S zsh -c helper",
 	}
-	if got := pickForegroundCommand(helper, 100); got != "" {
+	if got, _ := pickForegroundCommand(helper, 100); got != "" {
 		t.Fatalf("expected empty for background shell helper, got %q", got)
 	}
 
@@ -546,8 +546,8 @@ func TestPickForegroundCommand(t *testing.T) {
 		"300 100 S fish",
 		"400 300 S+ nvim",
 	}
-	if got := pickForegroundCommand(nested, 100); got != "nvim" {
-		t.Fatalf("expected nvim over launched shell, got %q", got)
+	if got, pid := pickForegroundCommand(nested, 100); got != "nvim" || pid != 400 {
+		t.Fatalf("expected nvim/400 over launched shell, got %q/%d", got, pid)
 	}
 }
 
@@ -559,8 +559,8 @@ func TestPickForegroundCommandFromProcessTree(t *testing.T) {
 		"200 100 S codex",
 	}
 
-	if got := pickForegroundCommand(lines, 100); got != "codex" {
-		t.Fatalf("expected child codex, got %q", got)
+	if got, pid := pickForegroundCommand(lines, 100); got != "codex" || pid != 200 {
+		t.Fatalf("expected child codex/200, got %q/%d", got, pid)
 	}
 }
 
@@ -574,8 +574,8 @@ func TestProcessTreeLinesExcludesUnrelatedProcesses(t *testing.T) {
 	}
 
 	tree := processTreeLines(lines, 100)
-	if got := pickForegroundCommand(tree, 100); got != "codex" {
-		t.Fatalf("expected codex from pane tree, got %q", got)
+	if got, pid := pickForegroundCommand(tree, 100); got != "codex" || pid != 200 {
+		t.Fatalf("expected codex/200 from pane tree, got %q/%d", got, pid)
 	}
 	if len(tree) != 1 {
 		t.Fatalf("expected one descendant, got %v", tree)


### PR DESCRIPTION
Fixes #276.

## Problem

Several panes running Claude Code in the same directory all get saved with the same `claude.session_id`. On restore they all run `claude --resume <same-id>` — one conversation duplicated N times instead of N distinct ones.

`Capture()` resolved the session purely by directory: `latestSessionID(cwd)` lists `~/.claude/projects/<EncodeProjectDir(cwd)>/*.jsonl` and takes the newest mtime. No pane-level signal, so every pane sharing a cwd gets whichever transcript happened to be written last across the whole group.

## Fix

The data to tell panes apart was already on disk, and this integration already reads it — just not from `Capture()`. Claude Code keeps `~/.claude/sessions/<pid>.json` per live process (`{pid, sessionId, cwd, tmux, status}`), and `statusFromSessionFile()` in `status.go` reads it for the picker's status dot — filtered by cwd, never keyed by pid.

- `internal/snapshot/types.go` — new `Pane.ForegroundPID int`, tagged `json:"-"`: in-memory only, never persisted, used by integrations during the same `save()` call.
- `internal/tmux/client.go` — `pickForegroundCommand`, `pickFromCandidates`, `foregroundCommand` and `fallbackForegroundCommand` now return the resolved pid alongside the command string, and `capturePanes` puts it on the pane. That pid was already being resolved internally and thrown away once the command string was picked, so nothing new is being computed here.
- `internal/integration/claude/claude.go` — `Capture()` tries `~/.claude/sessions/<pid>.json` first and falls back to `latestSessionID(cwd)` when the pid is 0, the file is missing or unreadable, or its `cwd` disagrees with the pane's. The single-pane-per-directory path is unchanged, and so is behaviour on older Claude Code versions that don't write that file.

## Tests

- `TestCaptureDisambiguatesPanesInSameDirectory` — two pids, same cwd, one shared transcript on disk: each pane resolves to its own session. This is the case that fails without the fix.
- `TestCaptureFallsBackWhenNoLiveSessionFile` — no `<pid>.json`, falls back to the directory scan.
- `TestCaptureIgnoresLiveSessionForDifferentCwd` — a live-session file whose `cwd` doesn't match the pane (recycled or stale pid) is not trusted.
- `internal/tmux/client_internal_test.go` updated to the new signatures, asserting the expected pid and not just the command string.

## Verification

`go build ./...`, `go vet ./...` and `go test ./...` are clean.

Checked against the real bug on macOS: a 4-pane window, 4 different conversations, same repo. Before the patch all four panes saved `8e060db2-…`; after it they save four distinct ids, each matching the live `claude` process in that pane (cross-checked against `~/.claude/sessions/*.json`).

I haven't run `make golangci-lint` locally — I don't have golangci-lint installed on this machine — so that's on CI here.

One open question from the issue that's worth your call: I couldn't find `~/.claude/sessions/<pid>.json` documented anywhere, so I don't know how stable its schema is meant to be. `status.go` already depends on it, so this isn't a new dependency, but it is a second use of one. Happy to rework the approach if you'd rather not lean on it further.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude session capture by selecting the active session associated with the foreground pane.
  * Prevented sessions from being incorrectly matched when pane details, home directories, or working directories do not align.
  * Preserved fallback behavior by continuing to use the latest available transcript when active session details cannot be found.
  * Improved handling of panes that share a working directory by distinguishing their active processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->