### PR TITLE
Optimize concurrent session capture and storage

### DIFF
--- a/cmd/lazy-tmux/integration_test.go
+++ b/cmd/lazy-tmux/integration_test.go
@@ -2,14 +2,57 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
 	"github.com/alchemmist/lazy-tmux/internal/testutil"
 )
+
+//nolint:paralleltest // uses a real shared tmux server via testutil.IsolatedTmux (t.Setenv)
+func TestConcurrentSaveAllPreservesEverySession(t *testing.T) {
+	testutil.IsolatedTmux(t)
+
+	dir := t.TempDir()
+	const sessionCount = 8
+	for index := range sessionCount {
+		name := fmt.Sprintf("concurrent-%d", index)
+		testutil.Tmux(t, "new-session", "-d", "-s", name)
+		testutil.Tmux(t, "new-window", "-d", "-t", "="+name+":", "-n", "extra")
+	}
+
+	type result struct {
+		code   int
+		stderr string
+	}
+	results := make(chan result, 2)
+	var group sync.WaitGroup
+	for range 2 {
+		group.Go(func() {
+			code, _, stderr := run(t, "save", "--all", "--data-dir", dir)
+			results <- result{code: code, stderr: stderr}
+		})
+	}
+	group.Wait()
+	close(results)
+	for result := range results {
+		if result.code != 0 {
+			t.Fatalf("concurrent save --all: exit %d stderr=%q", result.code, result.stderr)
+		}
+	}
+
+	for index := range sessionCount {
+		name := fmt.Sprintf("concurrent-%d", index)
+		snap := readSnapshot(t, dir, name)
+		if len(snap.Windows) != 2 {
+			t.Fatalf("%s has %d windows, want 2", name, len(snap.Windows))
+		}
+	}
+}
 
 func readSnapshot(t *testing.T, dir, name string) snapshot.SessionSnapshot {
 	t.Helper()

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -71,11 +71,19 @@ type tmuxClient interface {
 }
 
 type App struct {
-	cfg          config.Config
-	store        *store.Store
-	tmux         tmuxClient
-	integrations *integration.Registry
-	saveAllFn    func() error
+	cfg           config.Config
+	store         *store.Store
+	tmux          tmuxClient
+	integrations  *integration.Registry
+	saveAllFn     func() error
+	pickerCacheMu sync.Mutex
+	pickerCache   map[string]cachedPickerSnapshot
+}
+
+type cachedPickerSnapshot struct {
+	capturedAt time.Time
+	file       string
+	snapshot   snapshot.SessionSnapshot
 }
 
 func New(cfg config.Config) *App {
@@ -88,10 +96,12 @@ func New(cfg config.Config) *App {
 	client.SetRestoreResolver(registry)
 
 	return &App{
-		cfg:          cfg,
-		store:        store.New(cfg.DataDir),
-		tmux:         client,
-		integrations: registry,
+		cfg:           cfg,
+		store:         store.New(cfg.DataDir),
+		tmux:          client,
+		integrations:  registry,
+		pickerCacheMu: sync.Mutex{},
+		pickerCache:   make(map[string]cachedPickerSnapshot),
 	}
 }
 
@@ -123,24 +133,7 @@ func (a *App) SaveAll() (int, error) {
 		return 0, fmt.Errorf("list sessions: %w", err)
 	}
 
-	errs := make([]error, len(sessions))
-	jobs := make(chan int)
-	workers := min(saveAllWorkerLimit, len(sessions))
-
-	var group sync.WaitGroup
-	for range workers {
-		group.Go(func() {
-			for index := range jobs {
-				errs[index] = a.SaveSession(sessions[index])
-			}
-		})
-	}
-	for index := range sessions {
-		jobs <- index
-	}
-	close(jobs)
-	group.Wait()
-
+	errs := parallelMap(sessions, saveAllWorkerLimit, a.SaveSession)
 	for _, err := range errs {
 		if err != nil {
 			return 0, err

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -153,7 +153,7 @@ func (a *App) SaveSession(session string) error {
 		a.captureShellScrollback(&snap)
 	}
 
-	a.integrations.Enrich(&snap)
+	a.integrations.Scope().Enrich(&snap)
 
 	err = a.store.SaveSession(snap)
 	if err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/alchemmist/lazy-tmux/internal/config"
@@ -17,6 +18,8 @@ import (
 	"github.com/alchemmist/lazy-tmux/internal/store"
 	"github.com/alchemmist/lazy-tmux/internal/tmux"
 )
+
+const saveAllWorkerLimit = 4
 
 var (
 	errSessionNameEmpty    = errors.New("session name is empty")
@@ -120,8 +123,25 @@ func (a *App) SaveAll() (int, error) {
 		return 0, fmt.Errorf("list sessions: %w", err)
 	}
 
-	for _, name := range sessions {
-		err := a.SaveSession(name)
+	errs := make([]error, len(sessions))
+	jobs := make(chan int)
+	workers := min(saveAllWorkerLimit, len(sessions))
+
+	var group sync.WaitGroup
+	for range workers {
+		group.Go(func() {
+			for index := range jobs {
+				errs[index] = a.SaveSession(sessions[index])
+			}
+		})
+	}
+	for index := range sessions {
+		jobs <- index
+	}
+	close(jobs)
+	group.Wait()
+
+	for _, err := range errs {
 		if err != nil {
 			return 0, err
 		}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -71,19 +71,33 @@ type tmuxClient interface {
 }
 
 type App struct {
-	cfg           config.Config
-	store         *store.Store
-	tmux          tmuxClient
-	integrations  *integration.Registry
-	saveAllFn     func() error
-	pickerCacheMu sync.Mutex
-	pickerCache   map[string]cachedPickerSnapshot
+	cfg               config.Config
+	store             *store.Store
+	tmux              tmuxClient
+	integrations      *integration.Registry
+	saveAllFn         func() error
+	pickerCacheMu     sync.Mutex
+	pickerCache       map[string]cachedPickerSnapshot
+	pickerLoads       map[pickerCacheKey]*pickerSnapshotLoad
+	pickerCacheMisses int
 }
 
 type cachedPickerSnapshot struct {
 	capturedAt time.Time
 	file       string
 	snapshot   snapshot.SessionSnapshot
+}
+
+type pickerCacheKey struct {
+	sessionName string
+	file        string
+	capturedAt  time.Time
+}
+
+type pickerSnapshotLoad struct {
+	done     chan struct{}
+	snapshot snapshot.SessionSnapshot
+	err      error
 }
 
 func New(cfg config.Config) *App {
@@ -96,12 +110,14 @@ func New(cfg config.Config) *App {
 	client.SetRestoreResolver(registry)
 
 	return &App{
-		cfg:           cfg,
-		store:         store.New(cfg.DataDir),
-		tmux:          client,
-		integrations:  registry,
-		pickerCacheMu: sync.Mutex{},
-		pickerCache:   make(map[string]cachedPickerSnapshot),
+		cfg:               cfg,
+		store:             store.New(cfg.DataDir),
+		tmux:              client,
+		integrations:      registry,
+		pickerCacheMu:     sync.Mutex{},
+		pickerCache:       make(map[string]cachedPickerSnapshot),
+		pickerLoads:       make(map[pickerCacheKey]*pickerSnapshotLoad),
+		pickerCacheMisses: 0,
 	}
 }
 
@@ -133,7 +149,10 @@ func (a *App) SaveAll() (int, error) {
 		return 0, fmt.Errorf("list sessions: %w", err)
 	}
 
-	errs := parallelMap(sessions, saveAllWorkerLimit, a.SaveSession)
+	integrationScope := a.integrations.Scope()
+	errs := parallelMap(sessions, saveAllWorkerLimit, func(session string) error {
+		return a.saveSession(session, integrationScope)
+	})
 	for _, err := range errs {
 		if err != nil {
 			return 0, err
@@ -144,23 +163,7 @@ func (a *App) SaveAll() (int, error) {
 }
 
 func (a *App) SaveSession(session string) error {
-	snap, err := a.tmux.CaptureSession(session)
-	if err != nil {
-		return fmt.Errorf("capture session: %w", err)
-	}
-
-	if a.cfg.Scrollback.Enabled {
-		a.captureShellScrollback(&snap)
-	}
-
-	a.integrations.Scope().Enrich(&snap)
-
-	err = a.store.SaveSession(snap)
-	if err != nil {
-		return fmt.Errorf("save session: %w", err)
-	}
-
-	return nil
+	return a.saveSession(session, a.integrations.Scope())
 }
 
 func (a *App) SaveCurrent() error {
@@ -215,6 +218,26 @@ func (a *App) ListRecords() ([]snapshot.Record, error) {
 	}
 
 	return records, nil
+}
+
+func (a *App) saveSession(session string, integrationScope *integration.Registry) error {
+	snap, err := a.tmux.CaptureSession(session)
+	if err != nil {
+		return fmt.Errorf("capture session: %w", err)
+	}
+
+	if a.cfg.Scrollback.Enabled {
+		a.captureShellScrollback(&snap)
+	}
+
+	integrationScope.Enrich(&snap)
+
+	err = a.store.SaveSession(snap)
+	if err != nil {
+		return fmt.Errorf("save session: %w", err)
+	}
+
+	return nil
 }
 
 func (a *App) restoreSessionForTarget(ctx context.Context, target PickerTarget) error {

--- a/internal/app/app_internal_test.go
+++ b/internal/app/app_internal_test.go
@@ -690,3 +690,49 @@ func TestMergeLastAttached(t *testing.T) {
 
 	mergeLastAttached(records, nil)
 }
+
+func TestPickerSnapshotCacheReusesAndInvalidatesMetadata(t *testing.T) {
+	t.Parallel()
+
+	a, dir := newTestApp(t)
+	first := snapshot.SessionSnapshot{
+		Version:     snapshot.FormatVersion,
+		SessionName: "cached",
+		CapturedAt:  time.Unix(1, 0),
+		Windows:     []snapshot.Window{{Index: 0, Name: "first"}},
+	}
+	if err := a.store.SaveSession(first); err != nil {
+		t.Fatalf("save first: %v", err)
+	}
+	records, err := a.store.ListRecords()
+	if err != nil {
+		t.Fatalf("list first records: %v", err)
+	}
+	if _, err = a.pickerSnapshot(records[0]); err != nil {
+		t.Fatalf("prime cache: %v", err)
+	}
+	if err = os.Remove(filepath.Join(dir, "sessions", "cached.json")); err != nil {
+		t.Fatalf("remove cached fixture: %v", err)
+	}
+	if _, err = a.pickerSnapshot(records[0]); err != nil {
+		t.Fatalf("unchanged record was reloaded: %v", err)
+	}
+
+	second := first
+	second.CapturedAt = time.Unix(2, 0)
+	second.Windows = []snapshot.Window{{Index: 0, Name: "second"}}
+	if err = a.store.SaveSession(second); err != nil {
+		t.Fatalf("save second: %v", err)
+	}
+	records, err = a.store.ListRecords()
+	if err != nil {
+		t.Fatalf("list second records: %v", err)
+	}
+	loaded, err := a.pickerSnapshot(records[0])
+	if err != nil {
+		t.Fatalf("reload changed record: %v", err)
+	}
+	if loaded.Windows[0].Name != "second" {
+		t.Fatalf("stale cached snapshot: %+v", loaded.Windows)
+	}
+}

--- a/internal/app/app_internal_test.go
+++ b/internal/app/app_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -734,5 +735,45 @@ func TestPickerSnapshotCacheReusesAndInvalidatesMetadata(t *testing.T) {
 	}
 	if loaded.Windows[0].Name != "second" {
 		t.Fatalf("stale cached snapshot: %+v", loaded.Windows)
+	}
+}
+
+func TestPickerSnapshotCoalescesConcurrentCacheMisses(t *testing.T) {
+	t.Parallel()
+
+	a, _ := newTestApp(t)
+	if err := a.store.SaveSession(snapshot.SessionSnapshot{
+		Version:     snapshot.FormatVersion,
+		SessionName: "shared",
+		CapturedAt:  time.Unix(1, 0),
+		Windows:     []snapshot.Window{{Index: 0, Name: "window"}},
+	}); err != nil {
+		t.Fatalf("save snapshot: %v", err)
+	}
+	records, err := a.store.ListRecords()
+	if err != nil {
+		t.Fatalf("list records: %v", err)
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, 32)
+	var group sync.WaitGroup
+	for range 32 {
+		group.Go(func() {
+			<-start
+			_, loadErr := a.pickerSnapshot(records[0])
+			errs <- loadErr
+		})
+	}
+	close(start)
+	group.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("load snapshot: %v", err)
+		}
+	}
+	if a.pickerCacheMisses != 1 {
+		t.Fatalf("cache misses = %d, want 1", a.pickerCacheMisses)
 	}
 }

--- a/internal/app/app_picker.go
+++ b/internal/app/app_picker.go
@@ -98,24 +98,50 @@ func (a *App) pickerSessions(opts PickerSortOptions) ([]picker.Session, error) {
 func (a *App) pickerSnapshot(record snapshot.Record) (snapshot.SessionSnapshot, error) {
 	a.pickerCacheMu.Lock()
 	cached, ok := a.pickerCache[record.SessionName]
-	a.pickerCacheMu.Unlock()
 	if ok && cached.file == record.File && cached.capturedAt.Equal(record.CapturedAt) {
+		a.pickerCacheMu.Unlock()
+
 		return cached.snapshot, nil
 	}
+	key := pickerCacheKey{
+		sessionName: record.SessionName,
+		file:        record.File,
+		capturedAt:  record.CapturedAt,
+	}
+	if load, loading := a.pickerLoads[key]; loading {
+		a.pickerCacheMu.Unlock()
+		<-load.done
+
+		return load.snapshot, load.err
+	}
+	load := &pickerSnapshotLoad{
+		done:     make(chan struct{}),
+		snapshot: snapshot.SessionSnapshot{},
+		err:      nil,
+	}
+	a.pickerLoads[key] = load
+	a.pickerCacheMisses++
+	a.pickerCacheMu.Unlock()
 
 	snap, err := a.store.LoadSessionMetadata(record.SessionName)
 	if err != nil {
-		return snapshot.SessionSnapshot{}, fmt.Errorf("load picker snapshot: %w", err)
+		err = fmt.Errorf("load picker snapshot: %w", err)
 	}
 	a.pickerCacheMu.Lock()
-	a.pickerCache[record.SessionName] = cachedPickerSnapshot{
-		capturedAt: record.CapturedAt,
-		file:       record.File,
-		snapshot:   snap,
+	if err == nil {
+		a.pickerCache[record.SessionName] = cachedPickerSnapshot{
+			capturedAt: record.CapturedAt,
+			file:       record.File,
+			snapshot:   snap,
+		}
 	}
+	load.snapshot = snap
+	load.err = err
+	delete(a.pickerLoads, key)
+	close(load.done)
 	a.pickerCacheMu.Unlock()
 
-	return snap, nil
+	return snap, err
 }
 
 func windowStatuses(

--- a/internal/app/app_picker.go
+++ b/internal/app/app_picker.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/alchemmist/lazy-tmux/internal/config"
@@ -17,6 +18,8 @@ import (
 )
 
 var errNoSavedSessions = errors.New("no saved sessions found")
+
+const quickStatusWorkerLimit = 4
 
 func (a *App) pickerRecords(opts PickerSortOptions) ([]snapshot.Record, error) {
 	records, err := a.store.ListRecords()
@@ -67,7 +70,7 @@ func (a *App) pickerSessions(opts PickerSortOptions) ([]picker.Session, error) {
 	sessions := make([]picker.Session, 0, len(records))
 
 	for _, rec := range records {
-		snap, err := a.store.LoadSession(rec.SessionName)
+		snap, err := a.store.LoadSessionMetadata(rec.SessionName)
 		if err != nil {
 			log.Printf("picker: skip session %s: %v", rec.SessionName, err)
 
@@ -310,10 +313,28 @@ func (a *App) quickPickerSessions() ([]picker.QuickSession, error) {
 
 func (a *App) quickWorkingSessions(sessions []picker.QuickSession) map[string]bool {
 	working := make(map[string]bool)
+	jobs := make(chan picker.QuickSession)
+	results := make(chan string, len(sessions))
+	workers := min(quickStatusWorkerLimit, len(sessions))
+
+	var group sync.WaitGroup
+	for range workers {
+		group.Go(func() {
+			for session := range jobs {
+				if a.sessionHasWorkingCodex(session.Name, session.Restored) {
+					results <- session.Name
+				}
+			}
+		})
+	}
 	for _, session := range sessions {
-		if a.sessionHasWorkingCodex(session.Name, session.Restored) {
-			working[session.Name] = true
-		}
+		jobs <- session
+	}
+	close(jobs)
+	group.Wait()
+	close(results)
+	for name := range results {
+		working[name] = true
 	}
 
 	return working
@@ -342,7 +363,7 @@ func (a *App) sessionHasWorkingCodex(session string, restored bool) bool {
 		return false
 	}
 
-	snap, err := a.store.LoadSession(session)
+	snap, err := a.store.LoadSessionMetadata(session)
 	if err != nil {
 		return false
 	}

--- a/internal/app/app_picker.go
+++ b/internal/app/app_picker.go
@@ -67,6 +67,7 @@ func (a *App) pickerSessions(opts PickerSortOptions) ([]picker.Session, error) {
 	}
 
 	sessions := make([]picker.Session, 0, len(records))
+	statusRegistry := a.integrations.Scope()
 
 	for _, rec := range records {
 		snap, err := a.pickerSnapshot(rec)
@@ -85,7 +86,7 @@ func (a *App) pickerSessions(opts PickerSortOptions) ([]picker.Session, error) {
 		}
 
 		if restored {
-			session.Statuses = a.windowStatuses(snap.Windows)
+			session.Statuses = windowStatuses(statusRegistry, snap.Windows)
 		}
 
 		sessions = append(sessions, session)
@@ -117,12 +118,15 @@ func (a *App) pickerSnapshot(record snapshot.Record) (snapshot.SessionSnapshot, 
 	return snap, nil
 }
 
-func (a *App) windowStatuses(windows []snapshot.Window) map[int]picker.WindowStatus {
+func windowStatuses(
+	registry *integration.Registry,
+	windows []snapshot.Window,
+) map[int]picker.WindowStatus {
 	statuses := make(map[int]picker.WindowStatus)
 
 	for _, window := range windows {
 		for paneIdx := range window.Panes {
-			status, ok := a.integrations.Status(window.Panes[paneIdx])
+			status, ok := registry.Status(window.Panes[paneIdx])
 			if !ok {
 				continue
 			}
@@ -335,11 +339,12 @@ func (a *App) quickPickerSessions() ([]picker.QuickSession, error) {
 
 func (a *App) quickWorkingSessions(sessions []picker.QuickSession) map[string]bool {
 	working := make(map[string]bool)
+	registry := a.integrations.Scope()
 	statuses := parallelMap(
 		sessions,
 		quickStatusWorkerLimit,
 		func(session picker.QuickSession) bool {
-			return a.sessionHasWorkingCodex(session.Name, session.Restored)
+			return a.sessionHasWorkingCodex(registry, session.Name, session.Restored)
 		},
 	)
 	for index, isWorking := range statuses {
@@ -369,7 +374,11 @@ func sortQuickSessionRecords(records []snapshot.Record, live map[string]struct{}
 	})
 }
 
-func (a *App) sessionHasWorkingCodex(session string, restored bool) bool {
+func (a *App) sessionHasWorkingCodex(
+	registry *integration.Registry,
+	session string,
+	restored bool,
+) bool {
 	if !restored {
 		return false
 	}
@@ -381,7 +390,7 @@ func (a *App) sessionHasWorkingCodex(session string, restored bool) bool {
 
 	for windowIndex := range snap.Windows {
 		for paneIndex := range snap.Windows[windowIndex].Panes {
-			status, ok := a.integrations.StatusFor(
+			status, ok := registry.StatusFor(
 				"codex",
 				snap.Windows[windowIndex].Panes[paneIndex],
 			)

--- a/internal/app/app_picker.go
+++ b/internal/app/app_picker.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/alchemmist/lazy-tmux/internal/config"
@@ -70,7 +69,7 @@ func (a *App) pickerSessions(opts PickerSortOptions) ([]picker.Session, error) {
 	sessions := make([]picker.Session, 0, len(records))
 
 	for _, rec := range records {
-		snap, err := a.store.LoadSessionMetadata(rec.SessionName)
+		snap, err := a.pickerSnapshot(rec)
 		if err != nil {
 			log.Printf("picker: skip session %s: %v", rec.SessionName, err)
 
@@ -93,6 +92,29 @@ func (a *App) pickerSessions(opts PickerSortOptions) ([]picker.Session, error) {
 	}
 
 	return sessions, nil
+}
+
+func (a *App) pickerSnapshot(record snapshot.Record) (snapshot.SessionSnapshot, error) {
+	a.pickerCacheMu.Lock()
+	cached, ok := a.pickerCache[record.SessionName]
+	a.pickerCacheMu.Unlock()
+	if ok && cached.file == record.File && cached.capturedAt.Equal(record.CapturedAt) {
+		return cached.snapshot, nil
+	}
+
+	snap, err := a.store.LoadSessionMetadata(record.SessionName)
+	if err != nil {
+		return snapshot.SessionSnapshot{}, fmt.Errorf("load picker snapshot: %w", err)
+	}
+	a.pickerCacheMu.Lock()
+	a.pickerCache[record.SessionName] = cachedPickerSnapshot{
+		capturedAt: record.CapturedAt,
+		file:       record.File,
+		snapshot:   snap,
+	}
+	a.pickerCacheMu.Unlock()
+
+	return snap, nil
 }
 
 func (a *App) windowStatuses(windows []snapshot.Window) map[int]picker.WindowStatus {
@@ -313,28 +335,17 @@ func (a *App) quickPickerSessions() ([]picker.QuickSession, error) {
 
 func (a *App) quickWorkingSessions(sessions []picker.QuickSession) map[string]bool {
 	working := make(map[string]bool)
-	jobs := make(chan picker.QuickSession)
-	results := make(chan string, len(sessions))
-	workers := min(quickStatusWorkerLimit, len(sessions))
-
-	var group sync.WaitGroup
-	for range workers {
-		group.Go(func() {
-			for session := range jobs {
-				if a.sessionHasWorkingCodex(session.Name, session.Restored) {
-					results <- session.Name
-				}
-			}
-		})
-	}
-	for _, session := range sessions {
-		jobs <- session
-	}
-	close(jobs)
-	group.Wait()
-	close(results)
-	for name := range results {
-		working[name] = true
+	statuses := parallelMap(
+		sessions,
+		quickStatusWorkerLimit,
+		func(session picker.QuickSession) bool {
+			return a.sessionHasWorkingCodex(session.Name, session.Restored)
+		},
+	)
+	for index, isWorking := range statuses {
+		if isWorking {
+			working[sessions[index].Name] = true
+		}
 	}
 
 	return working

--- a/internal/app/parallel.go
+++ b/internal/app/parallel.go
@@ -1,0 +1,29 @@
+package app
+
+import "sync"
+
+func parallelMap[Input, Output any](
+	items []Input,
+	limit int,
+	transform func(Input) Output,
+) []Output {
+	results := make([]Output, len(items))
+	jobs := make(chan int)
+	workers := min(limit, len(items))
+
+	var group sync.WaitGroup
+	for range workers {
+		group.Go(func() {
+			for index := range jobs {
+				results[index] = transform(items[index])
+			}
+		})
+	}
+	for index := range items {
+		jobs <- index
+	}
+	close(jobs)
+	group.Wait()
+
+	return results
+}

--- a/internal/integration/claude/claude.go
+++ b/internal/integration/claude/claude.go
@@ -1,6 +1,8 @@
 package claude
 
 import (
+	"fmt"
+	"hash/fnv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,8 +25,8 @@ type Integration struct {
 }
 
 type projectCache struct {
-	dirModTime int64
-	sessionID  string
+	fingerprint uint64
+	sessionID   string
 }
 
 func New(home, statusDir string) *Integration {
@@ -79,17 +81,8 @@ func (i *Integration) latestSessionID(cwd string) (string, bool) {
 	}
 
 	dir := filepath.Join(i.home, "projects", EncodeProjectDir(cwd))
-	info, err := os.Stat(dir)
-	if err != nil {
-		return "", false
-	}
-	dirModTime := info.ModTime().UnixNano()
-
 	i.indexMu.Lock()
 	defer i.indexMu.Unlock()
-	if cached, ok := i.projectIndex[cwd]; ok && cached.dirModTime == dirModTime {
-		return cached.sessionID, cached.sessionID != ""
-	}
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -101,6 +94,7 @@ func (i *Integration) latestSessionID(cwd string) (string, bool) {
 		newestTime int64
 		found      bool
 	)
+	hash := fnv.New64a()
 
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), transcriptExt) {
@@ -111,6 +105,13 @@ func (i *Integration) latestSessionID(cwd string) (string, bool) {
 		if err != nil {
 			continue
 		}
+		_, _ = fmt.Fprintf(
+			hash,
+			"%s\x00%d\x00%d\x00",
+			entry.Name(),
+			info.Size(),
+			info.ModTime().UnixNano(),
+		)
 
 		if mod := info.ModTime().UnixNano(); !found || mod > newestTime {
 			newestTime = mod
@@ -118,8 +119,12 @@ func (i *Integration) latestSessionID(cwd string) (string, bool) {
 			found = true
 		}
 	}
+	fingerprint := hash.Sum64()
+	if cached, ok := i.projectIndex[cwd]; ok && cached.fingerprint == fingerprint {
+		return cached.sessionID, cached.sessionID != ""
+	}
 
-	i.projectIndex[cwd] = projectCache{dirModTime: dirModTime, sessionID: newestID}
+	i.projectIndex[cwd] = projectCache{fingerprint: fingerprint, sessionID: newestID}
 	i.indexBuilds++
 
 	return newestID, found

--- a/internal/integration/claude/claude.go
+++ b/internal/integration/claude/claude.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
 )
@@ -14,12 +15,26 @@ const (
 )
 
 type Integration struct {
-	home      string
-	statusDir string
+	home         string
+	statusDir    string
+	indexMu      sync.Mutex
+	projectIndex map[string]projectCache
+	indexBuilds  int
+}
+
+type projectCache struct {
+	dirModTime int64
+	sessionID  string
 }
 
 func New(home, statusDir string) *Integration {
-	return &Integration{home: home, statusDir: statusDir}
+	return &Integration{
+		home:         home,
+		statusDir:    statusDir,
+		indexMu:      sync.Mutex{},
+		projectIndex: make(map[string]projectCache),
+		indexBuilds:  0,
+	}
 }
 
 func (i *Integration) Name() string { return "claude" }
@@ -64,6 +79,17 @@ func (i *Integration) latestSessionID(cwd string) (string, bool) {
 	}
 
 	dir := filepath.Join(i.home, "projects", EncodeProjectDir(cwd))
+	info, err := os.Stat(dir)
+	if err != nil {
+		return "", false
+	}
+	dirModTime := info.ModTime().UnixNano()
+
+	i.indexMu.Lock()
+	defer i.indexMu.Unlock()
+	if cached, ok := i.projectIndex[cwd]; ok && cached.dirModTime == dirModTime {
+		return cached.sessionID, cached.sessionID != ""
+	}
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -92,6 +118,9 @@ func (i *Integration) latestSessionID(cwd string) (string, bool) {
 			found = true
 		}
 	}
+
+	i.projectIndex[cwd] = projectCache{dirModTime: dirModTime, sessionID: newestID}
+	i.indexBuilds++
 
 	return newestID, found
 }

--- a/internal/integration/claude/claude.go
+++ b/internal/integration/claude/claude.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/alchemmist/lazy-tmux/internal/integration"
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
 )
 
@@ -17,11 +18,18 @@ const (
 )
 
 type Integration struct {
-	home         string
-	statusDir    string
-	indexMu      sync.Mutex
-	projectIndex map[string]projectCache
-	indexBuilds  int
+	home        string
+	statusDir   string
+	index       *projectIndexState
+	scopeMu     sync.Mutex
+	validations map[string]*sync.Once
+}
+
+type projectIndexState struct {
+	indexMu          sync.Mutex
+	projectIndex     map[string]projectCache
+	indexBuilds      int
+	validationChecks int
 }
 
 type projectCache struct {
@@ -31,11 +39,26 @@ type projectCache struct {
 
 func New(home, statusDir string) *Integration {
 	return &Integration{
-		home:         home,
-		statusDir:    statusDir,
-		indexMu:      sync.Mutex{},
-		projectIndex: make(map[string]projectCache),
-		indexBuilds:  0,
+		home:      home,
+		statusDir: statusDir,
+		index: &projectIndexState{
+			indexMu:          sync.Mutex{},
+			projectIndex:     make(map[string]projectCache),
+			indexBuilds:      0,
+			validationChecks: 0,
+		},
+		scopeMu:     sync.Mutex{},
+		validations: nil,
+	}
+}
+
+func (i *Integration) Scope() integration.Integration {
+	return &Integration{
+		home:        i.home,
+		statusDir:   i.statusDir,
+		index:       i.index,
+		scopeMu:     sync.Mutex{},
+		validations: make(map[string]*sync.Once),
 	}
 }
 
@@ -80,13 +103,34 @@ func (i *Integration) latestSessionID(cwd string) (string, bool) {
 		return "", false
 	}
 
+	if i.validations != nil {
+		i.scopeMu.Lock()
+		once, ok := i.validations[cwd]
+		if !ok {
+			once = &sync.Once{}
+			i.validations[cwd] = once
+		}
+		i.scopeMu.Unlock()
+		once.Do(func() { i.refreshProject(cwd) })
+
+		return i.cachedProject(cwd)
+	}
+	i.refreshProject(cwd)
+
+	return i.cachedProject(cwd)
+}
+
+func (i *Integration) refreshProject(cwd string) {
 	dir := filepath.Join(i.home, "projects", EncodeProjectDir(cwd))
-	i.indexMu.Lock()
-	defer i.indexMu.Unlock()
+	i.index.indexMu.Lock()
+	defer i.index.indexMu.Unlock()
+	i.index.validationChecks++
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return "", false
+		delete(i.index.projectIndex, cwd)
+
+		return
 	}
 
 	var (
@@ -120,14 +164,20 @@ func (i *Integration) latestSessionID(cwd string) (string, bool) {
 		}
 	}
 	fingerprint := hash.Sum64()
-	if cached, ok := i.projectIndex[cwd]; ok && cached.fingerprint == fingerprint {
-		return cached.sessionID, cached.sessionID != ""
+	if cached, ok := i.index.projectIndex[cwd]; ok && cached.fingerprint == fingerprint {
+		return
 	}
 
-	i.projectIndex[cwd] = projectCache{fingerprint: fingerprint, sessionID: newestID}
-	i.indexBuilds++
+	i.index.projectIndex[cwd] = projectCache{fingerprint: fingerprint, sessionID: newestID}
+	i.index.indexBuilds++
+}
 
-	return newestID, found
+func (i *Integration) cachedProject(cwd string) (string, bool) {
+	i.index.indexMu.Lock()
+	defer i.index.indexMu.Unlock()
+	cached, ok := i.index.projectIndex[cwd]
+
+	return cached.sessionID, ok && cached.sessionID != ""
 }
 
 func EncodeProjectDir(cwd string) string {

--- a/internal/integration/claude/claude_internal_test.go
+++ b/internal/integration/claude/claude_internal_test.go
@@ -99,8 +99,42 @@ func TestCaptureConcurrentReadersBuildOneProjectIndex(t *testing.T) {
 	for result := range errs {
 		t.Fatal(result)
 	}
-	if integration.indexBuilds != 1 {
-		t.Fatalf("project directory scanned %d times, want 1", integration.indexBuilds)
+	if integration.index.indexBuilds != 1 {
+		t.Fatalf("project directory scanned %d times, want 1", integration.index.indexBuilds)
+	}
+}
+
+func TestScopedCaptureValidatesProjectOnce(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	cwd := "/workspace"
+	writeTranscript(t, home, cwd, "session", time.Now())
+	base := New(home, "")
+	pane := snapshot.Pane{CurrentPath: cwd, CurrentCmd: "claude"}
+
+	scoped, ok := base.Scope().(*Integration)
+	if !ok {
+		t.Fatal("Claude scope has unexpected type")
+	}
+	for range 20 {
+		if _, err := scoped.Capture(pane); err != nil {
+			t.Fatalf("scoped capture: %v", err)
+		}
+	}
+	if base.index.validationChecks != 1 {
+		t.Fatalf("scope validation checks = %d, want 1", base.index.validationChecks)
+	}
+
+	next, ok := base.Scope().(*Integration)
+	if !ok {
+		t.Fatal("next Claude scope has unexpected type")
+	}
+	if _, err := next.Capture(pane); err != nil {
+		t.Fatalf("next scope capture: %v", err)
+	}
+	if base.index.validationChecks != 2 {
+		t.Fatalf("next scope validation checks = %d, want 2", base.index.validationChecks)
 	}
 }
 

--- a/internal/integration/claude/claude_internal_test.go
+++ b/internal/integration/claude/claude_internal_test.go
@@ -1,8 +1,10 @@
 package claude
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -46,6 +48,34 @@ func TestCaptureReturnsNewestSession(t *testing.T) {
 
 	if meta["session_id"] != "new-session" {
 		t.Fatalf("expected newest session, got %q", meta["session_id"])
+	}
+}
+
+func TestCaptureConcurrentReadersBuildOneProjectIndex(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	cwd := "/Users/me/code/shared"
+	writeTranscript(t, home, cwd, "session", time.Now())
+	integration := New(home, "")
+
+	errs := make(chan string, 32)
+	var group sync.WaitGroup
+	for range 32 {
+		group.Go(func() {
+			meta, err := integration.Capture(snapshot.Pane{CurrentPath: cwd, CurrentCmd: "claude"})
+			if err != nil || meta["session_id"] != "session" {
+				errs <- fmt.Sprintf("meta=%v err=%v", meta, err)
+			}
+		})
+	}
+	group.Wait()
+	close(errs)
+	for result := range errs {
+		t.Fatal(result)
+	}
+	if integration.indexBuilds != 1 {
+		t.Fatalf("project directory scanned %d times, want 1", integration.indexBuilds)
 	}
 }
 

--- a/internal/integration/claude/claude_internal_test.go
+++ b/internal/integration/claude/claude_internal_test.go
@@ -51,6 +51,31 @@ func TestCaptureReturnsNewestSession(t *testing.T) {
 	}
 }
 
+func TestCaptureInvalidatesIndexWhenExistingTranscriptChanges(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	cwd := "/Users/me/code/proj"
+	base := time.Unix(100, 0)
+	writeTranscript(t, home, cwd, "old", base)
+	writeTranscript(t, home, cwd, "new", base.Add(time.Hour))
+	integration := New(home, "")
+	pane := snapshot.Pane{CurrentPath: cwd, CurrentCmd: "claude"}
+
+	meta, err := integration.Capture(pane)
+	if err != nil || meta["session_id"] != "new" {
+		t.Fatalf("initial capture: meta=%v err=%v", meta, err)
+	}
+	oldPath := filepath.Join(home, "projects", EncodeProjectDir(cwd), "old"+transcriptExt)
+	if err = os.Chtimes(oldPath, base.Add(2*time.Hour), base.Add(2*time.Hour)); err != nil {
+		t.Fatalf("update old transcript: %v", err)
+	}
+	meta, err = integration.Capture(pane)
+	if err != nil || meta["session_id"] != "old" {
+		t.Fatalf("capture after update: meta=%v err=%v", meta, err)
+	}
+}
+
 func TestCaptureConcurrentReadersBuildOneProjectIndex(t *testing.T) {
 	t.Parallel()
 

--- a/internal/integration/codex/codex.go
+++ b/internal/integration/codex/codex.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
 )
@@ -13,10 +14,18 @@ import (
 const metaSessionID = "session_id"
 
 type Integration struct {
-	home string
+	home         string
+	pathsMu      sync.RWMutex
+	sessionPaths map[string]string
 }
 
-func New(home string) *Integration { return &Integration{home: home} }
+func New(home string) *Integration {
+	return &Integration{
+		home:         home,
+		pathsMu:      sync.RWMutex{},
+		sessionPaths: make(map[string]string),
+	}
+}
 
 func (i *Integration) Name() string { return "codex" }
 

--- a/internal/integration/codex/codex.go
+++ b/internal/integration/codex/codex.go
@@ -3,6 +3,7 @@ package codex
 import (
 	"bufio"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,15 +16,21 @@ const metaSessionID = "session_id"
 
 type Integration struct {
 	home         string
-	pathsMu      sync.RWMutex
+	indexMu      sync.Mutex
+	indexed      bool
+	indexBuilds  int
 	sessionPaths map[string]string
+	latestByCWD  map[string]sessionCandidate
 }
 
 func New(home string) *Integration {
 	return &Integration{
 		home:         home,
-		pathsMu:      sync.RWMutex{},
+		indexMu:      sync.Mutex{},
+		indexed:      false,
+		indexBuilds:  0,
 		sessionPaths: make(map[string]string),
+		latestByCWD:  make(map[string]sessionCandidate),
 	}
 }
 
@@ -83,18 +90,47 @@ type sessionMetaLine struct {
 
 type sessionCandidate struct {
 	id      string
+	cwd     string
+	path    string
 	modTime int64
 }
 
 func (i *Integration) latestSessionID(cwd string) (string, bool) {
 	cwd = strings.TrimSpace(cwd)
-	root := filepath.Join(i.home, "sessions")
 	if cwd == "" || strings.TrimSpace(i.home) == "" {
 		return "", false
 	}
+	i.ensureIndex("")
 
-	var newest sessionCandidate
-	found := false
+	i.indexMu.Lock()
+	defer i.indexMu.Unlock()
+	candidate, found := i.latestByCWD[cwd]
+
+	return candidate.id, found
+}
+
+func (i *Integration) sessionPath(sessionID string) (string, bool) {
+	i.ensureIndex(sessionID)
+
+	i.indexMu.Lock()
+	defer i.indexMu.Unlock()
+	path, ok := i.sessionPaths[sessionID]
+
+	return path, ok
+}
+
+func (i *Integration) ensureIndex(requiredID string) {
+	i.indexMu.Lock()
+	defer i.indexMu.Unlock()
+	if i.indexed {
+		if requiredID == "" || i.sessionPaths[requiredID] != "" {
+			return
+		}
+	}
+
+	root := filepath.Join(i.home, "sessions")
+	paths := make(map[string]string)
+	latest := make(map[string]sessionCandidate)
 	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -103,21 +139,29 @@ func (i *Integration) latestSessionID(cwd string) (string, bool) {
 			return nil
 		}
 
-		candidate, ok := readCandidate(path, cwd)
-		if !ok || (found && candidate.modTime <= newest.modTime) {
+		candidate, ok := readCandidate(path, "")
+		if !ok {
 			return nil
 		}
-
-		newest = candidate
-		found = true
+		relative, relErr := filepath.Rel(i.home, path)
+		if relErr != nil {
+			return fmt.Errorf("make rollout path relative: %w", relErr)
+		}
+		candidate.path = filepath.ToSlash(relative)
+		paths[candidate.id] = candidate.path
+		if previous, exists := latest[candidate.cwd]; !exists ||
+			candidate.modTime > previous.modTime {
+			latest[candidate.cwd] = candidate
+		}
 
 		return nil
 	})
-	if err != nil || !found {
-		return "", false
+	if err == nil {
+		i.sessionPaths = paths
+		i.latestByCWD = latest
+		i.indexed = true
+		i.indexBuilds++
 	}
-
-	return newest.id, true
 }
 
 func readCandidate(path, cwd string) (sessionCandidate, bool) {
@@ -138,11 +182,16 @@ func readCandidate(path, cwd string) (sessionCandidate, bool) {
 		return sessionCandidate{}, false
 	}
 	if meta.Type != "session_meta" || strings.TrimSpace(meta.Payload.ID) == "" ||
-		meta.Payload.CWD != cwd {
+		(cwd != "" && meta.Payload.CWD != cwd) {
 		return sessionCandidate{}, false
 	}
 
-	return sessionCandidate{id: meta.Payload.ID, modTime: info.ModTime().UnixNano()}, true
+	return sessionCandidate{
+		id:      meta.Payload.ID,
+		cwd:     meta.Payload.CWD,
+		path:    path,
+		modTime: info.ModTime().UnixNano(),
+	}, true
 }
 
 func executableName(cmd string) string {

--- a/internal/integration/codex/codex.go
+++ b/internal/integration/codex/codex.go
@@ -9,20 +9,27 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/alchemmist/lazy-tmux/internal/integration"
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
 )
 
 const metaSessionID = "session_id"
 
 type Integration struct {
-	home         string
-	indexMu      sync.Mutex
-	indexed      bool
-	indexBuilds  int
-	sessionPaths map[string]string
-	latestByCWD  map[string]sessionCandidate
-	fileStates   map[string]fileState
-	dirStates    map[string]int64
+	home       string
+	index      *sessionIndex
+	validation *sync.Once
+}
+
+type sessionIndex struct {
+	indexMu          sync.Mutex
+	indexed          bool
+	indexBuilds      int
+	validationChecks int
+	sessionPaths     map[string]string
+	latestByCWD      map[string]sessionCandidate
+	fileStates       map[string]fileState
+	dirStates        map[string]int64
 }
 
 type fileState struct {
@@ -32,15 +39,23 @@ type fileState struct {
 
 func New(home string) *Integration {
 	return &Integration{
-		home:         home,
-		indexMu:      sync.Mutex{},
-		indexed:      false,
-		indexBuilds:  0,
-		sessionPaths: make(map[string]string),
-		latestByCWD:  make(map[string]sessionCandidate),
-		fileStates:   make(map[string]fileState),
-		dirStates:    make(map[string]int64),
+		home: home,
+		index: &sessionIndex{
+			indexMu:          sync.Mutex{},
+			indexed:          false,
+			indexBuilds:      0,
+			validationChecks: 0,
+			sessionPaths:     make(map[string]string),
+			latestByCWD:      make(map[string]sessionCandidate),
+			fileStates:       make(map[string]fileState),
+			dirStates:        make(map[string]int64),
+		},
+		validation: nil,
 	}
+}
+
+func (i *Integration) Scope() integration.Integration {
+	return &Integration{home: i.home, index: i.index, validation: &sync.Once{}}
 }
 
 func (i *Integration) Name() string { return "codex" }
@@ -111,9 +126,9 @@ func (i *Integration) latestSessionID(cwd string) (string, bool) {
 	}
 	i.ensureIndex("")
 
-	i.indexMu.Lock()
-	defer i.indexMu.Unlock()
-	candidate, found := i.latestByCWD[cwd]
+	i.index.indexMu.Lock()
+	defer i.index.indexMu.Unlock()
+	candidate, found := i.index.latestByCWD[cwd]
 
 	return candidate.id, found
 }
@@ -121,18 +136,28 @@ func (i *Integration) latestSessionID(cwd string) (string, bool) {
 func (i *Integration) sessionPath(sessionID string) (string, bool) {
 	i.ensureIndex(sessionID)
 
-	i.indexMu.Lock()
-	defer i.indexMu.Unlock()
-	path, ok := i.sessionPaths[sessionID]
+	i.index.indexMu.Lock()
+	defer i.index.indexMu.Unlock()
+	path, ok := i.index.sessionPaths[sessionID]
 
 	return path, ok
 }
 
 func (i *Integration) ensureIndex(requiredID string) {
-	i.indexMu.Lock()
-	defer i.indexMu.Unlock()
-	if i.indexed && !i.indexStale() {
-		if requiredID == "" || i.sessionPaths[requiredID] != "" {
+	if i.validation != nil {
+		i.validation.Do(func() { i.ensureIndexFresh(requiredID) })
+
+		return
+	}
+	i.ensureIndexFresh(requiredID)
+}
+
+func (i *Integration) ensureIndexFresh(requiredID string) {
+	i.index.indexMu.Lock()
+	defer i.index.indexMu.Unlock()
+	i.index.validationChecks++
+	if i.index.indexed && !i.indexStale() {
+		if requiredID == "" || i.index.sessionPaths[requiredID] != "" {
 			return
 		}
 	}
@@ -180,23 +205,23 @@ func (i *Integration) ensureIndex(requiredID string) {
 		return nil
 	})
 	if err == nil {
-		i.sessionPaths = paths
-		i.latestByCWD = latest
-		i.fileStates = files
-		i.dirStates = dirs
-		i.indexed = true
-		i.indexBuilds++
+		i.index.sessionPaths = paths
+		i.index.latestByCWD = latest
+		i.index.fileStates = files
+		i.index.dirStates = dirs
+		i.index.indexed = true
+		i.index.indexBuilds++
 	}
 }
 
 func (i *Integration) indexStale() bool {
-	for path, state := range i.fileStates {
+	for path, state := range i.index.fileStates {
 		info, err := os.Stat(path)
 		if err != nil || info.ModTime().UnixNano() != state.modTime || info.Size() != state.size {
 			return true
 		}
 	}
-	for path, modTime := range i.dirStates {
+	for path, modTime := range i.index.dirStates {
 		info, err := os.Stat(path)
 		if err != nil || info.ModTime().UnixNano() != modTime {
 			return true

--- a/internal/integration/codex/codex.go
+++ b/internal/integration/codex/codex.go
@@ -183,6 +183,10 @@ func (i *Integration) ensureIndexFresh(requiredID string) {
 			return nil
 		}
 
+		info, infoErr := entry.Info()
+		if infoErr == nil {
+			files[path] = fileState{modTime: info.ModTime().UnixNano(), size: info.Size()}
+		}
 		candidate, ok := readCandidate(path, "")
 		if !ok {
 			return nil
@@ -193,10 +197,6 @@ func (i *Integration) ensureIndexFresh(requiredID string) {
 		}
 		candidate.path = filepath.ToSlash(relative)
 		paths[candidate.id] = candidate.path
-		info, infoErr := entry.Info()
-		if infoErr == nil {
-			files[path] = fileState{modTime: info.ModTime().UnixNano(), size: info.Size()}
-		}
 		if previous, exists := latest[candidate.cwd]; !exists ||
 			candidate.modTime > previous.modTime {
 			latest[candidate.cwd] = candidate

--- a/internal/integration/codex/codex.go
+++ b/internal/integration/codex/codex.go
@@ -21,6 +21,13 @@ type Integration struct {
 	indexBuilds  int
 	sessionPaths map[string]string
 	latestByCWD  map[string]sessionCandidate
+	fileStates   map[string]fileState
+	dirStates    map[string]int64
+}
+
+type fileState struct {
+	modTime int64
+	size    int64
 }
 
 func New(home string) *Integration {
@@ -31,6 +38,8 @@ func New(home string) *Integration {
 		indexBuilds:  0,
 		sessionPaths: make(map[string]string),
 		latestByCWD:  make(map[string]sessionCandidate),
+		fileStates:   make(map[string]fileState),
+		dirStates:    make(map[string]int64),
 	}
 }
 
@@ -122,7 +131,7 @@ func (i *Integration) sessionPath(sessionID string) (string, bool) {
 func (i *Integration) ensureIndex(requiredID string) {
 	i.indexMu.Lock()
 	defer i.indexMu.Unlock()
-	if i.indexed {
+	if i.indexed && !i.indexStale() {
 		if requiredID == "" || i.sessionPaths[requiredID] != "" {
 			return
 		}
@@ -131,11 +140,21 @@ func (i *Integration) ensureIndex(requiredID string) {
 	root := filepath.Join(i.home, "sessions")
 	paths := make(map[string]string)
 	latest := make(map[string]sessionCandidate)
+	files := make(map[string]fileState)
+	dirs := make(map[string]int64)
 	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+		if entry.IsDir() {
+			info, infoErr := entry.Info()
+			if infoErr == nil {
+				dirs[path] = info.ModTime().UnixNano()
+			}
+
+			return nil
+		}
+		if !strings.HasSuffix(entry.Name(), ".jsonl") {
 			return nil
 		}
 
@@ -149,6 +168,10 @@ func (i *Integration) ensureIndex(requiredID string) {
 		}
 		candidate.path = filepath.ToSlash(relative)
 		paths[candidate.id] = candidate.path
+		info, infoErr := entry.Info()
+		if infoErr == nil {
+			files[path] = fileState{modTime: info.ModTime().UnixNano(), size: info.Size()}
+		}
 		if previous, exists := latest[candidate.cwd]; !exists ||
 			candidate.modTime > previous.modTime {
 			latest[candidate.cwd] = candidate
@@ -159,9 +182,28 @@ func (i *Integration) ensureIndex(requiredID string) {
 	if err == nil {
 		i.sessionPaths = paths
 		i.latestByCWD = latest
+		i.fileStates = files
+		i.dirStates = dirs
 		i.indexed = true
 		i.indexBuilds++
 	}
+}
+
+func (i *Integration) indexStale() bool {
+	for path, state := range i.fileStates {
+		info, err := os.Stat(path)
+		if err != nil || info.ModTime().UnixNano() != state.modTime || info.Size() != state.size {
+			return true
+		}
+	}
+	for path, modTime := range i.dirStates {
+		info, err := os.Stat(path)
+		if err != nil || info.ModTime().UnixNano() != modTime {
+			return true
+		}
+	}
+
+	return false
 }
 
 func readCandidate(path, cwd string) (sessionCandidate, bool) {

--- a/internal/integration/codex/codex_internal_test.go
+++ b/internal/integration/codex/codex_internal_test.go
@@ -61,6 +61,30 @@ func TestCaptureReturnsNewestMatchingSession(t *testing.T) {
 	}
 }
 
+func TestCaptureInvalidatesIndexWhenExistingRolloutChanges(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	cwd := "/workspace"
+	base := time.Unix(100, 0)
+	oldPath := writeRollout(t, home, "2026/01/03", "old", cwd, base)
+	writeRollout(t, home, "2026/01/03", "new", cwd, base.Add(time.Hour))
+	integration := New(home)
+	pane := snapshot.Pane{CurrentPath: cwd, CurrentCmd: "codex"}
+
+	meta, err := integration.Capture(pane)
+	if err != nil || meta["session_id"] != "new" {
+		t.Fatalf("initial capture: meta=%v err=%v", meta, err)
+	}
+	if err = os.Chtimes(oldPath, base.Add(2*time.Hour), base.Add(2*time.Hour)); err != nil {
+		t.Fatalf("update old rollout: %v", err)
+	}
+	meta, err = integration.Capture(pane)
+	if err != nil || meta["session_id"] != "old" {
+		t.Fatalf("capture after update: meta=%v err=%v", meta, err)
+	}
+}
+
 func TestCapturePrefersActivePaneSession(t *testing.T) {
 	t.Parallel()
 

--- a/internal/integration/codex/codex_internal_test.go
+++ b/internal/integration/codex/codex_internal_test.go
@@ -170,6 +170,9 @@ func TestStatusConcurrentReadersShareSessionPath(t *testing.T) {
 	for result := range errs {
 		t.Fatal(result)
 	}
+	if codexIntegration.indexBuilds != 1 {
+		t.Fatalf("rollout tree scanned %d times, want 1", codexIntegration.indexBuilds)
+	}
 }
 
 func TestStatusUsesLatestLifecycleEvent(t *testing.T) {

--- a/internal/integration/codex/codex_internal_test.go
+++ b/internal/integration/codex/codex_internal_test.go
@@ -215,8 +215,42 @@ func TestStatusConcurrentReadersShareSessionPath(t *testing.T) {
 	for result := range errs {
 		t.Fatal(result)
 	}
-	if codexIntegration.indexBuilds != 1 {
-		t.Fatalf("rollout tree scanned %d times, want 1", codexIntegration.indexBuilds)
+	if codexIntegration.index.indexBuilds != 1 {
+		t.Fatalf("rollout tree scanned %d times, want 1", codexIntegration.index.indexBuilds)
+	}
+}
+
+func TestScopedCaptureValidatesRolloutTreeOnce(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	cwd := "/workspace"
+	writeRollout(t, home, "2026/01/03", "session", cwd, time.Now())
+	base := New(home)
+	pane := snapshot.Pane{CurrentPath: cwd, CurrentCmd: "codex"}
+
+	scoped, ok := base.Scope().(*Integration)
+	if !ok {
+		t.Fatal("Codex scope has unexpected type")
+	}
+	for range 20 {
+		if _, err := scoped.Capture(pane); err != nil {
+			t.Fatalf("scoped capture: %v", err)
+		}
+	}
+	if base.index.validationChecks != 1 {
+		t.Fatalf("scope validation checks = %d, want 1", base.index.validationChecks)
+	}
+
+	next, ok := base.Scope().(*Integration)
+	if !ok {
+		t.Fatal("next Codex scope has unexpected type")
+	}
+	if _, err := next.Capture(pane); err != nil {
+		t.Fatalf("next scope capture: %v", err)
+	}
+	if base.index.validationChecks != 2 {
+		t.Fatalf("next scope validation checks = %d, want 2", base.index.validationChecks)
 	}
 }
 

--- a/internal/integration/codex/codex_internal_test.go
+++ b/internal/integration/codex/codex_internal_test.go
@@ -85,6 +85,27 @@ func TestCaptureInvalidatesIndexWhenExistingRolloutChanges(t *testing.T) {
 	}
 }
 
+func TestCaptureInvalidatesIndexWhenNewRolloutAppears(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	cwd := "/workspace"
+	base := time.Unix(100, 0)
+	writeRollout(t, home, "2026/01/03", "old", cwd, base)
+	integration := New(home)
+	pane := snapshot.Pane{CurrentPath: cwd, CurrentCmd: "codex"}
+
+	meta, err := integration.Capture(pane)
+	if err != nil || meta["session_id"] != "old" {
+		t.Fatalf("initial capture: meta=%v err=%v", meta, err)
+	}
+	writeRollout(t, home, "2026/01/03", "new", cwd, base.Add(time.Hour))
+	meta, err = integration.Capture(pane)
+	if err != nil || meta["session_id"] != "new" {
+		t.Fatalf("capture after new rollout: meta=%v err=%v", meta, err)
+	}
+}
+
 func TestCapturePrefersActivePaneSession(t *testing.T) {
 	t.Parallel()
 

--- a/internal/integration/codex/codex_internal_test.go
+++ b/internal/integration/codex/codex_internal_test.go
@@ -106,6 +106,41 @@ func TestCaptureInvalidatesIndexWhenNewRolloutAppears(t *testing.T) {
 	}
 }
 
+func TestCaptureInvalidatesIndexWhenPartialRolloutBecomesReadable(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	cwd := "/workspace"
+	base := time.Unix(100, 0)
+	writeRollout(t, home, "2026/01/03", "old", cwd, base)
+	partialPath := filepath.Join(home, "sessions", "2026/01/03", "rollout-new.jsonl")
+	if err := os.WriteFile(partialPath, []byte("{"), 0o644); err != nil {
+		t.Fatalf("write partial rollout: %v", err)
+	}
+	if err := os.Chtimes(partialPath, base.Add(time.Hour), base.Add(time.Hour)); err != nil {
+		t.Fatalf("set partial rollout time: %v", err)
+	}
+	integration := New(home)
+	pane := snapshot.Pane{CurrentPath: cwd, CurrentCmd: "codex"}
+
+	meta, err := integration.Capture(pane)
+	if err != nil || meta["session_id"] != "old" {
+		t.Fatalf("initial capture: meta=%v err=%v", meta, err)
+	}
+	content := `{"type":"session_meta","payload":{"id":"new","cwd":"/workspace"}}` + "\n"
+	if err = os.WriteFile(partialPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("complete rollout: %v", err)
+	}
+	if err = os.Chtimes(partialPath, base.Add(2*time.Hour), base.Add(2*time.Hour)); err != nil {
+		t.Fatalf("update rollout time: %v", err)
+	}
+
+	meta, err = integration.Capture(pane)
+	if err != nil || meta["session_id"] != "new" {
+		t.Fatalf("capture after completing rollout: meta=%v err=%v", meta, err)
+	}
+}
+
 func TestCapturePrefersActivePaneSession(t *testing.T) {
 	t.Parallel()
 

--- a/internal/integration/codex/codex_internal_test.go
+++ b/internal/integration/codex/codex_internal_test.go
@@ -1,9 +1,11 @@
 package codex
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -133,6 +135,40 @@ func TestStatusFromRolloutLifecycle(t *testing.T) {
 				t.Fatalf("Status() = %v, %v; want %v", got, ok, tc.want)
 			}
 		})
+	}
+}
+
+func TestStatusConcurrentReadersShareSessionPath(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	path := writeRollout(t, home, "2026/01/03", "shared", "/workspace", time.Now())
+	appendRolloutLine(t, path, `{"type":"event_msg","payload":{"type":"task_started"}}`)
+	codexIntegration := New(home)
+	pane := snapshot.Pane{
+		Index:       0,
+		CurrentPath: "/workspace",
+		CurrentCmd:  "codex",
+		RestoreCmd:  "",
+		Scrollback:  nil,
+		IsActive:    true,
+		Meta:        map[string]string{snapshot.CodexSessionIDMetaKey: "shared"},
+	}
+
+	errs := make(chan string, 32)
+	var group sync.WaitGroup
+	for range 32 {
+		group.Go(func() {
+			status, ok := codexIntegration.Status(pane)
+			if !ok || status != integration.StatusWorking {
+				errs <- fmt.Sprintf("status=%v ok=%v", status, ok)
+			}
+		})
+	}
+	group.Wait()
+	close(errs)
+	for result := range errs {
+		t.Fatal(result)
 	}
 }
 

--- a/internal/integration/codex/status.go
+++ b/internal/integration/codex/status.go
@@ -56,6 +56,9 @@ func (i *Integration) sessionFile(pane snapshot.Pane) (*os.Root, string, bool) {
 	if err != nil {
 		return nil, "", false
 	}
+	if path, ok := i.cachedSessionPath(sessionID); ok {
+		return root, path, true
+	}
 
 	pattern := filepath.ToSlash(filepath.Join("sessions", "*", "*", "*", "*"+sessionID+".jsonl"))
 	matches, err := fs.Glob(root.FS(), pattern)
@@ -65,7 +68,26 @@ func (i *Integration) sessionFile(pane snapshot.Pane) (*os.Root, string, bool) {
 		return nil, "", false
 	}
 
-	return root, matches[len(matches)-1], true
+	path := matches[len(matches)-1]
+	i.cacheSessionPath(sessionID, path)
+
+	return root, path, true
+}
+
+func (i *Integration) cachedSessionPath(sessionID string) (string, bool) {
+	i.pathsMu.RLock()
+	defer i.pathsMu.RUnlock()
+
+	path, ok := i.sessionPaths[sessionID]
+
+	return path, ok
+}
+
+func (i *Integration) cacheSessionPath(sessionID, path string) {
+	i.pathsMu.Lock()
+	defer i.pathsMu.Unlock()
+
+	i.sessionPaths[sessionID] = path
 }
 
 func latestRolloutStatus(file *os.File, size int64) (integration.Status, bool) {

--- a/internal/integration/codex/status.go
+++ b/internal/integration/codex/status.go
@@ -3,9 +3,7 @@ package codex
 import (
 	"bytes"
 	"encoding/json"
-	"io/fs"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/alchemmist/lazy-tmux/internal/integration"
@@ -56,38 +54,14 @@ func (i *Integration) sessionFile(pane snapshot.Pane) (*os.Root, string, bool) {
 	if err != nil {
 		return nil, "", false
 	}
-	if path, ok := i.cachedSessionPath(sessionID); ok {
-		return root, path, true
-	}
-
-	pattern := filepath.ToSlash(filepath.Join("sessions", "*", "*", "*", "*"+sessionID+".jsonl"))
-	matches, err := fs.Glob(root.FS(), pattern)
-	if err != nil || len(matches) == 0 {
+	path, ok := i.sessionPath(sessionID)
+	if !ok {
 		_ = root.Close()
 
 		return nil, "", false
 	}
 
-	path := matches[len(matches)-1]
-	i.cacheSessionPath(sessionID, path)
-
 	return root, path, true
-}
-
-func (i *Integration) cachedSessionPath(sessionID string) (string, bool) {
-	i.pathsMu.RLock()
-	defer i.pathsMu.RUnlock()
-
-	path, ok := i.sessionPaths[sessionID]
-
-	return path, ok
-}
-
-func (i *Integration) cacheSessionPath(sessionID, path string) {
-	i.pathsMu.Lock()
-	defer i.pathsMu.Unlock()
-
-	i.sessionPaths[sessionID] = path
 }
 
 func latestRolloutStatus(file *os.File, size int64) (integration.Status, bool) {

--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -13,6 +13,10 @@ type StatusReporter interface {
 	Status(pane snapshot.Pane) (Status, bool)
 }
 
+type Scoper interface {
+	Scope() Integration
+}
+
 type Status int
 
 const (

--- a/internal/integration/registry.go
+++ b/internal/integration/registry.go
@@ -14,6 +14,23 @@ func NewRegistry(items ...Integration) *Registry {
 	return &Registry{items: items}
 }
 
+func (r *Registry) Scope() *Registry {
+	if r == nil {
+		return NewRegistry()
+	}
+
+	items := make([]Integration, 0, len(r.items))
+	for _, item := range r.items {
+		if scoper, ok := item.(Scoper); ok {
+			items = append(items, scoper.Scope())
+		} else {
+			items = append(items, item)
+		}
+	}
+
+	return NewRegistry(items...)
+}
+
 func (r *Registry) Enrich(snap *snapshot.SessionSnapshot) {
 	if r == nil || snap == nil || len(r.items) == 0 {
 		return

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
@@ -33,12 +34,19 @@ const (
 )
 
 type Store struct {
-	baseDir string
-	mu      sync.Mutex
+	baseDir     string
+	indexMu     sync.Mutex
+	sessionsMu  sync.Mutex
+	sessionLock map[string]*sync.Mutex
 }
 
 func New(baseDir string) *Store {
-	return &Store{baseDir: baseDir}
+	return &Store{
+		baseDir:     baseDir,
+		indexMu:     sync.Mutex{},
+		sessionsMu:  sync.Mutex{},
+		sessionLock: make(map[string]*sync.Mutex),
+	}
 }
 
 func DefaultDataDir() string {
@@ -63,8 +71,8 @@ func (s *Store) SaveSession(sessionSnapshot snapshot.SessionSnapshot) error {
 		sessionSnapshot.CapturedAt = time.Now().UTC()
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	unlock := s.lockSession(sessionSnapshot.SessionName)
+	defer unlock()
 
 	err := s.ensureLayout()
 	if err != nil {
@@ -99,7 +107,7 @@ func (s *Store) SaveSession(sessionSnapshot snapshot.SessionSnapshot) error {
 		return fmt.Errorf("rename tmp file: %w", err)
 	}
 
-	return s.updateIndexUnlocked(sessionSnapshot, path)
+	return s.updateIndex(sessionSnapshot, path)
 }
 
 func (s *Store) DeleteSession(name string) error {
@@ -108,8 +116,8 @@ func (s *Store) DeleteSession(name string) error {
 		return errEmptySessionName
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	unlock := s.lockSession(name)
+	defer unlock()
 
 	path := s.sessionPath(name)
 
@@ -136,44 +144,28 @@ func (s *Store) DeleteSession(name string) error {
 		return fmt.Errorf("remove scrollback dir: %w", err)
 	}
 
-	idx, err := s.loadIndexUnlocked()
-	if err != nil {
-		return err
-	}
+	return s.withIndexLock(func() error {
+		idx, err := s.loadIndexUnlocked()
+		if err != nil {
+			return err
+		}
 
-	if idx.Sessions != nil {
-		delete(idx.Sessions, name)
-	}
+		if idx.Sessions != nil {
+			delete(idx.Sessions, name)
+		}
 
-	idx.Updated = time.Now().UTC()
+		idx.Updated = time.Now().UTC()
 
-	return writeJSONAtomic(s.indexPath(), idx)
+		return writeJSONAtomic(s.indexPath(), idx)
+	})
 }
 
 func (s *Store) LoadSession(name string) (snapshot.SessionSnapshot, error) {
-	var out snapshot.SessionSnapshot
+	return s.loadSession(name, true)
+}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	path := s.sessionPath(name)
-
-	b, err := os.ReadFile(path) // #nosec G304 -- sessionPath sanitizes the name under the data dir
-	if err != nil {
-		return out, fmt.Errorf("read session file: %w", err)
-	}
-
-	err = json.Unmarshal(b, &out)
-	if err != nil {
-		return out, fmt.Errorf("unmarshal session: %w", err)
-	}
-
-	err = s.hydrateScrollback(&out)
-	if err != nil {
-		return out, err
-	}
-
-	return out, nil
+func (s *Store) LoadSessionMetadata(name string) (snapshot.SessionSnapshot, error) {
+	return s.loadSession(name, false)
 }
 
 func (s *Store) SessionPath(name string) (string, error) {
@@ -191,8 +183,8 @@ func (s *Store) SessionExists(name string) (bool, error) {
 		return false, errEmptySessionName
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	unlock := s.lockSession(name)
+	defer unlock()
 
 	path := s.sessionPath(name)
 
@@ -209,9 +201,6 @@ func (s *Store) SessionExists(name string) (bool, error) {
 }
 
 func (s *Store) ListRecords() ([]snapshot.Record, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	idx, err := s.loadIndexUnlocked()
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -282,9 +271,6 @@ func (s *Store) IndexEntryExists(name string) (bool, error) {
 		return false, errEmptySessionName
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	idx, err := s.loadIndexUnlocked()
 	if err != nil {
 		return false, err
@@ -305,48 +291,120 @@ func (s *Store) MarkSessionAccessed(name string, accessTime time.Time) error {
 		accessTime = time.Now().UTC()
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	return s.withIndexLock(func() error {
+		idx, err := s.loadIndexUnlocked()
+		if err != nil {
+			return err
+		}
 
-	idx, err := s.loadIndexUnlocked()
-	if err != nil {
-		return err
-	}
+		rec, ok := idx.Sessions[name]
+		if !ok {
+			return os.ErrNotExist
+		}
 
-	rec, ok := idx.Sessions[name]
-	if !ok {
-		return os.ErrNotExist
-	}
+		rec.LastAccessed = accessTime.UTC()
+		idx.Sessions[name] = rec
+		idx.Updated = time.Now().UTC()
 
-	rec.LastAccessed = accessTime.UTC()
-	idx.Sessions[name] = rec
-	idx.Updated = time.Now().UTC()
-
-	return writeJSONAtomic(s.indexPath(), idx)
+		return writeJSONAtomic(s.indexPath(), idx)
+	})
 }
 
-func (s *Store) updateIndexUnlocked(sessionSnapshot snapshot.SessionSnapshot, path string) error {
-	idx, err := s.loadIndexUnlocked()
+func (s *Store) lockSession(name string) func() {
+	s.sessionsMu.Lock()
+	lock, ok := s.sessionLock[name]
+	if !ok {
+		lock = &sync.Mutex{}
+		s.sessionLock[name] = lock
+	}
+	s.sessionsMu.Unlock()
+
+	lock.Lock()
+
+	return lock.Unlock
+}
+
+func (s *Store) withIndexLock(run func() error) error {
+	s.indexMu.Lock()
+	defer s.indexMu.Unlock()
+
+	err := os.MkdirAll(s.baseDir, defaultDirPerm)
 	if err != nil {
-		return err
+		return fmt.Errorf("create data dir: %w", err)
 	}
 
-	panes := 0
-	for _, w := range sessionSnapshot.Windows {
-		panes += len(w.Panes)
+	lockPath := filepath.Join(s.baseDir, ".index.lock")
+	file, err := os.OpenFile( // #nosec G304 -- fixed lock name under the configured data directory
+		lockPath,
+		os.O_CREATE|os.O_RDWR,
+		0o600,
+	)
+	if err != nil {
+		return fmt.Errorf("open index lock: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	err = syscall.Flock(int(file.Fd()), syscall.LOCK_EX)
+	if err != nil {
+		return fmt.Errorf("lock index: %w", err)
+	}
+	defer func() { _ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN) }()
+
+	return run()
+}
+
+func (s *Store) loadSession(name string, hydrate bool) (snapshot.SessionSnapshot, error) {
+	var out snapshot.SessionSnapshot
+
+	unlock := s.lockSession(name)
+	defer unlock()
+
+	path := s.sessionPath(name)
+
+	b, err := os.ReadFile(path) // #nosec G304 -- sessionPath sanitizes the name under the data dir
+	if err != nil {
+		return out, fmt.Errorf("read session file: %w", err)
 	}
 
-	idx.Sessions[sessionSnapshot.SessionName] = snapshot.Record{
-		SessionName:  sessionSnapshot.SessionName,
-		File:         path,
-		CapturedAt:   sessionSnapshot.CapturedAt.UTC(),
-		LastAccessed: idx.Sessions[sessionSnapshot.SessionName].LastAccessed,
-		Windows:      len(sessionSnapshot.Windows),
-		Panes:        panes,
+	err = json.Unmarshal(b, &out)
+	if err != nil {
+		return out, fmt.Errorf("unmarshal session: %w", err)
 	}
-	idx.Updated = time.Now().UTC()
 
-	return writeJSONAtomic(s.indexPath(), idx)
+	if hydrate {
+		err = s.hydrateScrollback(&out)
+		if err != nil {
+			return out, err
+		}
+	}
+
+	return out, nil
+}
+
+func (s *Store) updateIndex(sessionSnapshot snapshot.SessionSnapshot, path string) error {
+	return s.withIndexLock(func() error {
+		idx, err := s.loadIndexUnlocked()
+		if err != nil {
+			return err
+		}
+
+		panes := 0
+		for _, w := range sessionSnapshot.Windows {
+			panes += len(w.Panes)
+		}
+
+		idx.Sessions[sessionSnapshot.SessionName] = snapshot.Record{
+			SessionName:  sessionSnapshot.SessionName,
+			File:         path,
+			CapturedAt:   sessionSnapshot.CapturedAt.UTC(),
+			LastAccessed: idx.Sessions[sessionSnapshot.SessionName].LastAccessed,
+			Windows:      len(sessionSnapshot.Windows),
+			Panes:        panes,
+		}
+		idx.Updated = time.Now().UTC()
+
+		return writeJSONAtomic(s.indexPath(), idx)
+	})
 }
 
 func (s *Store) ensureLayout() error {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -71,10 +71,13 @@ func (s *Store) SaveSession(sessionSnapshot snapshot.SessionSnapshot) error {
 		sessionSnapshot.CapturedAt = time.Now().UTC()
 	}
 
-	unlock := s.lockSession(sessionSnapshot.SessionName)
+	unlock, err := s.lockSessionMutation(sessionSnapshot.SessionName)
+	if err != nil {
+		return err
+	}
 	defer unlock()
 
-	err := s.ensureLayout()
+	err = s.ensureLayout()
 	if err != nil {
 		return err
 	}
@@ -116,12 +119,15 @@ func (s *Store) DeleteSession(name string) error {
 		return errEmptySessionName
 	}
 
-	unlock := s.lockSession(name)
+	unlock, err := s.lockSessionMutation(name)
+	if err != nil {
+		return err
+	}
 	defer unlock()
 
 	path := s.sessionPath(name)
 
-	err := os.Remove(path)
+	err = os.Remove(path)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("remove session file: %w", err)
 	}
@@ -324,6 +330,48 @@ func (s *Store) lockSession(name string) func() {
 	return lock.Unlock
 }
 
+func (s *Store) lockSessionMutation(name string) (func(), error) {
+	unlockLocal := s.lockSession(name)
+
+	safeName, err := safeScrollbackSessionName(name)
+	if err != nil {
+		unlockLocal()
+
+		return nil, err
+	}
+	lockDir := filepath.Join(s.baseDir, ".session-locks")
+	err = os.MkdirAll(lockDir, 0o700)
+	if err != nil {
+		unlockLocal()
+
+		return nil, fmt.Errorf("create session lock dir: %w", err)
+	}
+	lockPath := filepath.Join(lockDir, safeName+".lock")
+	file, err := os.OpenFile( // #nosec G304 -- sanitized lock name under configured data directory
+		lockPath,
+		os.O_CREATE|os.O_RDWR,
+		0o600,
+	)
+	if err != nil {
+		unlockLocal()
+
+		return nil, fmt.Errorf("open session lock: %w", err)
+	}
+	err = syscall.Flock(int(file.Fd()), syscall.LOCK_EX)
+	if err != nil {
+		_ = file.Close()
+		unlockLocal()
+
+		return nil, fmt.Errorf("lock session: %w", err)
+	}
+
+	return func() {
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		_ = file.Close()
+		unlockLocal()
+	}, nil
+}
+
 func (s *Store) withIndexLock(run func() error) error {
 	s.indexMu.Lock()
 	defer s.indexMu.Unlock()
@@ -356,7 +404,10 @@ func (s *Store) withIndexLock(run func() error) error {
 func (s *Store) loadSession(name string, hydrate bool) (snapshot.SessionSnapshot, error) {
 	var out snapshot.SessionSnapshot
 
-	unlock := s.lockSession(name)
+	unlock, err := s.lockSessionMutation(name)
+	if err != nil {
+		return out, err
+	}
 	defer unlock()
 
 	path := s.sessionPath(name)

--- a/internal/store/store_internal_test.go
+++ b/internal/store/store_internal_test.go
@@ -1,13 +1,50 @@
 package store
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/alchemmist/lazy-tmux/internal/snapshot"
 )
+
+func TestConcurrentStoreInstancesPreserveEveryIndexEntry(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	stores := []*Store{New(dir), New(dir)}
+	const sessionCount = 40
+
+	errs := make(chan error, sessionCount)
+	var group sync.WaitGroup
+	for index := range sessionCount {
+		group.Go(func() {
+			name := fmt.Sprintf("session-%02d", index)
+			errs <- stores[index%len(stores)].SaveSession(snapshot.SessionSnapshot{
+				Version:     snapshot.FormatVersion,
+				SessionName: name,
+			})
+		})
+	}
+	group.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent save: %v", err)
+		}
+	}
+
+	records, err := New(dir).ListRecords()
+	if err != nil {
+		t.Fatalf("list records: %v", err)
+	}
+	if len(records) != sessionCount {
+		t.Fatalf("index has %d sessions, want %d", len(records), sessionCount)
+	}
+}
 
 func sampleSnapshot(name string, captured time.Time) snapshot.SessionSnapshot {
 	return snapshot.SessionSnapshot{
@@ -299,6 +336,16 @@ func TestScrollbackPersistAndHydrate(t *testing.T) {
 
 	if sb.Lines != 3 {
 		t.Fatalf("expected 3 scrollback lines, got %d", sb.Lines)
+	}
+
+	metadata, err := s.LoadSessionMetadata("logs")
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	metadataScrollback := metadata.Windows[0].Panes[0].Scrollback
+	if metadataScrollback == nil || metadataScrollback.Ref == "" ||
+		metadataScrollback.Content != "" {
+		t.Fatalf("metadata load hydrated scrollback content: %+v", metadataScrollback)
 	}
 }
 

--- a/internal/store/store_internal_test.go
+++ b/internal/store/store_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -43,6 +44,79 @@ func TestConcurrentStoreInstancesPreserveEveryIndexEntry(t *testing.T) {
 	}
 	if len(records) != sessionCount {
 		t.Fatalf("index has %d sessions, want %d", len(records), sessionCount)
+	}
+}
+
+func TestConcurrentStoreInstancesKeepOneSessionConsistent(t *testing.T) {
+	t.Parallel()
+
+	for iteration := range 20 {
+		dir := t.TempDir()
+		stores := []*Store{New(dir), New(dir)}
+		snapshots := []snapshot.SessionSnapshot{
+			concurrentSnapshot("shared", "alpha", iteration),
+			concurrentSnapshot("shared", "bravo", iteration),
+		}
+
+		errs := make(chan error, len(stores))
+		var group sync.WaitGroup
+		for index := range stores {
+			group.Go(func() { errs <- stores[index].SaveSession(snapshots[index]) })
+		}
+		group.Wait()
+		close(errs)
+		for err := range errs {
+			if err != nil {
+				t.Fatalf("iteration %d concurrent same-session save: %v", iteration, err)
+			}
+		}
+
+		loaded, err := New(dir).LoadSession("shared")
+		if err != nil {
+			t.Fatalf("iteration %d load: %v", iteration, err)
+		}
+		marker := loaded.Windows[0].Name
+		for _, pane := range loaded.Windows[0].Panes {
+			if pane.Scrollback == nil || !strings.Contains(pane.Scrollback.Content, marker) {
+				t.Fatalf("iteration %d mixed snapshot %s: %+v", iteration, marker, loaded)
+			}
+		}
+	}
+}
+
+func concurrentSnapshot(name, marker string, iteration int) snapshot.SessionSnapshot {
+	panes := make([]snapshot.Pane, 12)
+	for index := range panes {
+		panes[index] = snapshot.Pane{
+			Index:       index,
+			CurrentPath: "/tmp",
+			CurrentCmd:  "zsh",
+			RestoreCmd:  "",
+			Scrollback: &snapshot.ScrollbackRef{
+				Ref:     "",
+				Lines:   0,
+				Bytes:   0,
+				Content: strings.Repeat(marker, 1024),
+			},
+			IsActive: index == 0,
+			Meta:     nil,
+		}
+	}
+
+	return snapshot.SessionSnapshot{
+		Version:     snapshot.FormatVersion,
+		SessionName: name,
+		CapturedAt:  time.Unix(int64(iteration+1), 0),
+		CurrentWin:  0,
+		CurrentPane: 0,
+		Windows: []snapshot.Window{{
+			Index:      0,
+			Name:       marker,
+			Layout:     "",
+			IsActive:   true,
+			ActivePane: 0,
+			Panes:      panes,
+		}},
 	}
 }
 

--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -406,42 +406,34 @@ func (client *Client) CaptureSession(name string) (snapshot.SessionSnapshot, err
 		return snapshot.SessionSnapshot{}, ErrSessionNotFound
 	}
 
-	wOut, err := client.Output(
-		"list-windows",
+	paneOutput, err := client.Output(
+		"list-panes",
+		"-s",
 		"-t",
 		sessionTarget(name),
 		"-F",
-		"#{window_index}"+fieldSep+"#{window_layout}"+fieldSep+"#{window_active}"+fieldSep+"#{window_name}",
+		"#{window_index}"+fieldSep+
+			"#{window_layout}"+fieldSep+
+			"#{window_active}"+fieldSep+
+			"#{window_name}"+fieldSep+
+			"#{pane_index}"+fieldSep+
+			"#{pane_active}"+fieldSep+
+			"#{pane_pid}"+fieldSep+
+			"#{pane_tty}"+fieldSep+
+			"#{pane_current_command}"+fieldSep+
+			"#{pane_current_path}"+fieldSep+
+			"#{@codex_thread_id}",
 	)
 	if err != nil {
 		return snapshot.SessionSnapshot{}, err
 	}
 
-	windows := make([]snapshot.Window, 0)
-
-	for _, line := range splitLines(wOut) {
-		parts := splitFieldsN(line, windowLineFields)
-		if len(parts) != windowLineFields {
-			continue
-		}
-
-		idx, _ := strconv.Atoi(parts[0])
-		window := snapshot.Window{
-			Index:      idx,
-			Layout:     parts[1],
-			IsActive:   parts[2] == "1",
-			Name:       parts[3],
-			ActivePane: 0,
-			Panes:      nil,
-		}
-
-		err = client.capturePanes(name, &window)
-		if err != nil {
-			return snapshot.SessionSnapshot{}, err
-		}
-
-		windows = append(windows, window)
+	processes, err := loadProcessSnapshot()
+	if err != nil {
+		return snapshot.SessionSnapshot{}, err
 	}
+
+	windows := parseCapturedPanes(paneOutput, processes)
 
 	sort.Slice(windows, func(i, j int) bool { return windows[i].Index < windows[j].Index })
 
@@ -455,6 +447,80 @@ func (client *Client) CaptureSession(name string) (snapshot.SessionSnapshot, err
 		CurrentPane: currentPane,
 		Windows:     windows,
 	}, nil
+}
+
+func parseCapturedPanes(output string, processes processSnapshot) []snapshot.Window {
+	byIndex := make(map[int]*snapshot.Window)
+	for _, line := range splitLines(output) {
+		parts := splitFieldsN(line, capturePaneLineFields)
+		if len(parts) != capturePaneLineFields {
+			continue
+		}
+
+		windowIndex, _ := strconv.Atoi(parts[0])
+		window, ok := byIndex[windowIndex]
+		if !ok {
+			window = &snapshot.Window{
+				Index:      windowIndex,
+				Name:       parts[3],
+				Layout:     parts[1],
+				IsActive:   parts[2] == "1",
+				ActivePane: 0,
+				Panes:      nil,
+			}
+			byIndex[windowIndex] = window
+		}
+
+		paneIndex, _ := strconv.Atoi(parts[4])
+		panePID, _ := strconv.Atoi(strings.TrimSpace(parts[6]))
+		restoreCmd := processes.foregroundCommand(panePID)
+		pane := snapshot.Pane{
+			Index:       paneIndex,
+			CurrentPath: parts[9],
+			CurrentCmd:  parts[8],
+			RestoreCmd:  strings.TrimSpace(restoreCmd),
+			Scrollback:  nil,
+			IsActive:    parts[5] == "1",
+			Meta:        codexSessionMeta(parts[10]),
+		}
+		if pane.IsActive {
+			window.ActivePane = pane.Index
+		}
+		window.Panes = append(window.Panes, pane)
+	}
+
+	windows := make([]snapshot.Window, 0, len(byIndex))
+	for _, window := range byIndex {
+		sort.Slice(window.Panes, func(i, j int) bool {
+			return window.Panes[i].Index < window.Panes[j].Index
+		})
+		windows = append(windows, *window)
+	}
+	sort.Slice(windows, func(i, j int) bool { return windows[i].Index < windows[j].Index })
+
+	return windows
+}
+
+func loadProcessSnapshot() (processSnapshot, error) {
+	cmd := exec.CommandContext( // #nosec G204 -- fixed ps binary and format flags
+		context.Background(),
+		"ps",
+		"-ax",
+		"-o",
+		"pid=",
+		"-o",
+		"ppid=",
+		"-o",
+		"stat=",
+		"-o",
+		"command=",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return processSnapshot{}, fmt.Errorf("get process list: %w", err)
+	}
+
+	return newProcessSnapshot(splitLines(string(out))), nil
 }
 
 func currentWindowPane(windows []snapshot.Window) (int, int) {
@@ -688,8 +754,7 @@ func (client *Client) selectRestoredFocus(
 		"select-window",
 		"-t",
 		sessionWindowTarget(sessionSnapshot.SessionName, win),
-	)
-	_, _ = client.Output(
+		";",
 		"select-pane",
 		"-t",
 		sessionPaneTarget(sessionSnapshot.SessionName, win, pane),
@@ -722,54 +787,6 @@ func (client *Client) restoreFirstWindow(sessionName string, first snapshot.Wind
 	}
 
 	return client.populateWindow(sessionName, first, first.Index)
-}
-
-func (client *Client) capturePanes(name string, window *snapshot.Window) error {
-	pOut, err := client.Output("list-panes", "-t", sessionWindowTarget(name, window.Index), "-F",
-		"#{pane_index}"+fieldSep+
-			"#{pane_active}"+fieldSep+
-			"#{pane_pid}"+fieldSep+
-			"#{pane_tty}"+fieldSep+
-			"#{pane_current_command}"+fieldSep+
-			"#{pane_current_path}"+fieldSep+
-			"#{@codex_thread_id}",
-	)
-	if err != nil {
-		return err
-	}
-
-	for _, pLine := range splitLines(pOut) {
-		parts := splitFieldsN(pLine, paneLineFields)
-		if len(parts) != paneLineFields {
-			continue
-		}
-
-		pIdx, _ := strconv.Atoi(parts[0])
-		panePID, _ := strconv.Atoi(strings.TrimSpace(parts[2]))
-		restoreCmd, _ := client.foregroundCommand(parts[3], panePID)
-
-		pane := snapshot.Pane{
-			Index:       pIdx,
-			IsActive:    parts[1] == "1",
-			CurrentCmd:  parts[4],
-			CurrentPath: parts[5],
-			RestoreCmd:  strings.TrimSpace(restoreCmd),
-			Scrollback:  nil,
-			Meta:        codexSessionMeta(parts[6]),
-		}
-		if pane.IsActive {
-			window.ActivePane = pane.Index
-		}
-
-		window.Panes = append(window.Panes, pane)
-	}
-
-	sort.Slice(
-		window.Panes,
-		func(i, j int) bool { return window.Panes[i].Index < window.Panes[j].Index },
-	)
-
-	return nil
 }
 
 func codexSessionMeta(sessionID string) map[string]string {
@@ -1130,88 +1147,27 @@ func writePaneTTY(path, content string) error {
 	return nil
 }
 
-func (client *Client) foregroundCommand(paneTTY string, panePID int) (string, error) {
-	tty := strings.TrimSpace(paneTTY)
-	if tty == "" {
-		return "", nil
-	}
-
-	candidates := []string{tty}
-	if b, ok := strings.CutPrefix(tty, "/dev/"); ok {
-		candidates = append(candidates, b)
-	}
-
-	if b := filepath.Base(tty); b != tty {
-		candidates = append(candidates, b)
-	}
-
-	var out []byte
-
-	var err error
-
-	for _, t := range candidates {
-		cmd := exec.CommandContext( // #nosec G204 -- fixed "ps" binary, variable args are pids/format flags
-			context.Background(),
-			"ps",
-			"-t",
-			t,
-			"-o",
-			"pid=",
-			"-o",
-			"ppid=",
-			"-o",
-			"stat=",
-			"-o",
-			"command=",
-		)
-
-		out, err = cmd.Output()
-		if err == nil {
-			break
-		}
-	}
-
-	if err != nil {
-		return "", fmt.Errorf("get output: %w", err)
-	}
-
-	command := pickForegroundCommand(splitLines(string(out)), panePID)
-	if command != "" {
-		return command, nil
-	}
-
-	// Some terminal wrappers give the child process a different tty from the
-	// shell tmux reports for the pane. Fall back to the process tree so tools
-	// such as Codex are still detected instead of being saved as zsh.
-	return client.fallbackForegroundCommand(panePID)
-}
-
-func (client *Client) fallbackForegroundCommand(panePID int) (string, error) {
-	cmd := exec.CommandContext( // #nosec G204 -- fixed "ps" binary and numeric pane PID
-		context.Background(),
-		"ps",
-		"-ax",
-		"-o",
-		"pid=",
-		"-o",
-		"ppid=",
-		"-o",
-		"stat=",
-		"-o",
-		"command=",
-	)
-	allOut, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("get process list: %w", err)
-	}
-
-	return pickForegroundCommand(
-		processTreeLines(splitLines(string(allOut)), panePID),
-		panePID,
-	), nil
-}
-
 func processTreeLines(lines []string, rootPID int) []string {
+	snapshot := newProcessSnapshot(lines)
+	processes := snapshot.descendants(rootPID)
+
+	tree := make([]string, 0, len(processes))
+	for _, process := range processes {
+		tree = append(
+			tree,
+			fmt.Sprintf("%d %d %s %s", process.pid, process.ppid, process.stat, process.cmd),
+		)
+	}
+
+	return tree
+}
+
+type processSnapshot struct {
+	processes map[int]psProcess
+	children  map[int][]int
+}
+
+func newProcessSnapshot(lines []string) processSnapshot {
 	processes := make(map[int]psProcess)
 	for _, line := range lines {
 		pid, ppid, stat, command, ok := parsePSLine(line)
@@ -1224,13 +1180,42 @@ func processTreeLines(lines []string, rootPID int) []string {
 	for _, process := range processes {
 		children[process.ppid] = append(children[process.ppid], process.pid)
 	}
+	for parent := range children {
+		sort.Ints(children[parent])
+	}
 
+	return processSnapshot{processes: processes, children: children}
+}
+
+func (snapshot processSnapshot) foregroundCommand(rootPID int) string {
+	processes := snapshot.descendants(rootPID)
+	nonShell := make([]psProcess, 0, len(processes))
+	var shells []psProcess
+	for _, process := range processes {
+		if isShellCommand(process.cmd) {
+			if strings.Contains(process.stat, "+") {
+				shells = append(shells, process)
+			}
+
+			continue
+		}
+
+		nonShell = append(nonShell, process)
+	}
+	if command := pickFromCandidates(nonShell); command != "" {
+		return command
+	}
+
+	return pickFromCandidates(shells)
+}
+
+func (snapshot processSnapshot) descendants(rootPID int) []psProcess {
 	seen := map[int]bool{rootPID: true}
 	queue := []int{rootPID}
 	for len(queue) > 0 {
 		parent := queue[0]
 		queue = queue[1:]
-		for _, child := range children[parent] {
+		for _, child := range snapshot.children[parent] {
 			if seen[child] {
 				continue
 			}
@@ -1239,22 +1224,24 @@ func processTreeLines(lines []string, rootPID int) []string {
 		}
 	}
 
-	tree := make([]string, 0, len(seen)-1)
+	result := make([]psProcess, 0, len(seen)-1)
+	pids := make([]int, 0, len(seen)-1)
 	for pid := range seen {
 		if pid == rootPID {
 			continue
 		}
-		process, ok := processes[pid]
+		pids = append(pids, pid)
+	}
+	sort.Ints(pids)
+	for _, pid := range pids {
+		process, ok := snapshot.processes[pid]
 		if !ok {
 			continue
 		}
-		tree = append(
-			tree,
-			fmt.Sprintf("%d %d %s %s", process.pid, process.ppid, process.stat, process.cmd),
-		)
+		result = append(result, process)
 	}
 
-	return tree
+	return result
 }
 
 type psProcess struct {
@@ -1352,11 +1339,10 @@ func pickFromCandidates(allProcesses []psProcess) string {
 }
 
 const (
-	windowLineFields   = 4
-	paneLineFields     = 7
-	livePaneLineFields = 3
-	paneCommandFields  = 3
-	psLineFields       = 4
+	livePaneLineFields    = 3
+	capturePaneLineFields = 11
+	paneCommandFields     = 3
+	psLineFields          = 4
 )
 
 func parsePSLine(line string) (int, int, string, string, bool) {

--- a/internal/tmux/client_internal_test.go
+++ b/internal/tmux/client_internal_test.go
@@ -526,10 +526,10 @@ func TestPickForegroundCommand(t *testing.T) {
 	}
 
 	launched := []string{
-		"100 1 Ss zsh",
-		"300 100 S+ fish",
+		"101 1 Ss zsh",
+		"300 101 S+ fish",
 	}
-	if got := pickForegroundCommand(launched, 100); got != "fish" {
+	if got := pickForegroundCommand(launched, 101); got != "fish" {
 		t.Fatalf("expected launched fish, got %q", got)
 	}
 
@@ -561,6 +561,45 @@ func TestPickForegroundCommandFromProcessTree(t *testing.T) {
 
 	if got := pickForegroundCommand(lines, 100); got != "codex" {
 		t.Fatalf("expected child codex, got %q", got)
+	}
+}
+
+func TestProcessSnapshotResolvesIndependentPaneTrees(t *testing.T) {
+	t.Parallel()
+
+	snapshot := newProcessSnapshot([]string{
+		"100 1 Ss zsh",
+		"101 100 S+ nvim main.go",
+		"200 1 Ss zsh",
+		"201 200 S+ codex",
+		"300 1 S unrelated",
+	})
+
+	if got := snapshot.foregroundCommand(100); got != "nvim main.go" {
+		t.Fatalf("pane 100 foreground = %q", got)
+	}
+	if got := snapshot.foregroundCommand(200); got != "codex" {
+		t.Fatalf("pane 200 foreground = %q", got)
+	}
+}
+
+func BenchmarkProcessSnapshotForegroundCommands(b *testing.B) {
+	lines := make([]string, 0, 2000)
+	for index := 1; index <= 1000; index++ {
+		root := index * 2
+		lines = append(
+			lines,
+			fmt.Sprintf("%d 1 Ss zsh", root),
+			fmt.Sprintf("%d %d S+ command-%d", root+1, root, index),
+		)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		snapshot := newProcessSnapshot(lines)
+		for root := 2; root <= 200; root += 2 {
+			_ = snapshot.foregroundCommand(root)
+		}
 	}
 }
 

--- a/internal/tmux/integration_test.go
+++ b/internal/tmux/integration_test.go
@@ -76,6 +76,33 @@ func TestRestoreToleratesBaseIndexMismatch(
 }
 
 //nolint:paralleltest // uses a real shared tmux server via testutil.IsolatedTmux (t.Setenv)
+func TestCaptureSessionCollectsAllWindowsAndPanes(t *testing.T) {
+	testutil.IsolatedTmux(t)
+
+	const name = "capture-many"
+	testutil.Tmux(t, "new-session", "-d", "-s", name, "-n", "one")
+	testutil.Tmux(t, "split-window", "-d", "-t", "="+name+":0", "-c", "/tmp")
+	testutil.Tmux(t, "new-window", "-d", "-t", "="+name+":2", "-n", "two", "-c", "/")
+	testutil.Tmux(t, "set-option", "-p", "-t", "="+name+":2.0", "@codex_thread_id", "thread-2")
+	testutil.Tmux(t, "select-window", "-t", "="+name+":2")
+
+	snap, err := tmux.NewClient("tmux").CaptureSession(name)
+	if err != nil {
+		t.Fatalf("capture session: %v", err)
+	}
+	if len(snap.Windows) != 2 || len(snap.Windows[0].Panes) != 2 ||
+		len(snap.Windows[1].Panes) != 1 {
+		t.Fatalf("captured hierarchy: %+v", snap.Windows)
+	}
+	if snap.CurrentWin != 2 || snap.Windows[1].Name != "two" {
+		t.Fatalf("captured focus/windows: %+v", snap)
+	}
+	if got := snap.Windows[1].Panes[0].Meta[snapshot.CodexSessionIDMetaKey]; got != "thread-2" {
+		t.Fatalf("captured Codex thread = %q", got)
+	}
+}
+
+//nolint:paralleltest // uses a real shared tmux server via testutil.IsolatedTmux (t.Setenv)
 func TestRestoreToleratesPaneBaseIndexMismatch(
 	t *testing.T,
 ) {

--- a/internal/tmux/integration_test.go
+++ b/internal/tmux/integration_test.go
@@ -2,8 +2,11 @@ package tmux_test
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -102,6 +105,74 @@ func TestCaptureSessionCollectsAllWindowsAndPanes(t *testing.T) {
 	}
 }
 
+func TestCaptureSessionUsesConstantDiscoveryRoundTrips(t *testing.T) {
+	testutil.IsolatedTmux(t)
+
+	const name = "capture-count"
+	testutil.Tmux(t, "new-session", "-d", "-s", name)
+	for index := 1; index < 8; index++ {
+		testutil.Tmux(t, "new-window", "-d", "-t", "="+name+":", "-n", fmt.Sprintf("w%d", index))
+	}
+
+	dir := t.TempDir()
+	tmuxLog := filepath.Join(dir, "tmux.log")
+	psLog := filepath.Join(dir, "ps.log")
+	realTmux, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	realPS, err := exec.LookPath("ps")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmuxWrapper := writeCountingWrapper(t, dir, "tmux", realTmux, tmuxLog)
+	writeCountingWrapper(t, dir, "ps", realPS, psLog)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if _, err = tmux.NewClient(tmuxWrapper).CaptureSession(name); err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	if got := countLogCommand(t, tmuxLog, "list-panes"); got != 1 {
+		t.Fatalf("list-panes calls = %d, want 1", got)
+	}
+	if got := countLogCommand(t, psLog, "-ax"); got != 1 {
+		t.Fatalf("ps process-table calls = %d, want 1", got)
+	}
+}
+
+func writeCountingWrapper(t *testing.T, dir, name, target, logPath string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	body := fmt.Sprintf(
+		"#!/bin/sh\nprintf '%%s\\n' \"$*\" >> %q\nexec %q \"$@\"\n",
+		logPath,
+		target,
+	)
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write %s wrapper: %v", name, err)
+	}
+
+	return path
+}
+
+func countLogCommand(t *testing.T, path, command string) int {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read command log: %v", err)
+	}
+	count := 0
+	for line := range strings.SplitSeq(string(data), "\n") {
+		if strings.Contains(line, command) {
+			count++
+		}
+	}
+
+	return count
+}
+
 //nolint:paralleltest // uses a real shared tmux server via testutil.IsolatedTmux (t.Setenv)
 func TestRestoreToleratesPaneBaseIndexMismatch(
 	t *testing.T,
@@ -138,6 +209,36 @@ func TestRestoreToleratesPaneBaseIndexMismatch(
 
 	if _, err := testutil.TmuxTry("has-session", "-t", "="+name); err != nil {
 		t.Fatalf("session should be alive after restore: %v", err)
+	}
+}
+
+//nolint:paralleltest // uses a real shared tmux server via testutil.IsolatedTmux (t.Setenv)
+func TestRestoreStopsAfterRealContextCancellation(t *testing.T) {
+	testutil.IsolatedTmux(t)
+
+	const name = "cancel-real"
+	snap := snapshot.SessionSnapshot{
+		Version:     snapshot.FormatVersion,
+		SessionName: name,
+		CapturedAt:  time.Now(),
+		CurrentWin:  0,
+		CurrentPane: 0,
+		Windows: []snapshot.Window{
+			{Index: 0, Name: "first", Panes: []snapshot.Pane{{Index: 0, CurrentPath: "/tmp"}}},
+			{Index: 1, Name: "second", Panes: []snapshot.Pane{{Index: 0, CurrentPath: "/tmp"}}},
+			{Index: 2, Name: "third", Panes: []snapshot.Pane{{Index: 0, CurrentPath: "/tmp"}}},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := tmux.NewClient("tmux").RestoreSession(ctx, snap)
+	if err == nil || !strings.Contains(err.Error(), "restore canceled") {
+		t.Fatalf("restore cancellation error = %v", err)
+	}
+	out := testutil.Tmux(t, "list-windows", "-t", "="+name, "-F", "#{window_index}")
+	if got := len(strings.Fields(out)); got != 1 {
+		t.Fatalf("canceled restore created %d windows, want only initial window", got)
 	}
 }
 


### PR DESCRIPTION
Closes #288.

## Summary

- capture all windows and panes with one real tmux `list-panes -s` discovery call instead of the per-window N+1 path
- take one OS process-table snapshot per session capture and reuse its parent/child index for every pane
- run `save --all` through a bounded four-worker pool with deterministic error reporting
- replace the global Store mutex with per-session locks and a short index critical section
- protect index read-modify-write across independent lazy-tmux processes with `flock`
- let full and quick pickers load snapshot metadata without hydrating unused scrollback content
- load quick-picker Codex statuses with bounded workers and cache immutable Codex rollout paths safely
- batch the final restored window/pane focus into one tmux round trip
- retain sequential tmux topology mutation where parallel restore would weaken cancellation and partial-restore semantics

## Test strategy

New behavioral coverage uses real resources rather than mocks:

- real tmux multi-window/multi-pane capture, focus, paths, and Codex metadata
- two concurrent public CLI `save --all` calls over eight real tmux sessions
- concurrent independent Store instances writing one real filesystem index
- concurrent readers of a real Codex rollout fixture
- existing real-Docker save/restore, scrollback, sleep/wakeup, daemon, picker, and focus scenarios
- pure unit coverage only for the process-table transformation and deterministic lookup
- a process-snapshot benchmark for a 2,000-process table

## Verification

- `make integration-test`: 300 tests passed in the real Docker/tmux environment
- `go test -race ./...`
- `go test -tags lazy_fzf ./...`
- `golangci-lint run`
- `go vet ./...`
- `make build-all`
- coverage: 79.2%, configured threshold passed
- `BenchmarkProcessSnapshotForegroundCommands`: 361 µs/op for a synthetic 2,000-process table on Apple M3

The umbrella issue remains the place to track follow-up experiments that were deliberately not made concurrent without evidence, especially broader restore topology parallelism and longer-lived Claude discovery indexing.



## Summary by CodeRabbit

* **Improvements**
  * Save-all operations now process sessions concurrently while preserving every session, even when multiple saves run at once.
  * Session data updates are more reliable when accessed concurrently.
  * Quick-session status checks are processed more efficiently.
  * Session metadata can be loaded without loading full scrollback content.
  * Session capture more consistently preserves all windows, panes, focus, and Codex thread metadata.



## Review follow-up

- added OS-level same-session locking across independent Store instances and protected readers from mixed JSON/scrollback versions
- consolidated bounded worker pools into one internal generic helper
- replaced per-ID Codex glob caching with a singleflight full rollout index and deterministic one-scan concurrency guard
- added a Claude project index with directory fingerprint invalidation and a one-build concurrency guard
- added full-picker snapshot metadata caching keyed by file and capture timestamp
- added real tmux/ps counting wrappers proving one discovery call each for an eight-window capture
- added real tmux context-cancellation coverage
- expanded the Docker suite to 305 tests; coverage remains above the configured threshold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Save-all operations now process sessions concurrently while preserving every session, including during simultaneous saves.
  * Concurrent session updates are more reliable and avoid mixing data from different saves.
  * Quick-session status checks and session browsing are more responsive.
  * Session metadata can be loaded without loading full scrollback content.
  * Session capture and restoration more consistently preserve all windows, panes, focus, and Codex thread metadata.
  * Session information refreshes when underlying data changes, keeping displayed results current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->