### PR TITLE
feat: render picker before loading sessions

### DIFF
--- a/internal/app/app_picker.go
+++ b/internal/app/app_picker.go
@@ -193,15 +193,6 @@ func (a *App) SelectTargetWithTUI() (PickerTarget, error) {
 }
 
 func (a *App) SelectTargetWithTUISorted(opts PickerSortOptions) (PickerTarget, error) {
-	sessions, err := a.pickerSessions(opts)
-	if err != nil {
-		if errors.Is(err, errNoSavedSessions) {
-			sessions = []picker.Session{}
-		} else {
-			return PickerTarget{}, err
-		}
-	}
-
 	actions := picker.Actions{
 		DeleteWindow:  a.DeleteWindow,
 		DeleteSession: a.DeleteSession,
@@ -228,7 +219,7 @@ func (a *App) SelectTargetWithTUISorted(opts PickerSortOptions) (PickerTarget, e
 		},
 	}
 
-	target, err := picker.ChooseTargetWithTheme(sessions, opts.Window, actions, a.cfg.Theme)
+	target, err := picker.ChooseTargetWithLoader(opts.Window, actions, a.cfg.Theme)
 	if err != nil {
 		return picker.Target{}, fmt.Errorf("choose target: %w", err)
 	}

--- a/internal/picker/actions.go
+++ b/internal/picker/actions.go
@@ -431,7 +431,7 @@ func (m *pickerModel) sleepSession() error {
 
 func (m *pickerModel) reload() {
 	m.reloadGeneration++
-	m.reloadPending = false
+	m.loading = false
 	if m.actions.Reload == nil {
 		return
 	}

--- a/internal/picker/actions.go
+++ b/internal/picker/actions.go
@@ -430,6 +430,8 @@ func (m *pickerModel) sleepSession() error {
 }
 
 func (m *pickerModel) reload() {
+	m.reloadGeneration++
+	m.reloadPending = false
 	if m.actions.Reload == nil {
 		return
 	}

--- a/internal/picker/actions.go
+++ b/internal/picker/actions.go
@@ -437,10 +437,25 @@ func (m *pickerModel) reload() {
 	}
 
 	sessions, err := m.actions.Reload()
+	m.applySessionLoadResult(sessions, err, sessionLoadMutation)
+}
+
+func (m *pickerModel) applySessionLoadResult(
+	sessions []Session,
+	err error,
+	source sessionLoadSource,
+) {
 	if err != nil {
-		m.setStatus(err.Error())
+		if source == sessionLoadBackground {
+			m.setLoaderStatus(err.Error())
+		} else {
+			m.setStatus(err.Error())
+		}
 
 		return
+	}
+	if source == sessionLoadBackground && m.statusFromLoader {
+		m.clearStatus()
 	}
 
 	m.sessions = sessions
@@ -458,11 +473,19 @@ func (m *pickerModel) currentRow() (pickerRow, bool) {
 
 func (m *pickerModel) setStatus(msg string) {
 	m.statusMsg = strings.TrimSpace(msg)
+	m.statusFromLoader = false
+	m.resize()
+}
+
+func (m *pickerModel) setLoaderStatus(msg string) {
+	m.statusMsg = strings.TrimSpace(msg)
+	m.statusFromLoader = true
 	m.resize()
 }
 
 func (m *pickerModel) clearStatus() {
 	m.statusMsg = ""
+	m.statusFromLoader = false
 	m.resize()
 }
 

--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -30,8 +30,9 @@ type statusTickMsg struct{}
 type spinnerTickMsg struct{}
 
 type sessionsLoadedMsg struct {
-	sessions []Session
-	err      error
+	sessions   []Session
+	err        error
+	generation uint64
 }
 
 type pickerRow struct {
@@ -49,32 +50,33 @@ type pickerRow struct {
 
 //nolint:recvcheck // deliberate value/pointer receiver mix, see above
 type pickerModel struct {
-	sessions      []Session
-	windowSort    []WindowSortKey
-	visible       []pickerRow
-	queryInput    textinput.Model
-	viewport      viewport.Model
-	theme         pickerTheme
-	themeName     string
-	selected      Target
-	cancelled     bool
-	cursor        int
-	width         int
-	height        int
-	actions       Actions
-	statusMsg     string
-	mode          pickerMode
-	action        actionMode
-	marked        map[string]struct{}
-	palette       bool
-	paletteIdx    int
-	promptInput   textinput.Model
-	pending       Target
-	helpOpen      bool
-	spinnerFrame  int
-	spinnerOn     bool
-	loading       bool
-	reloadPending bool
+	sessions         []Session
+	windowSort       []WindowSortKey
+	visible          []pickerRow
+	queryInput       textinput.Model
+	viewport         viewport.Model
+	theme            pickerTheme
+	themeName        string
+	selected         Target
+	cancelled        bool
+	cursor           int
+	width            int
+	height           int
+	actions          Actions
+	statusMsg        string
+	mode             pickerMode
+	action           actionMode
+	marked           map[string]struct{}
+	palette          bool
+	paletteIdx       int
+	promptInput      textinput.Model
+	pending          Target
+	helpOpen         bool
+	spinnerFrame     int
+	spinnerOn        bool
+	loading          bool
+	reloadPending    bool
+	reloadGeneration uint64
 }
 
 type pickerMode int
@@ -150,21 +152,23 @@ func newPickerModelWithTheme(
 func (m pickerModel) Init() tea.Cmd {
 	cmds := []tea.Cmd{textinput.Blink, scheduleStatusRefresh(), scheduleSpinner()}
 	if m.loading {
-		cmds = append(cmds, loadSessions(m.actions.Reload))
+		cmds = append(cmds, loadSessions(m.actions.Reload, m.reloadGeneration))
 	}
 
 	return tea.Batch(cmds...)
 }
 
-func loadSessions(loader func() ([]Session, error)) tea.Cmd {
+func loadSessions(loader func() ([]Session, error), generation uint64) tea.Cmd {
 	return func() tea.Msg {
 		if loader == nil {
-			return sessionsLoadedMsg{sessions: nil, err: errSessionLoaderUnavailable}
+			return sessionsLoadedMsg{
+				sessions: nil, err: errSessionLoaderUnavailable, generation: generation,
+			}
 		}
 
 		sessions, err := loader()
 
-		return sessionsLoadedMsg{sessions: sessions, err: err}
+		return sessionsLoadedMsg{sessions: sessions, err: err, generation: generation}
 	}
 }
 
@@ -190,19 +194,7 @@ func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case spinnerTickMsg:
 		return m.handleSpinnerTick()
 	case sessionsLoadedMsg:
-		m.loading = false
-		m.reloadPending = false
-		if msg.err != nil {
-			m.setStatus(msg.err.Error())
-		} else {
-			m.clearStatus()
-			m.sessions = msg.sessions
-			m.applyFilter()
-			m.ensureCursorVisible()
-		}
-		m.renderViewport()
-
-		return m, nil
+		return m.handleSessionsLoaded(msg)
 	case tea.MouseWheelMsg:
 		return m.handleWheel(msg)
 	case tea.MouseClickMsg:
@@ -278,12 +270,33 @@ func (m pickerModel) View() tea.View {
 	return view
 }
 
+func (m pickerModel) handleSessionsLoaded(msg sessionsLoadedMsg) (tea.Model, tea.Cmd) {
+	if msg.generation != m.reloadGeneration {
+		return m, nil
+	}
+
+	m.loading = false
+	m.reloadPending = false
+	if msg.err != nil {
+		m.setStatus(msg.err.Error())
+	} else {
+		m.clearStatus()
+		m.sessions = msg.sessions
+		m.applyFilter()
+		m.ensureCursorVisible()
+	}
+	m.renderViewport()
+
+	return m, nil
+}
+
 func (m pickerModel) handleStatusTick() (tea.Model, tea.Cmd) {
 	cmds := []tea.Cmd{scheduleStatusRefresh()}
 	if m.mode == modeBrowse && !m.palette && !m.loading && !m.reloadPending &&
 		m.actions.Reload != nil {
+		m.reloadGeneration++
 		m.reloadPending = true
-		cmds = append(cmds, loadSessions(m.actions.Reload))
+		cmds = append(cmds, loadSessions(m.actions.Reload, m.reloadGeneration))
 	}
 	if m.hasWorkingWindow() && !m.spinnerOn {
 		m.spinnerOn = true
@@ -1192,6 +1205,7 @@ func ChooseTargetWithLoader(
 	m := newPickerModelWithTheme([]Session{}, windowSort, actions, themeName)
 	m.loading = true
 	m.reloadPending = true
+	m.reloadGeneration = 1
 
 	return runPicker(m)
 }

--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"charm.land/bubbles/v2/textinput"
@@ -121,6 +122,7 @@ func newPickerModelWithTheme(
 	actions Actions,
 	themeName string,
 ) pickerModel {
+	actions.Reload = serializeSessionLoader(actions.Reload)
 	if themeName != themeLight {
 		themeName = themeDark
 	}
@@ -155,6 +157,21 @@ func newPickerModelWithTheme(
 	model.applyFilter()
 
 	return model
+}
+
+func serializeSessionLoader(loader func() ([]Session, error)) func() ([]Session, error) {
+	if loader == nil {
+		return nil
+	}
+
+	var mutex sync.Mutex
+
+	return func() ([]Session, error) {
+		mutex.Lock()
+		defer mutex.Unlock()
+
+		return loader()
+	}
 }
 
 func (m pickerModel) Init() tea.Cmd {

--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -279,12 +279,12 @@ func (m pickerModel) View() tea.View {
 }
 
 func (m pickerModel) handleSessionsLoaded(msg sessionsLoadedMsg) (tea.Model, tea.Cmd) {
+	m.reloadPending = false
 	if msg.generation != m.reloadGeneration {
 		return m, nil
 	}
 
 	m.loading = false
-	m.reloadPending = false
 	m.applySessionLoadResult(msg.sessions, msg.err, sessionLoadBackground)
 	m.renderViewport()
 

--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -35,6 +35,13 @@ type sessionsLoadedMsg struct {
 	generation uint64
 }
 
+type sessionLoadSource int
+
+const (
+	sessionLoadBackground sessionLoadSource = iota
+	sessionLoadMutation
+)
+
 type pickerRow struct {
 	target     Target
 	item       string
@@ -64,6 +71,7 @@ type pickerModel struct {
 	height           int
 	actions          Actions
 	statusMsg        string
+	statusFromLoader bool
 	mode             pickerMode
 	action           actionMode
 	marked           map[string]struct{}
@@ -277,14 +285,7 @@ func (m pickerModel) handleSessionsLoaded(msg sessionsLoadedMsg) (tea.Model, tea
 
 	m.loading = false
 	m.reloadPending = false
-	if msg.err != nil {
-		m.setStatus(msg.err.Error())
-	} else {
-		m.clearStatus()
-		m.sessions = msg.sessions
-		m.applyFilter()
-		m.ensureCursorVisible()
-	}
+	m.applySessionLoadResult(msg.sessions, msg.err, sessionLoadBackground)
 	m.renderViewport()
 
 	return m, nil

--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -14,10 +14,11 @@ import (
 )
 
 var (
-	errTUIDisabled       = errors.New("TUI picker disabled in fzf-only build")
-	errUnexpectedModel   = errors.New("unexpected picker model type")
-	errSelectionCanceled = errors.New("selection canceled")
-	errNoSessionSelected = errors.New("no session selected")
+	errTUIDisabled              = errors.New("TUI picker disabled in fzf-only build")
+	errUnexpectedModel          = errors.New("unexpected picker model type")
+	errSelectionCanceled        = errors.New("selection canceled")
+	errNoSessionSelected        = errors.New("no session selected")
+	errSessionLoaderUnavailable = errors.New("session loader unavailable")
 )
 
 const statusRefreshInterval = 2 * time.Second
@@ -27,6 +28,11 @@ const spinnerInterval = 160 * time.Millisecond
 type statusTickMsg struct{}
 
 type spinnerTickMsg struct{}
+
+type sessionsLoadedMsg struct {
+	sessions []Session
+	err      error
+}
 
 type pickerRow struct {
 	target     Target
@@ -43,30 +49,32 @@ type pickerRow struct {
 
 //nolint:recvcheck // deliberate value/pointer receiver mix, see above
 type pickerModel struct {
-	sessions     []Session
-	windowSort   []WindowSortKey
-	visible      []pickerRow
-	queryInput   textinput.Model
-	viewport     viewport.Model
-	theme        pickerTheme
-	themeName    string
-	selected     Target
-	cancelled    bool
-	cursor       int
-	width        int
-	height       int
-	actions      Actions
-	statusMsg    string
-	mode         pickerMode
-	action       actionMode
-	marked       map[string]struct{}
-	palette      bool
-	paletteIdx   int
-	promptInput  textinput.Model
-	pending      Target
-	helpOpen     bool
-	spinnerFrame int
-	spinnerOn    bool
+	sessions      []Session
+	windowSort    []WindowSortKey
+	visible       []pickerRow
+	queryInput    textinput.Model
+	viewport      viewport.Model
+	theme         pickerTheme
+	themeName     string
+	selected      Target
+	cancelled     bool
+	cursor        int
+	width         int
+	height        int
+	actions       Actions
+	statusMsg     string
+	mode          pickerMode
+	action        actionMode
+	marked        map[string]struct{}
+	palette       bool
+	paletteIdx    int
+	promptInput   textinput.Model
+	pending       Target
+	helpOpen      bool
+	spinnerFrame  int
+	spinnerOn     bool
+	loading       bool
+	reloadPending bool
 }
 
 type pickerMode int
@@ -140,7 +148,24 @@ func newPickerModelWithTheme(
 }
 
 func (m pickerModel) Init() tea.Cmd {
-	return tea.Batch(textinput.Blink, scheduleStatusRefresh(), scheduleSpinner())
+	cmds := []tea.Cmd{textinput.Blink, scheduleStatusRefresh(), scheduleSpinner()}
+	if m.loading {
+		cmds = append(cmds, loadSessions(m.actions.Reload))
+	}
+
+	return tea.Batch(cmds...)
+}
+
+func loadSessions(loader func() ([]Session, error)) tea.Cmd {
+	return func() tea.Msg {
+		if loader == nil {
+			return sessionsLoadedMsg{sessions: nil, err: errSessionLoaderUnavailable}
+		}
+
+		sessions, err := loader()
+
+		return sessionsLoadedMsg{sessions: sessions, err: err}
+	}
 }
 
 func scheduleStatusRefresh() tea.Cmd {
@@ -164,6 +189,20 @@ func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleStatusTick()
 	case spinnerTickMsg:
 		return m.handleSpinnerTick()
+	case sessionsLoadedMsg:
+		m.loading = false
+		m.reloadPending = false
+		if msg.err != nil {
+			m.setStatus(msg.err.Error())
+		} else {
+			m.clearStatus()
+			m.sessions = msg.sessions
+			m.applyFilter()
+			m.ensureCursorVisible()
+		}
+		m.renderViewport()
+
+		return m, nil
 	case tea.MouseWheelMsg:
 		return m.handleWheel(msg)
 	case tea.MouseClickMsg:
@@ -240,12 +279,12 @@ func (m pickerModel) View() tea.View {
 }
 
 func (m pickerModel) handleStatusTick() (tea.Model, tea.Cmd) {
-	if m.mode == modeBrowse && !m.palette {
-		m.reload()
-		m.renderViewport()
-	}
-
 	cmds := []tea.Cmd{scheduleStatusRefresh()}
+	if m.mode == modeBrowse && !m.palette && !m.loading && !m.reloadPending &&
+		m.actions.Reload != nil {
+		m.reloadPending = true
+		cmds = append(cmds, loadSessions(m.actions.Reload))
+	}
 	if m.hasWorkingWindow() && !m.spinnerOn {
 		m.spinnerOn = true
 		cmds = append(cmds, scheduleSpinner())
@@ -345,6 +384,12 @@ func (m pickerModel) writeTable(buf *strings.Builder, width int) {
 	if m.statusMsg != "" {
 		buf.WriteString(m.theme.frameLine(m.theme.statusErr.Render(m.statusMsg), width))
 		buf.WriteString("\n")
+	}
+	if m.loading {
+		buf.WriteString(m.theme.frameLine(m.theme.faint.Render("Loading sessions…"), width))
+		buf.WriteString("\n")
+
+		return
 	}
 
 	if len(m.visible) == 0 {
@@ -1131,6 +1176,27 @@ func ChooseTargetWithTheme(
 	}
 
 	m := newPickerModelWithTheme(sessions, windowSort, actions, themeName)
+
+	return runPicker(m)
+}
+
+func ChooseTargetWithLoader(
+	windowSort []WindowSortKey,
+	actions Actions,
+	themeName string,
+) (Target, error) {
+	if tuiDisabled() {
+		return Target{}, errTUIDisabled
+	}
+
+	m := newPickerModelWithTheme([]Session{}, windowSort, actions, themeName)
+	m.loading = true
+	m.reloadPending = true
+
+	return runPicker(m)
+}
+
+func runPicker(m pickerModel) (Target, error) {
 	runner := newPickerRunner(m)
 
 	finalModel, err := runner.Run()

--- a/internal/picker/model_internal_test.go
+++ b/internal/picker/model_internal_test.go
@@ -298,6 +298,16 @@ func TestStaleReloadDoesNotOverwriteMutationResult(t *testing.T) {
 	m.reloadGeneration = 1
 	m.reloadPending = true
 	m.applyActionResult(errBoom)
+	mutationGeneration := m.reloadGeneration
+
+	next, _ := m.handleStatusTick()
+	m, _ = next.(pickerModel)
+	if m.reloadGeneration != mutationGeneration {
+		t.Fatal("status tick scheduled another reload while an older reload was in flight")
+	}
+	if !m.reloadPending {
+		t.Fatal("mutation reload cleared the in-flight reload marker")
+	}
 
 	m = feed(t, m, sessionsLoadedMsg{
 		sessions:   []Session{makeSession("deleted", false, "old")},
@@ -309,6 +319,49 @@ func TestStaleReloadDoesNotOverwriteMutationResult(t *testing.T) {
 	}
 	if m.statusMsg != errBoom.Error() {
 		t.Fatalf("stale reload changed action status: %q", m.statusMsg)
+	}
+	if m.reloadPending {
+		t.Fatal("completed stale reload did not clear the in-flight marker")
+	}
+}
+
+func TestMutationReloadEndsInitialLoading(t *testing.T) {
+	t.Parallel()
+
+	current := []Session{makeSession("created", false, "one")}
+	m := newPickerModel(nil, nil, Actions{
+		Reload: func() ([]Session, error) {
+			return current, nil
+		},
+	})
+	m.loading = true
+	m.reloadPending = true
+	m.reloadGeneration = 1
+	m.applyActionResult(nil)
+
+	if m.loading {
+		t.Fatal("mutation reload left the picker in its initial loading state")
+	}
+	if !m.reloadPending {
+		t.Fatal("mutation reload lost track of the initial load still in flight")
+	}
+	if len(m.sessions) != 1 || m.sessions[0].Record.SessionName != "created" {
+		t.Fatalf("mutation reload did not apply current sessions: %+v", m.sessions)
+	}
+
+	m = feed(t, m, sessionsLoadedMsg{
+		sessions:   []Session{},
+		generation: 1,
+	})
+	if m.loading || m.reloadPending {
+		t.Fatalf(
+			"stale initial load changed lifecycle flags: loading=%v pending=%v",
+			m.loading,
+			m.reloadPending,
+		)
+	}
+	if len(m.sessions) != 1 || m.sessions[0].Record.SessionName != "created" {
+		t.Fatalf("stale initial load overwrote mutation sessions: %+v", m.sessions)
 	}
 }
 

--- a/internal/picker/model_internal_test.go
+++ b/internal/picker/model_internal_test.go
@@ -286,6 +286,32 @@ func TestSessionsLoadedMessageRendersError(t *testing.T) {
 	}
 }
 
+func TestStaleReloadDoesNotOverwriteMutationResult(t *testing.T) {
+	t.Parallel()
+
+	current := []Session{makeSession("remaining", false, "one")}
+	m := newPickerModel([]Session{makeSession("deleted", false, "old")}, nil, Actions{
+		Reload: func() ([]Session, error) {
+			return current, nil
+		},
+	})
+	m.reloadGeneration = 1
+	m.reloadPending = true
+	m.applyActionResult(errBoom)
+
+	m = feed(t, m, sessionsLoadedMsg{
+		sessions:   []Session{makeSession("deleted", false, "old")},
+		generation: 1,
+	})
+
+	if len(m.sessions) != 1 || m.sessions[0].Record.SessionName != "remaining" {
+		t.Fatalf("stale reload overwrote mutation result: %+v", m.sessions)
+	}
+	if m.statusMsg != errBoom.Error() {
+		t.Fatalf("stale reload changed action status: %q", m.statusMsg)
+	}
+}
+
 func TestStatusTickSchedulesReloadWithoutBlocking(t *testing.T) {
 	t.Parallel()
 

--- a/internal/picker/model_internal_test.go
+++ b/internal/picker/model_internal_test.go
@@ -365,6 +365,60 @@ func TestMutationReloadEndsInitialLoading(t *testing.T) {
 	}
 }
 
+func TestMutationReloadWaitsForBackgroundReload(t *testing.T) {
+	t.Parallel()
+
+	firstStarted := make(chan struct{})
+	secondStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(releaseFirst)
+		}
+	}()
+
+	calls := 0
+	m := newPickerModel(nil, nil, Actions{
+		Reload: func() ([]Session, error) {
+			calls++
+			if calls == 1 {
+				close(firstStarted)
+				<-releaseFirst
+			} else {
+				close(secondStarted)
+			}
+
+			return nil, nil
+		},
+	})
+
+	backgroundDone := make(chan struct{})
+	go func() {
+		_ = loadSessions(m.actions.Reload, 1)()
+		close(backgroundDone)
+	}()
+	<-firstStarted
+
+	mutationDone := make(chan struct{})
+	go func() {
+		m.reload()
+		close(mutationDone)
+	}()
+
+	select {
+	case <-secondStarted:
+		t.Fatal("mutation loader started while background loader was still running")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseFirst)
+	released = true
+	<-backgroundDone
+	<-secondStarted
+	<-mutationDone
+}
+
 func TestSuccessfulRefreshPreservesActionStatus(t *testing.T) {
 	t.Parallel()
 

--- a/internal/picker/model_internal_test.go
+++ b/internal/picker/model_internal_test.go
@@ -312,6 +312,41 @@ func TestStaleReloadDoesNotOverwriteMutationResult(t *testing.T) {
 	}
 }
 
+func TestSuccessfulRefreshPreservesActionStatus(t *testing.T) {
+	t.Parallel()
+
+	m := newPickerModel(nil, nil, Actions{})
+	m.reloadGeneration = 1
+	m.setStatus("delete failed")
+	m = feed(t, m, sessionsLoadedMsg{
+		sessions:   []Session{makeSession("alpha", false, "one")},
+		generation: 1,
+	})
+
+	if m.statusMsg != "delete failed" {
+		t.Fatalf("successful refresh cleared action status: %q", m.statusMsg)
+	}
+	if len(m.sessions) != 1 || m.sessions[0].Record.SessionName != "alpha" {
+		t.Fatalf("successful refresh did not apply sessions: %+v", m.sessions)
+	}
+}
+
+func TestSuccessfulRefreshClearsLoaderStatus(t *testing.T) {
+	t.Parallel()
+
+	m := newPickerModel(nil, nil, Actions{})
+	m.reloadGeneration = 1
+	m.setLoaderStatus("load failed")
+	m = feed(t, m, sessionsLoadedMsg{
+		sessions:   []Session{makeSession("alpha", false, "one")},
+		generation: 1,
+	})
+
+	if m.statusMsg != "" || m.statusFromLoader {
+		t.Fatalf("successful refresh kept loader status: %q", m.statusMsg)
+	}
+}
+
 func TestStatusTickSchedulesReloadWithoutBlocking(t *testing.T) {
 	t.Parallel()
 

--- a/internal/picker/model_internal_test.go
+++ b/internal/picker/model_internal_test.go
@@ -239,6 +239,90 @@ func TestStatusTickResumesSpinnerOnWork(t *testing.T) {
 	}
 }
 
+func TestLoadingModelRendersBeforeSessionsArrive(t *testing.T) {
+	t.Parallel()
+
+	m := newTestModel(t, &recordingActions{})
+	m.loading = true
+
+	if view := m.View().Content; !strings.Contains(view, "Loading sessions…") {
+		t.Fatalf("loading view missing from first frame:\n%s", view)
+	}
+}
+
+func TestSessionsLoadedMessagePopulatesPicker(t *testing.T) {
+	t.Parallel()
+
+	m := newTestModel(t, &recordingActions{})
+	m.loading = true
+	m.reloadPending = true
+	m = feed(t, m, sessionsLoadedMsg{
+		sessions: []Session{makeSession("alpha", false, "one")},
+	})
+
+	if m.loading || m.reloadPending {
+		t.Fatalf("load flags were not cleared: loading=%v pending=%v", m.loading, m.reloadPending)
+	}
+	if len(m.sessions) != 1 || m.sessions[0].Record.SessionName != "alpha" {
+		t.Fatalf("loaded sessions were not applied: %+v", m.sessions)
+	}
+	if len(m.visible) == 0 {
+		t.Fatal("loaded sessions were not rendered")
+	}
+}
+
+func TestSessionsLoadedMessageRendersError(t *testing.T) {
+	t.Parallel()
+
+	m := newTestModel(t, &recordingActions{})
+	m.loading = true
+	m = feed(t, m, sessionsLoadedMsg{err: errBoom})
+
+	if m.loading {
+		t.Fatal("loading flag must clear after an error")
+	}
+	if !strings.Contains(m.View().Content, errBoom.Error()) {
+		t.Fatalf("loader error is missing from view: %s", m.View().Content)
+	}
+}
+
+func TestStatusTickSchedulesReloadWithoutBlocking(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	m := newPickerModel(nil, nil, Actions{
+		Reload: func() ([]Session, error) {
+			called = true
+
+			return nil, nil
+		},
+	})
+
+	next, cmd := m.handleStatusTick()
+	updated, _ := next.(pickerModel)
+	if called {
+		t.Fatal("status tick called the session loader synchronously")
+	}
+	if !updated.reloadPending {
+		t.Fatal("status tick did not mark the asynchronous reload as pending")
+	}
+	if cmd == nil {
+		t.Fatal("status tick did not schedule reload commands")
+	}
+}
+
+func TestEscapeCancelsWhileSessionsLoad(t *testing.T) {
+	t.Parallel()
+
+	m := newTestModel(t, &recordingActions{})
+	m.loading = true
+	m = feed(t, m, keyCode(tea.KeyEscape))
+
+	if !m.cancelled {
+		t.Fatal("escape must cancel the picker while sessions load")
+	}
+}
+
 func TestModelNavigationAndSelect(t *testing.T) {
 	t.Parallel()
 
@@ -931,11 +1015,67 @@ func TestChooseTargetNoSelection(
 	}
 }
 
+//nolint:paralleltest // stubs the package-level newPickerRunner seam
+func TestChooseTargetWithLoaderStartsRunnerBeforeLoaderCompletes(t *testing.T) {
+	orig := newPickerRunner
+	defer func() { newPickerRunner = orig }()
+
+	loaderStarted := make(chan struct{})
+	releaseLoader := make(chan struct{})
+	runnerStarted := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(releaseLoader)
+		}
+	}()
+
+	newPickerRunner = func(m pickerModel) pickerRunner {
+		return blockingLoaderRunner{model: m, started: runnerStarted}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = ChooseTargetWithLoader(nil, Actions{
+			Reload: func() ([]Session, error) {
+				close(loaderStarted)
+				<-releaseLoader
+
+				return []Session{makeSession("alpha", false, "one")}, nil
+			},
+		}, themeDark)
+		close(done)
+	}()
+
+	select {
+	case <-runnerStarted:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("picker runner did not start while session loader was blocked")
+	}
+	<-loaderStarted
+	close(releaseLoader)
+	released = true
+	<-done
+}
+
 type staticRunner struct {
 	model pickerModel
 }
 
 func (s staticRunner) Run() (tea.Model, error) { return s.model, nil }
+
+type blockingLoaderRunner struct {
+	model   pickerModel
+	started chan struct{}
+}
+
+func (r blockingLoaderRunner) Run() (tea.Model, error) {
+	close(r.started)
+	_, _ = r.model.actions.Reload()
+	r.model.cancelled = true
+
+	return r.model, nil
+}
 
 func TestModelHelpToggle(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- start Bubble Tea before loading saved sessions and integration statuses
- render a loading frame immediately and replace it when sessions arrive
- move periodic status reloads out of the Bubble Tea update loop
- coalesce refreshes while a previous reload is pending
- keep cancellation and loader errors inside the picker UI

## Performance

Measured with 30 saved sessions / 111 windows:

- before: first visible picker output took 0.7–2.6s
- after: loading frame is visible in a real tmux pane after ~50ms
- loaded session list replaces it asynchronously after ~1s

## Validation

- `make check`
- 267 unit/race tests
- Docker integration suite
- real tmux `capture-pane`: `Loading sessions` at 50ms, `30 sessions` after load

Closes #279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session data now loads asynchronously when opening the target picker.
  * A loading state is shown while session data is retrieved.
  * The picker can open and respond to user actions before loading completes.
  * Session refreshes are coordinated to avoid overlapping requests.

* **Bug Fixes**
  * Improved loading and session-error message handling.
  * Prevented outdated refresh results from overwriting newer picker data or status messages.
  * Preserved relevant action messages during refreshes.
  * Canceling the picker while sessions load now behaves correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->