### PR TITLE
fix: stabilize tmux size integration fixture

### DIFF
--- a/internal/tmux/integration_test.go
+++ b/internal/tmux/integration_test.go
@@ -260,8 +260,8 @@ func TestSynchronizeWindowSizeUsesAttachedClient(t *testing.T) {
 	testutil.IsolatedTmux(t)
 
 	client := tmux.NewClient("tmux")
-	testutil.Tmux(t, "set-option", "-g", "window-size", "manual")
 	testutil.Tmux(t, "new-session", "-d", "-s", "restored", "-x", "80", "-y", "24")
+	testutil.Tmux(t, "set-option", "-w", "-t", "=restored:0", "window-size", "manual")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	control := exec.CommandContext(ctx, "tmux", "-C", "attach-session", "-t", "=restored")


### PR DESCRIPTION
## Summary

- create the detached tmux session before changing its window sizing mode
- target the existing restored window instead of setting a global window option on an empty server

## Why

Distro tmux can exit the empty isolated server between `set-option` and `new-session`, causing `server exited unexpectedly`.

## Validation

- `ENABLE_INTEGRATION_TESTS=true go test ./internal/tmux -run TestSynchronizeWindowSizeUsesAttachedClient -count=50`
- full Podman integration suite: 261/261 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an integration test to more accurately verify window-size synchronization for attached sessions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->