### PR TITLE
Speed up TUI picker spinner rendering

### DIFF
--- a/internal/picker/model.go
+++ b/internal/picker/model.go
@@ -61,6 +61,7 @@ type pickerModel struct {
 	sessions         []Session
 	windowSort       []WindowSortKey
 	visible          []pickerRow
+	rendered         []string
 	queryInput       textinput.Model
 	viewport         viewport.Model
 	theme            pickerTheme
@@ -334,11 +335,35 @@ func (m pickerModel) handleSpinnerTick() (tea.Model, tea.Cmd) {
 	m.spinnerFrame++
 
 	if m.mode == modeBrowse && !m.palette {
-		m.applyFilter()
-		m.renderViewport()
+		m.refreshSpinnerRows()
 	}
 
 	return m, scheduleSpinner()
+}
+
+func (m *pickerModel) refreshSpinnerRows() {
+	if len(m.rendered) != len(m.visible) {
+		m.renderViewport()
+
+		return
+	}
+
+	layout := buildPickerTableLayout(m.tableContentWidth())
+	barWidth := max(0, m.contentWidth()-2)
+	changed := false
+
+	for rowIndex := range m.visible {
+		row := &m.visible[rowIndex]
+		if row.status == StatusWorking {
+			row.state = statusGlyphFrame(row.status, m.spinnerFrame)
+			m.rendered[rowIndex] = m.renderRow(rowIndex, layout, barWidth)
+			changed = true
+		}
+	}
+
+	if changed {
+		m.viewport.SetContent(strings.Join(m.rendered, "\n"))
+	}
 }
 
 func (m pickerModel) hasWorkingWindow() bool {
@@ -1054,6 +1079,7 @@ func (m pickerModel) nearestSelectable(from int) int {
 
 func (m *pickerModel) renderViewport() {
 	if len(m.visible) == 0 {
+		m.rendered = nil
 		m.viewport.SetContent("")
 
 		return
@@ -1061,25 +1087,32 @@ func (m *pickerModel) renderViewport() {
 
 	layout := buildPickerTableLayout(m.tableContentWidth())
 	barWidth := max(0, m.contentWidth()-2)
-	lines := make([]string, 0, len(m.visible))
+	m.rendered = make([]string, len(m.visible))
 
-	for rowIndex, row := range m.visible {
-		if rowIndex == m.cursor && m.rowSelectable(row) {
-			body := m.selectedMarker(row) + layout.selectedRow(row, m.theme)
-
-			if pad := barWidth - displayWidth(body); pad > 0 {
-				body += m.theme.selBar.Render(strings.Repeat(" ", pad))
-			}
-
-			lines = append(lines, m.theme.stripe.Render("▌")+m.theme.selBar.Render(" ")+body)
-
-			continue
-		}
-
-		lines = append(lines, "  "+m.markerFor(row)+layout.styledRow(row, m.theme))
+	for rowIndex := range m.visible {
+		m.rendered[rowIndex] = m.renderRow(rowIndex, layout, barWidth)
 	}
 
-	m.viewport.SetContent(strings.Join(lines, "\n"))
+	m.viewport.SetContent(strings.Join(m.rendered, "\n"))
+}
+
+func (m pickerModel) renderRow(
+	rowIndex int,
+	layout pickerTableLayout,
+	barWidth int,
+) string {
+	row := m.visible[rowIndex]
+	if rowIndex == m.cursor && m.rowSelectable(row) {
+		body := m.selectedMarker(row) + layout.selectedRow(row, m.theme)
+
+		if pad := barWidth - displayWidth(body); pad > 0 {
+			body += m.theme.selBar.Render(strings.Repeat(" ", pad))
+		}
+
+		return m.theme.stripe.Render("▌") + m.theme.selBar.Render(" ") + body
+	}
+
+	return "  " + m.markerFor(row) + layout.styledRow(row, m.theme)
 }
 
 func (m pickerModel) markGlyph(row pickerRow) (string, bool) {

--- a/internal/picker/model_internal_test.go
+++ b/internal/picker/model_internal_test.go
@@ -4,6 +4,7 @@ package picker
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -142,6 +143,66 @@ func workingSession(name string) Session {
 	sess.Statuses = map[int]WindowStatus{1: StatusWorking}
 
 	return sess
+}
+
+func largeWorkingPickerModel() pickerModel {
+	sessions := make([]Session, 100)
+	for sessionIndex := range sessions {
+		windowNames := make([]string, 10)
+		for windowIndex := range windowNames {
+			windowNames[windowIndex] = fmt.Sprintf("window-%03d-%02d", sessionIndex, windowIndex)
+		}
+
+		sessions[sessionIndex] = makeSession(
+			fmt.Sprintf("session-%03d", sessionIndex),
+			true,
+			windowNames...,
+		)
+	}
+	sessions[0].Statuses = map[int]WindowStatus{1: StatusWorking}
+
+	m := newPickerModel(sessions, DefaultSortOptions().Window, Actions{})
+	m.queryInput.SetValue("session")
+	m.applyFilter()
+	m.width = 120
+	m.height = 30
+	m.resize()
+	m.renderViewport()
+
+	return m
+}
+
+//nolint:paralleltest // AllocsPerRun cannot execute in a parallel test
+func TestSpinnerTickAllocationBudget(t *testing.T) {
+	m := largeWorkingPickerModel()
+	allocations := testing.AllocsPerRun(10, func() {
+		m = spinnerTickModel(m)
+	})
+
+	if allocations > 300 {
+		t.Fatalf("spinner tick allocated %.0f objects, want at most 300", allocations)
+	}
+}
+
+func BenchmarkSpinnerTickLargePicker(b *testing.B) {
+	m := largeWorkingPickerModel()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		m = spinnerTickModel(m)
+	}
+}
+
+func spinnerTickModel(m pickerModel) pickerModel {
+	next, _ := m.handleSpinnerTick()
+	updated, ok := next.(pickerModel)
+	if !ok {
+		panic(fmt.Sprintf("unexpected spinner model type %T", next))
+	}
+
+	return updated
 }
 
 func TestHasWorkingWindow(t *testing.T) {


### PR DESCRIPTION
## Summary

- stop re-filtering, fuzzy-ranking, copying, and sorting every picker row on each 160 ms spinner tick
- cache rendered table rows and refresh only rows whose working-status glyph changes
- add a large-picker benchmark and an allocation regression budget

## Why

A single working window enables the spinner timer. With 100 sessions and 10 windows each, every tick previously rebuilt the entire filtered tree and fully restyled all 1,000 rows even though only one glyph changed.

## Benchmark

`go test ./internal/picker -run '^$' -bench '^BenchmarkSpinnerTickLargePicker$' -benchmem -count=5`

Apple M3, Go 1.26.5:

| Metric | Before | After |
| --- | ---: | ---: |
| Time | 18.7–23.7 ms/op | 1.58–1.87 ms/op |
| Memory | 4.91 MB/op | 316 KB/op |
| Allocations | 76,823/op | 246/op |

This is roughly 10× lower latency, 94% less allocated memory, and more than 99% fewer allocations on the animated path.

## Validation

- `make test` with the repository Go bin on `PATH`: 274 tests passed under `-race`, 24 integration-only tests skipped as expected
- `make golangci-lint`: 0 issues
- allocation guard: at most 300 allocations per large-picker spinner tick
- benchmark repeated five times
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved picker responsiveness during spinner updates, especially when displaying many sessions and windows.
  * Spinner animations now refresh more efficiently without reprocessing the entire filtered list on every tick.

* **Tests**
  * Added coverage and benchmarking for spinner performance with large picker views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->